### PR TITLE
#32 - playlist time stamping fix & enhancements

### DIFF
--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -43,7 +43,7 @@ interface IPlaylist {
     function updatePlaylist($playlist, $date, $time, $description, $airname);
     function getTrack($id);
     function getTracks($playlist, $desc = 0);
-    function insertTrack($playlist, $tag, $artist, $track, $album, $label);
+    function insertTrack($playlist, $tag, $artist, $track, $album, $label, $wantTimestamp);
     function updateTrack($id, $tag, $artist, $track, $album, $label);
     function deleteTrack($id);
     function getTopPlays(&$result, $airname=0, $days=41, $count=10);

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -207,11 +207,11 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
         return $retVal;
     }
 
-    public function insertTrack($playlistId, $tag, $artist, $track, $album, $label) {
+    public function insertTrack($playlistId, $tag, $artist, $track, $album, $label, $wantTimestamp) {
         $row = Engine::api(IPlaylist::class)->getPlaylist($playlistId, 1);
 
         // log time iff 'now' is within playlist start/end time.
-        $doTimestamp = self::isWithinShow($row);
+        $doTimestamp = $wantTimestamp && self::isWithinShow($row);
         $timeName    = $doTimestamp ? "created, " : "";
         $timeValue   = $doTimestamp ? "NOW(), "   : "";
 
@@ -236,24 +236,35 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
         return $stmt->execute();
     }
     
+    // update track and set created if it is currently null, eg first edit
+    // of a track following a CSV import.
     public function updateTrack($id, $tag, $artist, $track, $album, $label) {
+        $trackRow  = Engine::api(IPlaylist::class)->getTrack($id);
+        $timestamp = $trackRow['created'];
+        if ($timestamp == null)
+            $timestamp = date('Y-m-d G:i:s');
+        
         $query = "UPDATE tracks SET ";
         $query .= "artist=?, " .
                   "track=?, " .
                   "album=?, " .
                   "label=?, " .
+                  "created=?, " .
                   "tag=" . ($tag?"?":"NULL");
         $query .= " WHERE id = ?";
+
         $stmt = $this->prepare($query);
         $stmt->bindValue(1, $artist);
         $stmt->bindValue(2, $track);
         $stmt->bindValue(3, $album);
         $stmt->bindValue(4, $label);
+        $stmt->bindValue(5, $timestamp);
         if($tag) {
-            $stmt->bindValue(5, $tag);
-            $stmt->bindValue(6, (int)$id, \PDO::PARAM_INT);
+            $stmt->bindValue(6, $tag);
+            $stmt->bindValue(7, (int)$id, \PDO::PARAM_INT);
         } else
-            $stmt->bindValue(5, (int)$id, \PDO::PARAM_INT);
+            $stmt->bindValue(6, (int)$id, \PDO::PARAM_INT);
+
         return $stmt->execute();
     }
     
@@ -456,7 +467,7 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
                     $swap = 1;
                     $id = $row[0];
                 }
-            } else if(sizeof($prevRow)){
+            } else if(isset($prevRow) && sizeof($prevRow)){
                 // move track down
                 $swap = 1;
                 $id = $prevRow[0];
@@ -470,7 +481,6 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
                         "track = ?, " .
                         "album = ?, " .
                         "label = ? " .
-                        "created = ? " .
                         "WHERE id = ?";
             $stmt = $this->prepare($query);
 
@@ -479,8 +489,7 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
             $stmt->bindValue(3, $prevRow[3]);
             $stmt->bindValue(4, $prevRow[4]);
             $stmt->bindValue(5, $prevRow[5]);
-            $stmt->bindValue(6, $prevRow[6]);
-            $stmt->bindValue(7, (int)$row[0], \PDO::PARAM_INT);
+            $stmt->bindValue(6, (int)$row[0], \PDO::PARAM_INT);
             $stmt->execute();
 
             $stmt->bindValue(1, $row[1]?$row[1]:null);
@@ -488,8 +497,7 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
             $stmt->bindValue(3, $row[3]);
             $stmt->bindValue(4, $row[4]);
             $stmt->bindValue(5, $row[5]);
-            $stmt->bindValue(6, $row[6]);
-            $stmt->bindValue(7, (int)$prevRow[0], \PDO::PARAM_INT);
+            $stmt->bindValue(6, (int)$prevRow[0], \PDO::PARAM_INT);
             $stmt->execute();
         }
     }

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -716,10 +716,10 @@ class Playlists extends MenuItem {
         UI::setFocus("track");
     }
     
