### PR TITLE
Adds Travis CI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+.DS_Store
+config/config.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: php
+
+php:
+  - 5.6
+  - 7.2
+
+services:
+  - mysql
+
+before_install:
+  - mysql -e 'CREATE DATABASE zookeeper'
+
+before_script:
+  # Install Apache
+  - sudo apt-get update
+  - sudo apt-get install apache2 libapache2-mod-fastcgi
+  # Enable php-fpm
+  - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+  - sudo a2enmod rewrite actions fastcgi alias
+  - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
+  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
+  - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
+  # Configure Apache vhosts
+  - sudo cp -f build/travis-ci-apache /etc/apache2/sites-available/000-default.conf
+  - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/000-default.conf
+  - sudo service apache2 restart
+  # Set timezone
+  - phpenv config-add build/zookeeper.ini
+  # Copy configuration file
+  - cp config/config.example.php config/config.php
+  # Set up MySQL
+  - mysql -u root zookeeper < db/zkdbSchema.sql
+  - mysql -u root zookeeper < db/categories.sql
+  - mysql -u root zookeeper < db/chartemail.sql
+  - mysql -u root zookeeper < db/bootstrapUser.sql
+  # Set some $_SERVER vars used in Main.php
+  - export HTTP_ACCEPT="application/json"
+  - export HTTP_USER_AGENT="Travis CI"
+
+script: php zk test action=test subaction=test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## Zookeeper Online
+[![Build Status](https://travis-ci.org/rocketman/zookeeper.svg?branch=master)](https://travis-ci.org/rocketman/zookeeper)
 
 Zookeeper Online is a music database and charting application for
 college and independent radio.

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -1,0 +1,25 @@
+<VirtualHost *:80>
+  # [...]
+
+  DocumentRoot %TRAVIS_BUILD_DIR%
+
+  <Directory "%TRAVIS_BUILD_DIR%/">
+    Options FollowSymLinks MultiViews ExecCGI
+    AllowOverride All
+    Require all granted
+  </Directory>
+
+  # Wire up Apache to use Travis CI's php-fpm.
+  <IfModule mod_fastcgi.c>
+    AddHandler php5-fcgi .php
+    Action php5-fcgi /php5-fcgi
+    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+
+    <Directory /usr/lib/cgi-bin>
+        Require all granted
+    </Directory>
+  </IfModule>
+
+  # [...]
+</VirtualHost>

--- a/build/zookeeper.ini
+++ b/build/zookeeper.ini
@@ -1,0 +1,1 @@
+date.timezone="Europe/London"

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -100,8 +100,8 @@ $config = [
     'db' => [
         'driver' => 'mysql',
         'host' => 'localhost',
-        'database' => '',
-        'user' => '',
+        'database' => 'zookeeper',
+        'user' => 'root',
         'pass' => '',
     ],
 

--- a/db/zkdbSchema.sql
+++ b/db/zkdbSchema.sql
@@ -364,7 +364,7 @@ CREATE TABLE IF NOT EXISTS `tracks` (
   `track` varchar(80) DEFAULT NULL,
   `album` varchar(80) DEFAULT NULL,
   `label` varchar(80) DEFAULT NULL,
-  `created` timestamp DEFAULT NULL,
+  `created` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `list` (`list`),
   KEY `tag` (`tag`),

--- a/ui/Home.php
+++ b/ui/Home.php
@@ -50,7 +50,7 @@ class Home extends MenuItem {
        if($weeks && ($lastWeek = $weeks->fetch()))
           list($y,$m,$d) = explode("-", $lastWeek["week"]);
     
-       if(!$y)
+       if(! isset($y) || !$y)
           return;    // No charts!  bail.
     
        if(!$numWeeks || $numWeeks == 1)

--- a/ui/Main.php
+++ b/ui/Main.php
@@ -44,7 +44,7 @@ class Main implements IController {
         $isJson = substr($_SERVER["HTTP_ACCEPT"], 0, 16) === 'application/json';
         if ($isJson) {
             $action =  $_REQUEST["action"];
-            $subAction =  $_REQUEST["subaction"];
+            $subaction =  $_REQUEST["subaction"];
             $dispatcher->dispatch($action, $subaction, $this->session);
         } else {
             $this->emitResponseHeader();


### PR DESCRIPTION
This PR adds a Travis CI build configuration to the project.

It will create a boot up an Apache instance and create a MySQL database using the database dumps provided in the project.

As per the installation instructions, a timezone is required, so one will be set using `build/zookeeper.ini`.

The final step of the build will run the `zk` executable with two test arguments to ensure that the page can be loaded and the executable runs without failure.

Whilst establishing the script portion of the build, I came across a few small issues that required fixing. None of the changes are breaking changes (i.e., backwards-incompatible), they are merely oversights or changes that make testing a bit easier. If any clarification is needed on the changes, I'll be happy to explain.

The builds will run on both PHP 5.6 and 7.2.

Here are links to 3 separate successful builds:

https://travis-ci.org/corazzi/zookeeper/builds/601803948
https://travis-ci.org/corazzi/zookeeper/builds/601804961
https://travis-ci.org/corazzi/zookeeper/builds/601806713