### PR TITLE
65/100: add artist name swapping to manually entered tracks

### DIFF
--- a/controllers/API.php
+++ b/controllers/API.php
@@ -318,7 +318,7 @@ class API extends CommandTarget implements IController {
                             }
                         })->onSpin(function($entry) use(&$break) {
                             echo "<track";
-                            $artist = $entry->getArtist();
+                            $artist = UI::swapNames($entry->getArtist());
                             if($artist)
                                 echo " artist=\"".self::spec2hexAttr(stripslashes($artist))."\"";
                             $track = $entry->getTrack();
@@ -370,7 +370,7 @@ class API extends CommandTarget implements IController {
 
         $attrs = $this->addSuccess();
         $attrs["tag"] = $key;
-        $attrs["artist"] = $artist;
+        $attrs["artist"] =  UI::swapNames($artist);
         $attrs["album"] = $albums[0]["album"];
         $attrs["label"] = $label;
         $attrs["collection"] = Search::GENRES[$albums[0]["category"]];

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -971,7 +971,7 @@ class Playlists extends MenuItem {
                     $("#track-title").val("");
                     $("#track-submit").attr("disabled");
                     $("#track-submit").prop("disabled", true);
-                    $("#tag-artist").text(diskInfo.artist  + '-' + diskInfo.album);
+                    $("#tag-artist").text(diskInfo.artist  + ' - ' + diskInfo.album);
 
                 }).fail(function (jqXHR, textStatus, errorThrown) {
                     showUserError('Ajax error: ' + textStatus);
@@ -1996,9 +1996,7 @@ class Playlists extends MenuItem {
                     $this->makeEditDiv($entry, $playlist) . "</TD>" : "";
                 $timeplayed = self::timestampToAMPM($entry->getCreated());
                 $reviewCell = $entry->getReviewed() ? "<div class='albumReview'></div>" : "";
-                $artistName = $entry->getArtist();
-                if ($entry->getTag()) // don't swap manual entries
-                    $artistName = UI::swapNames($artistName);
+                $artistName = UI::swapNames($entry->getArtist());
 
                 $albumLink = $this->makeAlbumLink($entry, true);
                 echo "<TR class='songRow'>" . $editCell .


### PR DESCRIPTION
   * show swapped artist name for all playlist entries (was only for tagged entries)
   * return swapped artist names in REST queries
   * add space between artist & album in track editor