-    private function insertTrack($playlist, $tag, $artist, $track, $album, $label) {
+    private function insertTrack($playlist, $tag, $artist, $track, $album, $label, $wantTimestamp) {
         // Run the query
         $success = Engine::api(IPlaylist::class)->insertTrack($playlist,
-                     $tag, $artist, $track, $album, $label);    
+                     $tag, $artist, $track, $album, $label, $wantTimestamp);    
     }
     
     private function updateTrack($id, $tag, $artist, $track, $album, $label) {
@@ -744,7 +744,7 @@ class Playlists extends MenuItem {
     
     private function insertSetSeparator($playlist) {
         $specialTrack = IPlaylist::SPECIAL_TRACK;
-        $this->insertTrack($playlist, 0, $specialTrack, $specialTrack, $specialTrack, $specialTrack);
+        $this->insertTrack($playlist, 0, $specialTrack, $specialTrack, $specialTrack, $specialTrack, true);
     }
     
     public function emitEditor() {
@@ -823,7 +823,7 @@ class Playlists extends MenuItem {
                     $this->updateTrack($id, $tag, $artist, $track, $album, $label);
                     $id = "";
                 } else
-                    $this->insertTrack($playlist, $tag, $artist, $track, $album, $label);
+                    $this->insertTrack($playlist, $tag, $artist, $track, $album, $label, true);
                 $this->emitTagForm($playlist, "");
             }
             break;
@@ -1083,7 +1083,7 @@ class Playlists extends MenuItem {
                                      trim($line[0]),  // artist
                                      trim($line[1]),  // track
                                      trim($line[2]),  // album
-                                     trim($line[3])); // label
+                                     trim($line[3]), false); // label
                     $count++;
                 } else if(count($line) == 5) {
                     // artist track album tag label
@@ -1112,7 +1112,7 @@ class Playlists extends MenuItem {
                                      trim($line[0]),  // artist
                                      trim($line[1]),  // track
                                      trim($line[2]),  // album
-                                     trim($line[4])); // label
+                                     trim($line[4]), false); // label
                     $count++;
                 }
             }
@@ -1360,14 +1360,15 @@ class Playlists extends MenuItem {
               if ($editMode)
                   $editCell = "<TD>" . self::makeEditDiv($row, $playlist) . "</TD>";
 
+              $timeplayed = self::timestampToAMPM($row["created"]);
               if(substr($row["artist"], 0, strlen(IPlaylist::SPECIAL_TRACK)) == IPlaylist::SPECIAL_TRACK) {
-                echo "<TR class='songDivider'>".$editCell."<TD COLSPAN=5><HR></TD></TR>";
+                echo "<TR class='songDivider'>".$editCell.
+                      "<TD>".$timeplayed . "</TD><TD COLSPAN=4><HR></TD></TR>";
                 continue;
               }
 
               $reviewCell = $row["REVIEWED"] ? $REVIEW_DIV : "";
               $artistName = self::swapNames($row["artist"]);
-              $timeplayed = self::timestampToAMPM($row["created"]);
               $albumLink = self::makeAlbumLink($row, true);
               echo "<TR class='songRow'>" . $editCell .
                      "<TD>" . $timeplayed . "</TD>" .


### PR DESCRIPTION
   - don't set timetamp when importing a playlist
   - set timestamp on track update if created is null
   - show timestamp for set divider
   - update timestamps when tracks are moved up/down in playlist
   - fix error when clicking down on bottom track