### PR TITLE
#6 - timestamp playlist inserts when adding to a live showEndTime

### DIFF
--- a/css/kzsustyle.css
+++ b/css/kzsustyle.css
@@ -4,9 +4,6 @@
 body {
 	color: black;
 	background-color: #4D0A0A;
-	background-image: url(../img/kzsu/kzsu_heart.png);
-	background-repeat: no-repeat;
-	background-position: 30px 455px;
 }
 a {
 	color: #990010;
@@ -44,6 +41,9 @@ img.right {
 
 
 /* Header styles */
+.playlistBanner {
+    background-color: #4D0A0A;
+}
 
 div.header {
 	font-family: "century gothic", "urw gothic l",

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -239,9 +239,7 @@ DIV.headerLogo IMG {
 DIV.content {
     float: right;
     width: 650px;
-    padding: 30px;
-    padding-top: 10px;
-    padding-right: 10px;
+    padding: 10px;
     min-height: 450px;
     margin-left: auto;
     margin-right: auto;
@@ -327,6 +325,28 @@ P.zktitle A {
 }
 
 /* general */
+.playlistBanner {
+    font-family: verdana, arial, helvetica, sans-serif;
+    font-size: 11pt;
+    font-weight: bold;
+    color: white;
+    background-color: #2530A7;
+    line-height: 24px;
+    margin-bottom: 4px;
+}
+.playlistBanner > div {
+    font-size: 11pt;
+    float: right;
+    font-size: 10px;
+}
+
+.playlistHdr {
+    border-bottom: 1px solid gray;
+}
+.playlistTable {
+    width: 100%;
+}
+
 TH {
     font-family: verdana, arial, helvetica, sans-serif;
     font-size: 11pt;
@@ -485,3 +505,50 @@ A.calLink {
     border: 0px;
     background-image: URL('../img/list_dn.gif');
 }
+
+/* up/down & edit links for playlist edits */
+.songManager {
+    top: 8px;
+    height: 20px;
+    width: 24px;
+    position: relative;
+    font-size:12px;
+}
+
+.songManager a {
+    position: absolute;
+    line-height: 1.4;
+    background-repeat: no-repeat;
+    width: 10px;
+    height: 4px;
+}
+.songUp {
+    top: 0px;
+    background-image: URL('/img/arrow_up_beta.gif');
+}
+
+.songDown {
+    background-image: URL('/img/arrow_down_beta.gif');
+    top: 8px;
+}
+.songEdit {
+    top: -2px;
+    left: 12px;
+    font-size:14px;
+}
+
+.songLabel {
+    font-size:10px;
+}
+.songReview {
+    background-image: URL('/img/rinfo_beta.gif');
+    width:11px;
+    height:11px;
+}
+.songDivider hr {
+    position: relative;
+    top: 3px;
+    height: 0px;
+    background-color: gray;
+}
+

--- a/db/convert_v1_to_v2.sql
+++ b/db/convert_v1_to_v2.sql
@@ -1,0 +1,76 @@
+/*
+ * Zookeeper Online
+ *
+ * @author Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @link https://zookeeper.ibinx.com/
+ * @license GPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3, along with this program.  If not, see
+ * http://www.gnu.org/licenses/
+ */
+
+/**
+ * IMPORTANT NOTE:
+ *
+ * Run this script ONLY if you are converting an existing Zookeeper Online v1
+ * database for use with the current codebase.
+ *
+ * If you are creating a new database, run zkdbSchema.sql and then populate
+ * the resulting db using the various bootstrap scripts as appropriate.
+ */
+
+--
+-- Database: `zkdb`
+--
+
+SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT;
+SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS;
+SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION;
+SET NAMES utf8;
+
+ALTER DATABASE `zkdb` CHARACTER SET utf8 COLLATE utf8_general_ci;
+
+ALTER TABLE `airnames` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `albumvol` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `categories` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `chartemail` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `colltracknames` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `currents` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `lists` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `plays` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `publist` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `reviews` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `sessions` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `ssoredirect` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `ssosetup` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `tagqueue` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `tracknames` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `tracks` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+ALTER TABLE `users` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;
+
+ALTER TABLE `categories` ADD COLUMN `email` varchar(80) DEFAULT NULL;
+
+UPDATE `categories` SET email='reggae@kzsu.stanford.edu' WHERE id = 9;
+UPDATE `categories` SET email='classical@kzsu.stanford.edu' WHERE id = 8;
+UPDATE `categories` SET email='world@kzsu.stanford.edu' WHERE id = 7;
+UPDATE `categories` SET email='jazz@kzsu.stanford.edu' WHERE id = 6;
+UPDATE `categories` SET email='hiphop@kzsu.stanford.edu' WHERE id = 5;
+UPDATE `categories` SET email='metal@kzsu.stanford.edu' WHERE id = 4;
+UPDATE `categories` SET email='rpm@kzsu.stanford.edu' WHERE id = 3;
+UPDATE `categories` SET email='country@kzsu.stanford.edu' WHERE id = 2;
+UPDATE `categories` SET email='blues@kzsu.stanford.edu' WHERE id = 1;
+
+SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT;
+SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS;
+SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION;

--- a/db/convert_v2_to_v3.sql
+++ b/db/convert_v2_to_v3.sql
@@ -1,0 +1,37 @@
+/*
+ * Zookeeper Online
+ *
+ * @author Eric Gilbertson <ericg@kzsu.stanford.edu>
+ * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @link https://zookeeper.ibinx.com/
+ * @license GPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3, along with this program.  If not, see
+ * http://www.gnu.org/licenses/
+ */
+
+/**
+ * IMPORTANT NOTE:
+ *
+ * Run this script ONLY if you are converting an existing Zookeeper Online v2
+ * database for use with the current codebase.
+ *
+ * If you are creating a new database, run zkdbSchema.sql and then populate
+ * the resulting db using the various bootstrap scripts as appropriate.
+ */
+
+--
+-- Database: `zkdb`
+--
+
+alter table tracks add created timestamp null default NULL;

--- a/db/zkdbSchema.sql
+++ b/db/zkdbSchema.sql
@@ -363,6 +363,7 @@ CREATE TABLE IF NOT EXISTS `tracks` (
   `track` varchar(80) DEFAULT NULL,
   `album` varchar(80) DEFAULT NULL,
   `label` varchar(80) DEFAULT NULL,
+  `created` timestamp DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `list` (`list`),
   KEY `tag` (`tag`),

--- a/engine/impl/Library.php
+++ b/engine/impl/Library.php
@@ -246,7 +246,7 @@ class LibraryImpl extends BaseImpl implements ILibrary {
         $chain = [];
         $tags = [];
         $queryset = "";
-        for($i = 0; $i < sizeof($albums); $i++) {
+        for($i = 0; $albums != null && $i < sizeof($albums); $i++) {
             $tag = array_key_exists("tag", $albums[$i])?$albums[$i]["tag"]:0;
             if($tag) {
                 if(array_key_exists($tag, $tags))

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -24,6 +24,8 @@
 
 namespace ZK\Engine;
 
+use \Datetime;
+use \DateTimeZone;
 use ZK\Engine\ILibrary;
 
 
@@ -162,7 +164,7 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
     }
 
     public function getTrack($id) {
-        $query = "SELECT tag, artist, track, album, label, id FROM tracks " .
+        $query = "SELECT tag, artist, track, album, label, id, created FROM tracks " .
                  "WHERE id = ?";
         $stmt = $this->prepare($query);
         $stmt->bindValue(1, (int)$id, \PDO::PARAM_INT);
@@ -170,7 +172,7 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
     }
     
     public function getTracks($playlist, $desc = 0) {
-        $query = "SELECT tag, artist, track, album, label, id FROM tracks " .
+        $query = "SELECT tag, artist, track, album, label, id, created FROM tracks " .
                  "WHERE list = ? ORDER BY id";
         if($desc)
             $query .= " DESC";
@@ -178,23 +180,59 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
         $stmt->bindValue(1, (int)$playlist, \PDO::PARAM_INT);
         return $this->execute($stmt);
     }
-    
-    public function insertTrack($playlist, $tag, $artist, $track, $album, $label) {
+
+    // return true if "now" is within the show start/end time & date.
+    // NOTE: this routine must be tolerant of improperly formatted dates.
+    public function isWithinShow($listRow) {
+        $TIME_FORMAT = "Y-m-d Gi"; // eg, 2019-01-01 1234
+        $retVal = false;
+
+        try {
+            $timeAr = explode("-", $listRow[2]);
+            if (count($timeAr) == 2) {
+                $timeStr1 = $listRow[1] . " " . $timeAr[0];
+                $start = DateTime::createFromFormat($TIME_FORMAT, $timeStr1);
+                $endStr = $timeAr[1] == "0000" ? "2359" : $timeAr[1];
+                $timeStr2 = $listRow[1] . " " . $endStr;
+                $end = DateTime::createFromFormat($TIME_FORMAT, $timeStr2);
+
+                if (isset($start) && isset($end)) {
+                    $now = new DateTime("now");
+                    $retVal = (($now > $start) && ($now < $end));
+                }
+            }
+        } catch (Throwable $t) {
+            ;
+        }
+        return $retVal;
+    }
+
+    public function insertTrack($playlistId, $tag, $artist, $track, $album, $label) {
+        $row = Engine::api(IPlaylist::class)->getPlaylist($playlistId, 1);
+
+        // log time iff 'now' is within playlist start/end time.
+        $doTimestamp = self::isWithinShow($row);
+        $timeName    = $doTimestamp ? "created, " : "";
+        $timeValue   = $doTimestamp ? "NOW(), "   : "";
+
         // Insert tag?
-        $noTag = ($tag == 0) || ($tag == "");
+        $haveTag  = ($tag != 0) && ($tag != "");
+        $tagName  = $haveTag ? ", tag" : "";
+        $tagValue = $haveTag ? ", ?"   : "";
     
-        $query = "INSERT INTO tracks " .
-                 "(list, artist, track, album, label" . ($noTag?")":", tag)") .
-                 " VALUES (?, ?, ?, ?, ?" .
-                 ($noTag?")":", ?)");
+        $names = "(" . $timeName . "list, artist, track, album, label " . $tagName . ")";
+        $values = " VALUES (" . $timeValue . "?, ?, ?, ?, ?" . $tagValue . ");";
+
+        $query = "INSERT INTO tracks " . ($names) . ($values);
         $stmt = $this->prepare($query);
-        $stmt->bindValue(1, (int)$playlist, \PDO::PARAM_INT);
+        $stmt->bindValue(1, (int)$playlistId, \PDO::PARAM_INT); 
         $stmt->bindValue(2, $artist);
         $stmt->bindValue(3, $track);
         $stmt->bindValue(4, $album);
         $stmt->bindValue(5, $label);
-        if(!$noTag)
+        if($haveTag)
             $stmt->bindValue(6, $tag);
+
         return $stmt->execute();
     }
     


### PR DESCRIPTION
add timestamp to track inserts on playlist if show is realtime, eg
insert is done during the user specified begin/end times. also simplify
markup generation by breaking large functions up and by using CSS to
reduce the amount of required markup. other changes include:

  - show time in 12 hour format
  - show album & artist names as 'first last' (was 'last, first')
  - remove the butt ugly heart logo
  - simplify playlist banner
  - add playlist CSS classes
  - normailize border width
  - add border between playlist header and body
  - improved track edit glyphs
  - replace \" with ' for readability
  - update zkdbSchema.sql and provide an upgrade script
  - protect against empty arrays in for loops (generate ugly warning messages)
  - make album link clickable in playlist edit mode (now matches view mode markup)
  - added 'created' to tracks query (as last column in the select statement)
  - added function to check if insert is within show start/end times