### PR TITLE
Ericg/6 add playlist timestamp

### DIFF
--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -43,8 +43,8 @@ interface IPlaylist {
     function updatePlaylist($playlist, $date, $time, $description, $airname);
     function getTrack($id);
     function getTracks($playlist, $desc = 0);
-    function insertTrack($playlist, $tag, $artist, $track, $album, $label);
-    function updateTrack($id, $tag, $artist, $track, $album, $label);
+    function insertTrack($playlist, $tag, $artist, $track, $album, $label, $wantTimestamp);
+    function updateTrack($playlistId, $id, $tag, $artist, $track, $album, $label);
     function deleteTrack($id);
     function getTopPlays(&$result, $airname=0, $days=41, $count=10);
     function getLastPlays($tag, $count=0);

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -433,8 +433,9 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
         return $this->execute($stmt, \PDO::FETCH_BOTH);
     }
 
+    // NOTE: up is newer, eg list is in reverse time order
     public function moveTrackUpDown($playlist, &$id, $up) {
-        $query = "SELECT id, tag, artist, track, album, label FROM tracks " .
+        $query = "SELECT id, tag, artist, track, album, label, created FROM tracks " .
                  "WHERE list = ? ORDER BY id";
         $stmt = $this->prepare($query);
         $stmt->bindValue(1, $playlist);
@@ -469,6 +470,7 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
                         "track = ?, " .
                         "album = ?, " .
                         "label = ? " .
+                        "created = ? " .
                         "WHERE id = ?";
             $stmt = $this->prepare($query);
 
@@ -477,7 +479,8 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
             $stmt->bindValue(3, $prevRow[3]);
             $stmt->bindValue(4, $prevRow[4]);
             $stmt->bindValue(5, $prevRow[5]);
-            $stmt->bindValue(6, (int)$row[0], \PDO::PARAM_INT);
+            $stmt->bindValue(6, $prevRow[6]);
+            $stmt->bindValue(7, (int)$row[0], \PDO::PARAM_INT);
             $stmt->execute();
 
             $stmt->bindValue(1, $row[1]?$row[1]:null);
@@ -485,7 +488,8 @@ class PlaylistImpl extends BaseImpl implements IPlaylist {
             $stmt->bindValue(3, $row[3]);
             $stmt->bindValue(4, $row[4]);
             $stmt->bindValue(5, $row[5]);
-            $stmt->bindValue(6, (int)$prevRow[0], \PDO::PARAM_INT);
+            $stmt->bindValue(6, $row[6]);
+            $stmt->bindValue(7, (int)$prevRow[0], \PDO::PARAM_INT);
             $stmt->execute();
         }
     }

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -716,15 +716,15 @@ class Playlists extends MenuItem {
         UI::setFocus("track");
     }
     
-    private function insertTrack($playlist, $tag, $artist, $track, $album, $label) {
+    private function insertTrack($playlist, $tag, $artist, $track, $album, $label, $wantTimestamp) {
         // Run the query
         $success = Engine::api(IPlaylist::class)->insertTrack($playlist,
-                     $tag, $artist, $track, $album, $label);    
+                     $tag, $artist, $track, $album, $label, $wantTimestamp);    
     }
     
