### PR TITLE
Upstream/hotfix 2 4 0

### DIFF
--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -363,6 +363,7 @@ TH.sec {
     background-color: #2530a7;
 }
 .error {
+    font-weight: bold;
     color: #cc0000;
 }
 .input { }

--- a/engine/Engine.php
+++ b/engine/Engine.php
@@ -24,6 +24,7 @@
 
 namespace ZK\Engine;
 
+
 class Engine {
     const VERSION = "2.4.1-DEV";
 

--- a/engine/Engine.php
+++ b/engine/Engine.php
@@ -25,7 +25,7 @@
 namespace ZK\Engine;
 
 class Engine {
-    const VERSION = "2.5.0-DEV";
+    const VERSION = "2.4.1-DEV";
 
     private static $apis;
     private static $config;


### PR DESCRIPTION
75: make album & label optional fields and fix error display
   - manual mode no longer requires user entry of album & label names
   - retain user entry if track when track posts return an error
   - display server errors just below page banner & use bold font
   - show NMEs in playlist if user is logged in

NOTE: this change is also present in the NME branch.