-    private function updateTrack($id, $tag, $artist, $track, $album, $label) {
+    private function updateTrack($playlistId, $id, $tag, $artist, $track, $album, $label) {
         // Run the query
-        Engine::api(IPlaylist::class)->updateTrack($id, $tag, $artist, $track, $album, $label);
+        Engine::api(IPlaylist::class)->updateTrack($playlistId, $id, $tag, $artist, $track, $album, $label);
     }
     
     private function deleteTrack($id) {
@@ -744,7 +744,7 @@ class Playlists extends MenuItem {
     
     private function insertSetSeparator($playlist) {
         $specialTrack = IPlaylist::SPECIAL_TRACK;
-        $this->insertTrack($playlist, 0, $specialTrack, $specialTrack, $specialTrack, $specialTrack);
+        $this->insertTrack($playlist, 0, $specialTrack, $specialTrack, $specialTrack, $specialTrack, true);
     }
     
     public function emitEditor() {
@@ -820,10 +820,10 @@ class Playlists extends MenuItem {
                     }
                 }
                 if($id) {
-                    $this->updateTrack($id, $tag, $artist, $track, $album, $label);
+                    $this->updateTrack($playlist, $id, $tag, $artist, $track, $album, $label);
                     $id = "";
                 } else
-                    $this->insertTrack($playlist, $tag, $artist, $track, $album, $label);
+                    $this->insertTrack($playlist, $tag, $artist, $track, $album, $label, true);
                 $this->emitTagForm($playlist, "");
             }
             break;
@@ -1083,7 +1083,7 @@ class Playlists extends MenuItem {
                                      trim($line[0]),  // artist
                                      trim($line[1]),  // track
                                      trim($line[2]),  // album
-                                     trim($line[3])); // label
+                                     trim($line[3]), false); // label
                     $count++;
                 } else if(count($line) == 5) {
                     // artist track album tag label
@@ -1112,7 +1112,7 @@ class Playlists extends MenuItem {
                                      trim($line[0]),  // artist
                                      trim($line[1]),  // track
                                      trim($line[2]),  // album
-                                     trim($line[4])); // label
+                                     trim($line[4]), false); // label
                     $count++;
                 }
             }
@@ -1360,14 +1360,15 @@ class Playlists extends MenuItem {
               if ($editMode)
                   $editCell = "<TD>" . self::makeEditDiv($row, $playlist) . "</TD>";
 
+              $timeplayed = self::timestampToAMPM($row["created"]);
               if(substr($row["artist"], 0, strlen(IPlaylist::SPECIAL_TRACK)) == IPlaylist::SPECIAL_TRACK) {
-                echo "<TR class='songDivider'>".$editCell."<TD COLSPAN=5><HR></TD></TR>";
+                echo "<TR class='songDivider'>".$editCell.
+                      "<TD>".$timeplayed . "</TD><TD COLSPAN=4><HR></TD></TR>";
                 continue;
               }
 
               $reviewCell = $row["REVIEWED"] ? $REVIEW_DIV : "";
               $artistName = self::swapNames($row["artist"]);
-              $timeplayed = self::timestampToAMPM($row["created"]);
               $albumLink = self::makeAlbumLink($row, true);
               echo "<TR class='songRow'>" . $editCell .
                      "<TD>" . $timeplayed . "</TD>" .

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1314,7 +1314,7 @@ class Playlists extends MenuItem {
     }
     
     private function makeAlbumLink($row, $includeLabel) {
-        $albumName = self::swapNames($row["album"]);
+        $albumName = $row["album"];
         $labelSpan = "<span class='songLabel'>/" . self::smartURL($row["label"]) . "</span>";
         if($row["tag"]) {
             $albumTitle = "<A HREF='?s=byAlbumKey&amp;n=" . UI::URLify($row["tag"]) .
@@ -1402,11 +1402,10 @@ class Playlists extends MenuItem {
         $showDateTime = self::makeShowDateAndTime($row);
 
         // make print view header
-        echo "<TABLE WIDTH='100%'>" .  
-             "<TR><TD ALIGN=RIGHT><A HREF='#top' " .
-             "CLASS='nav' onClick='window.open('?target=export&amp;session=" . 
-             $this->session->getSessionID() . "&amp;playlist='" . $playlist . 
-             "&amp;format=html)'>Print View</A></TD></TR>\n</TABLE>";
+        echo "<TABLE WIDTH='100%'><TR><TD ALIGN=RIGHT><A HREF='#top' " .
+             "CLASS='nav' onClick=window.open('?target=export&amp;session=" . 
+             $this->session->getSessionID() . "&amp;playlist=" . $playlist . 
+             "&amp;format=html')>Print View</A></TD></TR></TABLE>";
 
         $dateDiv = "<DIV>".$showDateTime."&nbsp;</div>";
         $djLink = "<A HREF='?action=viewDJ&amp;seq=selUser&amp;session=" . 


### PR DESCRIPTION
#25 - don't add timestamp when editing an old playlist

add time window check when updating a playlist check so that
change is not timestamped when editing an older show, eg update
must be done within the the playlist's start/end time in order to be
time stamped.

