### PR TITLE
Improve session management

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -17,5 +17,7 @@ RewriteEngine on
 RewriteRule ^zkrss\.php$ index.php?target=rss [QSA,L]
 RewriteRule ^zkapi\.php$ index.php?target=api [QSA,L]
 RewriteRule ^ssoLogin\.php$ index.php?target=sso [QSA,L]
+RewriteCond $0 !^\.mdhandler.php/.*$
+RewriteRule ^(.+)\.md$ .mdhandler.php/$1.md [L]
 RewriteRule ^zk$ - [R=404,L]
 </IfModule>

--- a/.mdhandler.php
+++ b/.mdhandler.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Zookeeper Online
+ *
+ * @author Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @link https://zookeeper.ibinx.com/
+ * @license GPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3, along with this program.  If not, see
+ * http://www.gnu.org/licenses/
+ *
+ */
+
+require('ui/3rdp/Parsedown.php');
+ 
+$target = realpath(__DIR__.$_SERVER['PATH_INFO']);
+if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
+        !file_exists($target)) {
+    http_response_code(404);
+    return;
+}
+    
+header("Content-Type: text/html");
+header("Last-Modified: ".gmdate('D, d M Y H:i:s', filemtime($target))." GMT");
+
+// for HEAD requests, there is nothing more to do
+if($_SERVER['REQUEST_METHOD'] == "HEAD")
+    return;
+
+ob_start("ob_gzhandler");
+ob_start("markdown");
+
+function markdown($buffer) {
+    return Parsedown::instance()->text($buffer);
+}
+
+require_once($target);
+
+ob_end_flush(); // markdown
+ob_end_flush(); // ob_gzhandler

--- a/.mdhandler.php
+++ b/.mdhandler.php
@@ -45,8 +45,9 @@ if($_SERVER['REQUEST_METHOD'] == "HEAD")
 
 ob_start("ob_gzhandler");
 
-echo "<!DOCTYPE html>\n<HTML>\n<HEAD>\n";
+echo "<!DOCTYPE html>\n<HTML lang=\"en\">\n<HEAD>\n";
 UI::emitCSS($stylesheet);
+echo "<TITLE>".basename($_SERVER['REQUEST_URI'])."</TITLE>\n";
 echo "</HEAD>\n<BODY>\n<DIV class='box'>\n";
 
 ob_start("markdown");

--- a/.mdhandler.php
+++ b/.mdhandler.php
@@ -23,6 +23,11 @@
  */
 
 require('ui/3rdp/Parsedown.php');
+require('ui/UICommon.php');
+
+use ZK\UI\UICommon as UI;
+
+$stylesheet = "css/zoostyle.css";
 
 $target = realpath(__DIR__.$_SERVER['PATH_INFO']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
@@ -39,6 +44,11 @@ if($_SERVER['REQUEST_METHOD'] == "HEAD")
     return;
 
 ob_start("ob_gzhandler");
+
+echo "<!DOCTYPE html>\n<HTML>\n<HEAD>\n";
+UI::emitCSS($stylesheet);
+echo "</HEAD>\n<BODY>\n<DIV class='box'>\n";
+
 ob_start("markdown");
 
 function markdown($buffer) {
@@ -48,4 +58,7 @@ function markdown($buffer) {
 require_once($target);
 
 ob_end_flush(); // markdown
+
+echo "\n</DIV>\n</BODY>\n</HTML>\n";
+
 ob_end_flush(); // ob_gzhandler

--- a/.mdhandler.php
+++ b/.mdhandler.php
@@ -23,14 +23,14 @@
  */
 
 require('ui/3rdp/Parsedown.php');
- 
+
 $target = realpath(__DIR__.$_SERVER['PATH_INFO']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);
     return;
 }
-    
+
 header("Content-Type: text/html");
 header("Last-Modified: ".gmdate('D, d M Y H:i:s', filemtime($target))." GMT");
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,71 @@
+## Privacy Policy for Zookeeper Online
+
+This Privacy Policy documents the types of information that are
+collected and processed by Zookeeper Online.
+
+### What is Zookeeper Online?
+
+Zookeeper Online is free and open source (FOSS) software that assists
+in the management of various radio station functions such as music
+library, playlists, and charting.  The source code is available at
+<https://zookeeper.ibinx.com/>.
+
+### Scope of this Privacy Policy
+
+This Privacy Policy covers only the open source components of
+Zookeeper Online as released via <https://zookeeper.ibinx.com/>.  Any
+radio station or other third-party who makes use of this software is
+free to enhance the software.  This may include changes which impact
+privacy.  **_In addition to this Privacy Policy, please see also the
+privacy policy of the radio station or other party who is hosting the
+website you are accessing now._**
+
+### What data do we collect and how do we collect it?
+
+For visitors who access Zookeeper Online without logging in, we do not
+collect any personally identifiable information.  If you are an
+authorized user, Zookeeper Online will collect your name and e-mail
+address.  We collect and process this information when you login to
+our website for the first time.
+
+### How will we use your data?
+
+We collect your data so that we can authenticate your access to our
+service and manage your account.  We do not share your data with any
+third-parties.
+
+### Cookies and web beacons
+
+For visitors who access Zookeeper Online without logging in, no
+cookies are created during the visit.  Zookeeper Online uses transient
+(session) cookies for those visitors who have a user account with us
+and who login to access additional content on the website.  These cookies
+are used to maintain session information whilst a user is logged in.
+The cookies are deleted automatically when the user logs out or closes
+the browser window.
+
+Zookeeper Online does not use third-party cookies nor web beacons.
+
+### Log files
+
+Zookeeper Online follows a standard practice of using web server log
+files. These files log visitors when they access the website. The
+information collected by log files includes internet protocol (IP)
+address, browser type, date and time of access, and possibly the
+referring web page.  This log information is not linked to any
+information that is personally identifiable. The purpose of this
+information is for administering the site and resolving any technical
+issues that may arise.
+
+### Changes to our Privacy Policy
+
+This Privacy Policy was last updated on 23 June 2019.
+
+### How to contact us
+
+If you have any questions about this Privacy Policy, please contact us
+via e-mail at <zookeeper@ibinx.com>.  If you have questions about the
+privacy policy of the website you are accessing now, the data held on
+you, or you would like to exercise one of your data protection rights,
+please contact the radio station or other party who is hosting this
+website.

--- a/controllers/ExportAfile.php
+++ b/controllers/ExportAfile.php
@@ -32,7 +32,7 @@ class ExportAfile implements IController {
     public function processRequest($dispatcher) {
         $userAgent = $_SERVER["HTTP_USER_AGENT"];
         ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <HTML>
 <HEAD>
   <TITLE>KZSU Zookeeper Online</TITLE>

--- a/controllers/ExportAfile.php
+++ b/controllers/ExportAfile.php
@@ -32,7 +32,7 @@ class ExportAfile implements IController {
     public function processRequest($dispatcher) {
         $userAgent = $_SERVER["HTTP_USER_AGENT"];
         ?>
-<!DOCTYPE html>
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <HTML>
 <HEAD>
   <TITLE>KZSU Zookeeper Online</TITLE>

--- a/controllers/ExportPlaylist.php
+++ b/controllers/ExportPlaylist.php
@@ -173,7 +173,7 @@ class ExportPlaylist extends CommandTarget implements IController {
         list($y,$m,$d) = explode("-", $this->date);
         $displayDate = date("D, j M Y", mktime(0,0,0,$m,$d,$y));
     ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <HTML>
 <HEAD>
 <TITLE><?php echo "Zookeeper playlist for $this->show, $displayDate";?></TITLE>

--- a/controllers/ExportPlaylist.php
+++ b/controllers/ExportPlaylist.php
@@ -173,7 +173,7 @@ class ExportPlaylist extends CommandTarget implements IController {
         list($y,$m,$d) = explode("-", $this->date);
         $displayDate = date("D, j M Y", mktime(0,0,0,$m,$d,$y));
     ?>
-<!DOCTYPE html>
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <HTML>
 <HEAD>
 <TITLE><?php echo "Zookeeper playlist for $this->show, $displayDate";?></TITLE>

--- a/controllers/RSS.php
+++ b/controllers/RSS.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/controllers/RSS.php
+++ b/controllers/RSS.php
@@ -119,7 +119,7 @@ class RSS extends CommandTarget implements IController {
                 $output .= "&lt;A HREF=\"".UI::getBaseUrl().
                              "?s=byAlbumKey&amp;n=".$chart[$i]["tag"].
                              "&amp;q=10".
-                             "&amp;action=search&amp;session=".$this->session->getSessionID().
+                             "&amp;action=search".
                              "\"&gt;". self::htmlnumericentities(self::xmlentities($album)) . "&lt;/A&gt;&lt;/I&gt;$medium (" .
                      self::htmlnumericentities(self::xmlentities($label)) . ")&lt;BR&gt;\n";
             }
@@ -287,7 +287,7 @@ class RSS extends CommandTarget implements IController {
                 $output .= "&lt;A HREF=\"".UI::getBaseUrl().
                              "?s=byAlbumKey&amp;n=".$row["tag"].
                              "&amp;q=10".
-                             "&amp;action=search&amp;session=".$this->session->getSessionID().
+                             "&amp;action=search".
                              "\"&gt;". self::htmlnumericentities(self::xmlentities($album)) . "&lt;/A&gt;&lt;/I&gt;$medium (" .
                      self::htmlnumericentities(self::xmlentities($label)) . ")&lt;BR&gt;\n";
             }

--- a/controllers/SSOLogin.php
+++ b/controllers/SSOLogin.php
@@ -51,8 +51,7 @@ class SSOLogin implements IController {
             // setup redirection to the application
             $rq = [
                 "action" => $this->action,
-                "ssoOptions" => $this->ssoOptions,
-                "session" => Engine::session()->getSessionID()
+                "ssoOptions" => $this->ssoOptions
             ];
         
             if($location) {

--- a/controllers/SSOLogin.php
+++ b/controllers/SSOLogin.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/controllers/SSOLogin.php
+++ b/controllers/SSOLogin.php
@@ -68,7 +68,7 @@ class SSOLogin implements IController {
                     // the cookie test was successful!
 
                     // clear the test cookie
-                    setcookie("testcookie", "", time() - 3600, "/", $_SERVER['SERVER_NAME']);
+                    setcookie("testcookie", "", time() - 3600);
 
                     // generate the SSO state token
                     $token = Engine::api(IUser::class)->setupSsoRedirect($params["location"]);

--- a/custom/KzsuContacts.php
+++ b/custom/KzsuContacts.php
@@ -45,7 +45,7 @@ class KzsuContacts extends MenuItem {
     vinyl from 7&quot;s to 12&quot;s, all it takes to be considered for
     airplay is to send us a copy.</P>
     
-    <P><A HREF="?session=<?php echo $this->session->getSessionID();?>&amp;action=contactGuidelines"><B>PLEASE READ THESE GUIDELINES BEFORE SUBMITTING MUSIC</B></A></P>
+    <P><A HREF="?action=contactGuidelines"><B>PLEASE READ THESE GUIDELINES BEFORE SUBMITTING MUSIC</B></A></P>
     
     <TABLE BORDER=0 CELLSPACING=0 WIDTH="100%">
       <TR><TH ALIGN=LEFT CLASS="subhead">Music Mailing Addresses</TH></TR>
@@ -129,8 +129,7 @@ class KzsuContacts extends MenuItem {
     <P CLASS="subhead2">What Do We Play?</P>
     <P>All submissions will be listened to and assessed for their
     appropriateness on KZSU.  If you are unfamiliar with what we play
-    please consult our <A HREF="?session=<?php echo
-    $this->session->getSessionID();?>&amp;action=viewChart">weekly charts</A> posted online or
+    please consult our <A HREF="?action=viewChart">weekly charts</A> posted online or
     check our <A HREF="<?php echo Engine::param('urls')['home'];?>schedule/">air schedule</A> and
     the show descriptions of our current DJs.  KZSU has very limited
     library space and it is important that we only keep what we feel will
@@ -172,15 +171,14 @@ class KzsuContacts extends MenuItem {
     
     <P>Please allow 4-6 weeks for processing of submissions.  If you are
     wondering whether your music has been accepted into our rotation and
-    library, please consult our <A HREF="?session=<?php echo
-    $this->session->getSessionID();?>">Zookeeper database</A> after that time.  All music that
+    library, please consult our <A HREF="?">Zookeeper database</A> after that time.  All music that
     is accepted is entered into this easily searchable database.</P>
     
     <P CLASS="subhead2">Tracking</P>
     <P>With few exceptions, we do not do tracking.  With the volume of
     submissions and the fact that our staff is all-volunteer, busy with
     classes, day jobs, families, we prefer to let the publicly searchable
-    <A HREF="?session=<?php echo $this->session->getSessionID();?>">Zookeeper</A> database, our CD
+    <A HREF="?">Zookeeper</A> database, our CD
     reviews, our A-file and charts be a measure of how much we love your
     music.  Please consult Zookeeper in lieu of tracking calls,
     emails.</P>
@@ -211,7 +209,7 @@ class KzsuContacts extends MenuItem {
     station.</P>
      
     <P>Thanks in advance for your submissions.<BR>
-    <A HREF="?session=<?php echo $this->session->getSessionID();?>&amp;action=contact"><I>The Music
+    <A HREF="?action=contact"><I>The Music
     Department Staff of KZSU Stanford</I></A></P>
     <?php 
         UI::setFocus();

--- a/custom/KzsuContacts.php
+++ b/custom/KzsuContacts.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2019 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/custom/KzsuContacts.php
+++ b/custom/KzsuContacts.php
@@ -26,8 +26,6 @@ namespace ZK\UI;
 
 use ZK\Engine\Engine;
 
-use ZK\UI\UICommon as UI;
-
 class KzsuContacts extends MenuItem {
     private static $actions = [
         [ "contact", "emitContacts" ],
@@ -115,7 +113,6 @@ class KzsuContacts extends MenuItem {
     </TABLE>
     <P><A CLASS="nav" HREF="http://kzsu.stanford.edu/contact/"><B>Additional contact information</B></A> for KZSU radio is available here.</P>
     <?php 
-        UI::setFocus();
     }
     
     public function emitGuidelines() {
@@ -212,6 +209,5 @@ class KzsuContacts extends MenuItem {
     <A HREF="?action=contact"><I>The Music
     Department Staff of KZSU Stanford</I></A></P>
     <?php 
-        UI::setFocus();
     }
 }

--- a/custom/KzsuUIController.php
+++ b/custom/KzsuUIController.php
@@ -51,7 +51,7 @@ class KzsuUIController extends Main {
     </DIV>
     <DIV CLASS="headerNavbar">
       <A HREF="<?php echo $urls['home'];?>schedule/">schedule</A> +
-      <A HREF="<?php echo "?session=".$this->session->getSessionID();?>">music</A> +
+      <A HREF="?">music</A> +
       <A HREF="<?php echo $urls['home'];?>sports/">sports</a> +
       <A HREF="<?php echo $urls['home'];?>concerts/">concerts</a> +
       <!--A HREF="<?php echo $urls['home'];?>news/" target="_blank">news</A> + -->

--- a/custom/KzsuUIController.php
+++ b/custom/KzsuUIController.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2019 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/engine/Session.php
+++ b/engine/Session.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/engine/Session.php
+++ b/engine/Session.php
@@ -51,7 +51,7 @@ class Session {
            break;
         default:
            // non-standard port, apply suffix
-           $this->sessionCookieName .= "-" + $port;
+           $this->sessionCookieName .= "-" . $port;
            break;
         }
 

--- a/engine/Session.php
+++ b/engine/Session.php
@@ -62,7 +62,6 @@ class Session {
     }
 
     public function getDN() { return $this->displayName; }
-    public function getSessionID() { return $this->sessionID; }
     public function getUser() { return $this->user; }
 
     private function setSessionCookie($session) {
@@ -186,7 +185,7 @@ class Session {
             $allow = true;
             break;
         case "u":    // authenticated users only
-            $allow = $this->sessionID;
+            $allow = !empty($this->sessionID);
             break;
         case "U":    // local (not SSO) user
             $allow = $this->sessionID &&

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -336,7 +336,6 @@ $().ready(function(){
 
     function moveTrack(list, fromId, toId, tr, si, rows) {
         var postData = {
-            session: $("#track-session").val(),
             playlist: list,
             fromId: fromId,
             toId: toId
@@ -431,7 +430,6 @@ $().ready(function(){
 
         var postData = {
             playlist: $("#track-playlist").val(),
-            session: $("#track-session").val(),
             type: type,
             tag: $("#track-tag").val(),
             artist: artist,
@@ -458,8 +456,7 @@ $().ready(function(){
                 case -1:
                     // playlist is out of sync with table; reload
                     location.href = "?action=" + $("#track-action").val() +
-                        "&playlist=" + $("#track-playlist").val() +
-                        "&session=" + $("#track-session").val();
+                        "&playlist=" + $("#track-playlist").val();
                     break;
                 case 0:
                     // playlist is in natural order; prepend

--- a/js/search.findit.js
+++ b/js/search.findit.js
@@ -97,7 +97,6 @@ function getArtist(node) {
 }
 
 function emitAlbumsEx(table, data, header, tag) {
-    var session = $("#session").val();
     var tr = $("<TR>");
     var th = $("<TH>", {
         class: 'sec',
@@ -113,12 +112,10 @@ function emitAlbumsEx(table, data, header, tag) {
             tagId = "Tag #" + entry.tag + "&nbsp;&#8226;&nbsp;";
         td = $("<TD>").html(tagId + '<A HREF="?s=byArtist&n=' +
                             encodeURIComponent(entry.artist) +
-                            '&q=10&action=search&session=' +
-                            session + '" CLASS="nav">' +
+                            '&q=10&action=search" CLASS="nav">' +
                             getArtist(entry) + '</A>' +
                             "&nbsp;&#8226;&nbsp;");
-        var album = $("<I>").html('<A HREF="?session=' + session +
-                                  '&action=findAlbum&n=' + entry.tag +
+        var album = $("<I>").html('<A HREF="?action=findAlbum&n=' + entry.tag +
                                   '" CLASS="nav">' + entry.album + '</A>');
         td.append(album).append('&nbsp; (' + entry.name + ')');
         tr.append(td);
@@ -179,7 +176,6 @@ var lists = {
     },
 
     compilations: function(table, data) {
-        var session = $("#session").val();
         var tr = $("<TR>");
         var th = $("<TH>", {
             class: 'sec',
@@ -192,11 +188,9 @@ var lists = {
             tr = $("<TR>").append(indent());
             var td = $("<TD>").html('<A HREF="?s=byArtist&n=' +
                                     encodeURIComponent(entry.artist) +
-                                    '&q=10&action=search&session=' + session +
-                                    '" CLASS="nav">' + getArtist(entry) + '</A>' +
+                                    '&q=10&action=search" CLASS="nav">' + getArtist(entry) + '</A>' +
                                     "&nbsp;&#8226;&nbsp;");
-            var album = $("<I>").html('<A HREF="?session=' + session +
-                                      '&action=findAlbum&n=' + entry.tag +
+            var album = $("<I>").html('<A HREF="?action=findAlbum&n=' + entry.tag +
                                       '" CLASS="nav">' + entry.album + '</A>');
             td.append(album);
             td.append('&nbsp;&#8226;&nbsp;"' + entry.track + '"');
@@ -208,7 +202,6 @@ var lists = {
     },
 
     labels: function(table, data) {
-        var session = $("#session").val();
         var tr = $("<TR>");
         var th = $("<TH>", {
             class: 'sec',
@@ -220,8 +213,7 @@ var lists = {
         data.data.forEach(function(entry) {
             tr = $("<TR>").append(indent());
             var td = $("<TD>").html('<A HREF="?s=byLabelKey&n=' +
-                                    entry.pubkey + '&q=10&action=search&session=' +
-                                    session + '" CLASS="nav">' +
+                                    entry.pubkey + '&q=10&action=search" CLASS="nav">' +
                                     entry.name + '</A>');
             if(entry.city)
                 td.append("&nbsp;&#8226; " + entry.city + "&nbsp;" +
@@ -234,7 +226,6 @@ var lists = {
     },
 
     playlists: function(table, data) {
-        var session = $("#session").val();
         var tr = $("<TR>");
         var th = $("<TH>", {
             class: 'sec',
@@ -257,8 +248,7 @@ var lists = {
                 td = $("<TD>", {
                     align: 'left'
                 }).html('<A HREF="?action=viewDJ&seq=selList&playlist=' +
-                        list + '&session=' +
-                        session + '" CLASS="nav">' +
+                        list + '" CLASS="nav">' +
                         entry.description + '</A>' +
                         '&nbsp;&#8226;&nbsp;' +
                         day + " " + months[month-1] + year + '&nbsp;&nbsp;(' +
@@ -284,7 +274,6 @@ var lists = {
     },
 
     reviews: function(table, data) {
-        var session = $("#session").val();
         var tr = $("<TR>");
         var th = $("<TH>", {
             class: 'sec',
@@ -297,11 +286,10 @@ var lists = {
             tr = $("<TR>").append(indent());
             var td = $("<TD>").html('<A HREF="?s=byArtist&n=' +
                                     encodeURIComponent(entry.artist) +
-                                    '&q=10&action=search&session=' +
-                                    session + '" CLASS="nav">' +
+                                    '&q=10&action=search" CLASS="nav">' +
                                     getArtist(entry) + '</A>' +
                                     '&nbsp;&#8226;&nbsp;' +
-                                    '<I><A HREF="?session=' + session + '&action=findAlbum&n=' +
+                                    '<I><A HREF="?action=findAlbum&n=' +
                                     entry.tag + '" CLASS="nav">' +
                                     entry.album + '</A></I>' +
                                     '&nbsp;&nbsp;(' +
@@ -314,7 +302,6 @@ var lists = {
     },
 
     tracks: function(table, data) {
-        var session = $("#session").val();
         var tr = $("<TR>");
         var th = $("<TH>", {
             class: 'sec',
@@ -328,13 +315,11 @@ var lists = {
             var td = $("<TD>");
             td.html('<A HREF="?s=byArtist&n=' +
                     encodeURIComponent(entry.artist) +
-                    '&q=10&action=search&session=' +
-                    session + '" CLASS="nav">' +
+                    '&q=10&action=search" CLASS="nav">' +
                     getArtist(entry) + '</A>' +
                     "&nbsp;&#8226;&nbsp;" +
                     "<I>" +
-                    '<A HREF="?session=' + session +
-                    '&action=findAlbum&n=' +
+                    '<A HREF="?action=findAlbum&n=' +
                     entry.tag + '" CLASS="nav">' +
                     entry.album + '</A></I>' +
                     '&nbsp;&#8226;&nbsp;"' + entry.track + '"');
@@ -382,7 +367,7 @@ function search(type, size, offset) {
                 var search = $("#key").val();
                 if(search.length < 4 ||
                    search.match(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]/g) != null) {
-                    results.html('TIP: For short names or names with punctuation, try the <A HREF="?action=search&s=byArtist&n=' + encodeURIComponent(search) + '&session=' + $("#session").val() + '">Classic Search</A>.');
+                    results.html('TIP: For short names or names with punctuation, try the <A HREF="?action=search&s=byArtist&n=' + encodeURIComponent(search) + '">Classic Search</A>.');
                 }
             }
         },

--- a/js/search.library.js
+++ b/js/search.library.js
@@ -123,7 +123,6 @@ function getArtist(node) {
 }
 
 function emitAlbumsEx(table, data) {
-    var session = $("#session").val();
     var tr = $("<TR>");
     tr.append(header("Artist", true));
     tr.append(header("", false));
@@ -143,7 +142,7 @@ function emitAlbumsEx(table, data) {
                 href: "?s=byAlbumKey&n=" +
                     encodeURIComponent(entry.tag) +
                     "&q=" + maxresults +
-                    "&action=search&session=" + session
+                    "&action=search"
             }).html(getArtist(entry)));
         } else {
             td.append(
@@ -165,7 +164,7 @@ function emitAlbumsEx(table, data) {
             href: "?s=byAlbumKey&n=" +
                 encodeURIComponent(entry.tag) +
                 "&q=" + maxresults +
-                "&action=search&session=" + session
+                "&action=search"
         }).html(htmlify(entry.album))));
         var collection = entry.location;
         collection = (collection == "Library")?entry.category:
@@ -208,7 +207,6 @@ var lists = {
     },
 
     tracks: function(table, data) {
-        var session = $("#session").val();
         var tr = $("<TR>");
         tr.append(header("Artist", true));
         tr.append(header("Album", true));
@@ -227,7 +225,7 @@ var lists = {
                     href: "?s=byAlbumKey&n=" +
                         encodeURIComponent(entry.tag) +
                         "&q=" + maxresults +
-                        "&action=search&session=" + session
+                        "&action=search"
                 }).html(getArtist(entry)));
             } else {
                 td.append(
@@ -243,7 +241,7 @@ var lists = {
                 href: "?s=byAlbumKey&n=" +
                     encodeURIComponent(entry.tag) +
                     "&q=" + maxresults +
-                    "&action=search&session=" + session
+                    "&action=search"
             }).html(htmlify(entry.album))));
             tr.append($("<TD>").append(
                 $("<A href='#" + encobj({
@@ -276,7 +274,6 @@ var lists = {
     },
 
     labels: function(table, data) {
-        var session = $("#session").val();
         var tr = $("<TR>");
         tr.append(header("Name", false));
         tr.append(header("Location", false).attr('colSpan', 2));
@@ -302,7 +299,7 @@ var lists = {
     },
 
     reviews: function(table, data) {
-        var session = $("#session").val();
+        var showTag = $("#showTag").val();
         var tr = $("<TR>");
         tr.append(header("Artist", true));
         tr.append(header("Album", true));
@@ -319,22 +316,22 @@ var lists = {
                     href: "?s=byAlbumKey&n=" +
                         encodeURIComponent(entry.tag) +
                         "&q=" + maxresults +
-                        "&action=search&session=" + session
+                        "&action=search"
                 }).html(getArtist(entry)));
             } else {
                 td.html($("<A>", {
                     href: "?s=byArtist&n=" +
                         encodeURIComponent(entry.artist) +
                         "&q=" + maxresults +
-                        "&action=search&session=" + session
+                        "&action=search"
                 }).html(getArtist(entry)));
             }
             tr.append(td);
             tr.append($("<TD>").html($("<A>", {
                 href: "?s=byAlbumKey&n=" + encodeURIComponent(entry.tag) +
                     "&q=" + maxresults +
-                    "&action=search&session=" + session
-            }).html(htmlify(entry.album))).append(session.length>0?
+                    "&action=search"
+            }).html(htmlify(entry.album))).append(showTag == 'true'?
                                          " <FONT CLASS='sub'>(Tag&nbsp;#" +
                                          entry.tag + ")<FONT>":""));
             if(entry.pubkey) {
@@ -342,7 +339,7 @@ var lists = {
                     href: "?s=byLabelKey&n=" +
                         encodeURIComponent(entry.pubkey) +
                         "&q=" + maxresults +
-                        "&action=search&session=" + session
+                        "&action=search"
                 }).html(htmlify(entry.name))));
             } else {
                 tr.append($("<TD>").html("Unknown"));

--- a/ui/AddManager.php
+++ b/ui/AddManager.php
@@ -570,7 +570,7 @@ class AddManager extends MenuItem {
         $artist = $_REQUEST["artist"];
         $album = $_REQUEST["album"];
     
-        if($validate) {
+        if($validate && $_SERVER['REQUEST_METHOD'] == 'POST') {
             // Add the album
             $emitted = false;
             $catstr = "";
@@ -726,7 +726,7 @@ class AddManager extends MenuItem {
         $artist = $_REQUEST["artist"];
         $album = $_REQUEST["album"];
     
-        if($validate) {
+        if($validate && $_SERVER['REQUEST_METHOD'] == 'POST') {
             // Add the album
             $emitted = false;
             $catstr = "";
@@ -846,14 +846,15 @@ class AddManager extends MenuItem {
             $_REQUEST["date"] = $row["adddate"];
         }
     
-        Engine::api(IChart::class)->deleteAlbum($id);
+        if($_SERVER['REQUEST_METHOD'] == 'POST')
+            Engine::api(IChart::class)->deleteAlbum($id);
         $this->addManagerShowAdd();
     }
     
     public function addManagerCats() {
         $seq = $_REQUEST["seq"];
     
-        if($seq == "update") {
+        if($seq == "update" && $_SERVER['REQUEST_METHOD'] == 'POST') {
             $success = true;
             for($i=1; $success && $i<=16; $i++) {
                 $name = $_POST["name".$i];

--- a/ui/AddManager.php
+++ b/ui/AddManager.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2019 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/AddManager.php
+++ b/ui/AddManager.php
@@ -127,14 +127,13 @@ class AddManager extends MenuItem {
     private function getEditCell($row) {
        $requestId = $_REQUEST["id"];
        $albumId = $row["id"];
-       $sessionId="?session=".$this->session->getSessionID();
 
-       $hrefDate= $sessionId .  "&amp;action=addmgr&amp;subaction=adds&amp;date=$date ";
+       $hrefDate= "action=addmgr&amp;subaction=adds&amp;date=$date ";
        $class = ($requestId && $requestId == $albumId) ? "sel" : "nav";
        $cellDate = "<A CLASS='nav' HREF='" . $hrefDate .
           "' onClick='ConfirmDelete(" . $albumId . "); return false;'>[x]</A>&nbsp;";
 
-       $hrefId =  $sessionId . "&amp;action=addmgr&amp;subaction=addsedit&amp;id=" . $albumId;
+       $hrefId =  "action=addmgr&amp;subaction=addsedit&amp;id=" . $albumId;
        $cellId = "<A CLASS='songEdit' HREF='" . $hrefId . "'>&#x270f;</A>";
 
        return "<TD>" . $cellDate . $cellId . "</TD>";
@@ -200,8 +199,7 @@ class AddManager extends MenuItem {
                     if($row["reviewed"]) {
                         echo "<A CLASS=\"albumReview\" HREF=\"".
                              "?s=byAlbumKey&amp;n=". UI::URLify($row["tag"]).
-                             "&amp;action=search&amp;session=".$this->session->getSessionID().
-                             "\"><IMG SRC=\"img/blank.gif\" WIDTH=12 HEIGHT=11 ALT=\"[i]\"></A>";
+                             "&amp;action=search\"><IMG SRC=\"img/blank.gif\" WIDTH=12 HEIGHT=11 ALT=\"[i]\"></A>";
                     }
                     echo "</TD>";
                 }
@@ -224,8 +222,7 @@ class AddManager extends MenuItem {
                 else
                     echo "<TD><A CLASS='nav' HREF='".
                          "?s=byAlbumKey&amp;n=". UI::URLify($row["tag"]).
-                         "&amp;action=search&amp;session=".$this->session->getSessionID().
-                         "'>" . $albumName . "</A>$tagNum&nbsp;&nbsp;</TD>";
+                         "&amp;action=search'>" . $albumName . "</A>$tagNum&nbsp;&nbsp;</TD>";
     
                 if(!$static)
                     echo "<TD>" . htmlentities($row["label"]) . "</TD>";
@@ -248,7 +245,7 @@ class AddManager extends MenuItem {
         if($showEdit) {
             $this->emitConfirmID("Delete",
                         "Delete this album from the add?",
-                        "session=".$this->session->getSessionID()."&action=addmgr&subaction=addsdel",
+                        "action=addmgr&subaction=addsdel",
                         "id");
         }
     ?>
@@ -303,7 +300,6 @@ class AddManager extends MenuItem {
             echo "            <OPTION VALUE=\"$row[0]\"$selected>$row[0]\n";
         }
     ?>          </SELECT>
-              <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
               <INPUT TYPE=HIDDEN NAME=action VALUE="addmgr">
               <INPUT TYPE=HIDDEN NAME=subaction VALUE="adds">
               <INPUT TYPE=HIDDEN NAME=seq VALUE="update">
@@ -319,7 +315,6 @@ class AddManager extends MenuItem {
                   <OPTION VALUE="email">E-Mail
               </SELECT>
               <INPUT TYPE=BUTTON NAME=button onClick="onExport();" VALUE=" Export ">
-              <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
               <INPUT TYPE=HIDDEN NAME=date VALUE="">
               <INPUT TYPE=HIDDEN NAME=target VALUE="addexp">
             </FORM>
@@ -893,7 +888,6 @@ class AddManager extends MenuItem {
         }
     ?>
         </TABLE>
-        <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
         <INPUT TYPE=HIDDEN NAME=action VALUE="addmgr">
         <INPUT TYPE=HIDDEN NAME=subaction VALUE="categories">
         <INPUT TYPE=HIDDEN NAME=seq VALUE="update">
@@ -1027,7 +1021,6 @@ class AddManager extends MenuItem {
           <TR><TD></TD><TD><INPUT TYPE=SUBMIT VALUE=" E-Mail Add "></TD></TR>
         </TABLE>
         <INPUT TYPE=HIDDEN NAME=date VALUE="<?php echo $date;?>">
-        <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
         <INPUT TYPE=HIDDEN NAME=action VALUE="addmgr">
         <INPUT TYPE=HIDDEN NAME=subaction VALUE="addsemail">
       </FORM>
@@ -1190,7 +1183,7 @@ class AddManager extends MenuItem {
     
             echo "<TD><A CLASS=\"nav\" HREF=\"".
                   "?action=viewDJ&amp;playlist=".$row["id"].
-                  "&amp;seq=selList&amp;session=".$this->session->getSessionID()."\">".
+                  "&amp;seq=selList\">".
                   htmlentities($row["description"]) . "</A></TD>\n";
     
             // Totals
@@ -1237,7 +1230,6 @@ class AddManager extends MenuItem {
             echo "            <OPTION VALUE=\"$row[0]\"$selected>$row[0]\n";
         }
     ?>          </SELECT>
-              <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
               <INPUT TYPE=HIDDEN NAME=action VALUE="addmgr">
               <INPUT TYPE=HIDDEN NAME=subaction VALUE="activity">
               <INPUT TYPE=HIDDEN NAME=seq VALUE="update">

--- a/ui/AddManager.php
+++ b/ui/AddManager.php
@@ -128,12 +128,12 @@ class AddManager extends MenuItem {
        $requestId = $_REQUEST["id"];
        $albumId = $row["id"];
 
-       $hrefDate= "action=addmgr&amp;subaction=adds&amp;date=$date ";
+       $hrefDate= "?action=addmgr&amp;subaction=adds&amp;date=$date ";
        $class = ($requestId && $requestId == $albumId) ? "sel" : "nav";
        $cellDate = "<A CLASS='nav' HREF='" . $hrefDate .
           "' onClick='ConfirmDelete(" . $albumId . "); return false;'>[x]</A>&nbsp;";
 
-       $hrefId =  "action=addmgr&amp;subaction=addsedit&amp;id=" . $albumId;
+       $hrefId = "?action=addmgr&amp;subaction=addsedit&amp;id=" . $albumId;
        $cellId = "<A CLASS='songEdit' HREF='" . $hrefId . "'>&#x270f;</A>";
 
        return "<TD>" . $cellDate . $cellId . "</TD>";

--- a/ui/ChangePass.php
+++ b/ui/ChangePass.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/ChangePass.php
+++ b/ui/ChangePass.php
@@ -69,7 +69,6 @@ class ChangePass extends MenuItem {
         <TD><INPUT TYPE=SUBMIT VALUE=" Change Password "></TD>
       </TR>
     </TABLE>
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=action VALUE="changePass">
     <INPUT TYPE=HIDDEN NAME=validate VALUE="y">
     </FORM>

--- a/ui/ChangePass.php
+++ b/ui/ChangePass.php
@@ -31,7 +31,7 @@ use ZK\UI\UICommon as UI;
 
 class ChangePass extends MenuItem {
     public function processLocal($action, $subaction) {
-        if(isset($_REQUEST["validate"])) {
+        if(isset($_POST["validate"])) {
             $userAPI = Engine::api(IUser::class);
             if($userAPI->validatePassword($this->session->getUser(), $_REQUEST["oldPass"], 0)) {
                 $newPass = $_REQUEST["newPass"];

--- a/ui/Charts.php
+++ b/ui/Charts.php
@@ -96,7 +96,7 @@ class Charts extends MenuItem {
             if($year[0] == $currentYear)
                 echo "<TH>$currentYear</TH>";
             else
-                echo "<TH><A CLASS=\"nav\" HREF=\"?action=viewChart&amp;subaction=weekly&amp;year=" . $year[0] . "&amp;session=".$this->session->getSessionID()."\">" . $year[0] . "</A></TH>";
+                echo "<TH><A CLASS=\"nav\" HREF=\"?action=viewChart&amp;subaction=weekly&amp;year=" . $year[0] . "\">" . $year[0] . "</A></TH>";
             echo "<TD>&nbsp;&nbsp;&nbsp;</TD>";
         }
         $urls = Engine::param('urls');
@@ -149,7 +149,7 @@ class Charts extends MenuItem {
                     echo "      </UL><UL>\n";
                     $month = $m;
                 }
-                echo "        <LI><A HREF=\"?action=viewChart&amp;subaction=weekly&amp;year=$y&amp;month=$m&amp;day=$d&amp;session=".$this->session->getSessionID()."\">Week ending ".date("j F Y", mktime(0,0,0,$m,$d,$y))."</A>\n";
+                echo "        <LI><A HREF=\"?action=viewChart&amp;subaction=weekly&amp;year=$y&amp;month=$m&amp;day=$d\">Week ending ".date("j F Y", mktime(0,0,0,$m,$d,$y))."</A>\n";
             }
             echo "      </UL>\n    </TD></TR>\n";
             echo "  </TABLE>\n";
@@ -181,7 +181,6 @@ class Charts extends MenuItem {
             <INPUT TYPE=HIDDEN NAME=year VALUE=<?php echo $year; ?>>
             <INPUT TYPE=HIDDEN NAME=month VALUE=<?php echo $month; ?>>
             <INPUT TYPE=HIDDEN NAME=day VALUE=<?php echo $day; ?>>
-            <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
           </FORM>
         </TD>
       </TR>
@@ -277,7 +276,7 @@ class Charts extends MenuItem {
                             if($y - $earliestYear < 10)
                                 $name .= " (based on available data)";
                             echo "    <TR><TH CLASS=\"header\" ALIGN=LEFT>Amalgamated charts $dstart - $y</TH></TR>\n    <TR><TD>\n      <UL>\n";
-                            echo "        <LI><A HREF=\"?action=viewChart&amp;subaction=amalgamated&amp;dnum=$dnum&amp;session=".$this->session->getSessionID()."\">Top 100 for the decennium that was the $name</A>\n      </UL><UL>\n";
+                            echo "        <LI><A HREF=\"?action=viewChart&amp;subaction=amalgamated&amp;dnum=$dnum\">Top 100 for the decennium that was the $name</A>\n      </UL><UL>\n";
                         }
                         echo "    <TR><TH CLASS=\"header\" ALIGN=LEFT>Amalgamated charts $y</TH></TR>\n    <TR><TD>\n      <UL>\n";
     
@@ -288,9 +287,9 @@ class Charts extends MenuItem {
                     }
     
                     if($genYearChart)
-                        echo "        <LI><A HREF=\"?action=viewChart&amp;subaction=amalgamated&amp;cyear=$y&amp;session=".$this->session->getSessionID()."\">Top 100 for the year $y</A>\n      </UL><UL>\n";
+                        echo "        <LI><A HREF=\"?action=viewChart&amp;subaction=amalgamated&amp;cyear=$y\">Top 100 for the year $y</A>\n      </UL><UL>\n";
     
-                     echo "        <LI><A HREF=\"?action=viewChart&amp;subaction=amalgamated&amp;year=$y&amp;month=$m&amp;session=".$this->session->getSessionID()."\">".date("F Y", mktime(0,0,0,$m,1,$y))."</A>\n";
+                     echo "        <LI><A HREF=\"?action=viewChart&amp;subaction=amalgamated&amp;year=$y&amp;month=$m\">".date("F Y", mktime(0,0,0,$m,1,$y))."</A>\n";
                 }
     
                 if($year)
@@ -414,8 +413,7 @@ class Charts extends MenuItem {
                 echo "<A CLASS=\"calNav\" HREF=\"".
                              "?s=byAlbumKey&amp;n=". UI::URLify($chart[$i]["tag"]).
                              "&amp;q=10".
-                             "&amp;action=search&amp;session=".$this->session->getSessionID().
-                             "\">". UI::HTMLify($album, 20) . "</A></I>$medium (" .
+                             "&amp;action=search\">". UI::HTMLify($album, 20) . "</A></I>$medium (" .
                      UI::HTMLify($label, 20) . ")\n";
             }
             echo "  </OL></TD></TR>\n</TABLE><BR>\n";
@@ -470,8 +468,7 @@ class Charts extends MenuItem {
                 echo "<A CLASS=\"calNav\" HREF=\"".
                              "?s=byAlbumKey&amp;n=". UI::URLify($chart[$i]["tag"]).
                              "&amp;q=10".
-                             "&amp;action=search&amp;session=".$this->session->getSessionID().
-                             "\">". UI::HTMLify($album, 20) . "</A></I>$medium (" .
+                             "&amp;action=search\">". UI::HTMLify($album, 20) . "</A></I>$medium (" .
                      UI::HTMLify($label, 20) . ")<BR>\n";
             }
             echo "          </TD></TR>\n";
@@ -580,7 +577,6 @@ class Charts extends MenuItem {
         }
     ?>
         </TABLE>
-        <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
         <INPUT TYPE=HIDDEN NAME=action VALUE="viewChart">
         <INPUT TYPE=HIDDEN NAME=subaction VALUE="chartemail">
         <INPUT TYPE=HIDDEN NAME=seq VALUE="update">
@@ -597,7 +593,7 @@ class Charts extends MenuItem {
         $startDate = "";
         $endDate = "$year-$month-$day";
         $displayDate = date("j F Y", mktime(0,0,0,$month,$day,$year));
-        echo "<TABLE WIDTH=\"100%\"><TR><TH ALIGN=LEFT>CMJ upload chart for the week ending $displayDate</TH><!--TH ALIGN=RIGHT><A HREF=\"?action=viewChart&amp;subaction=weekly&amp;year=$year&amp;month=$month&amp;day=$day&amp;session=".$this->session->getSessionID()."\" CLASS=\"nav\">[Back to Weekly]</A></TH--></TR></TABLE><BR>\n";
+        echo "<TABLE WIDTH=\"100%\"><TR><TH ALIGN=LEFT>CMJ upload chart for the week ending $displayDate</TH><!--TH ALIGN=RIGHT><A HREF=\"?action=viewChart&amp;subaction=weekly&amp;year=$year&amp;month=$month&amp;day=$day\" CLASS=\"nav\">[Back to Weekly]</A></TH--></TR></TABLE><BR>\n";
         ////echo "<P CLASS=\"header\">CMJ upload chart for the week ending $displayDate</P>\n";
     
     

--- a/ui/Charts.php
+++ b/ui/Charts.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/DeepStorage.php
+++ b/ui/DeepStorage.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/DeepStorage.php
+++ b/ui/DeepStorage.php
@@ -33,7 +33,7 @@ use ZK\UI\UICommon as UI;
 class DeepStorage extends MenuItem {
     public function processLocal($action, $subaction) {
         $userfile = $_FILES['userfile']['tmp_name'];
-        if(!$userfile) {
+        if(!$userfile || $_SERVER['REQUEST_METHOD'] != 'POST') {
     ?>
       <FORM ENCTYPE="multipart/form-data" ACTION="?" METHOD=post>
         <INPUT TYPE=hidden name=action value="deepStorage">

--- a/ui/DeepStorage.php
+++ b/ui/DeepStorage.php
@@ -37,7 +37,6 @@ class DeepStorage extends MenuItem {
     ?>
       <FORM ENCTYPE="multipart/form-data" ACTION="?" METHOD=post>
         <INPUT TYPE=hidden name=action value="deepStorage">
-        <INPUT TYPE=hidden name=session value="<?php echo $this->session->getSessionID();?>">
         <INPUT TYPE=hidden name=MAX_FILE_SIZE value=100000>
         <TABLE BORDER=0>
           <TR><TD ALIGN=RIGHT>Send this tab-delimited file:</TD><TD><INPUT NAME=userfile TYPE=file></TD></TR>

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -639,6 +639,9 @@ class Editor extends MenuItem {
     }
 
     private function insertUpdateAlbum() {
+        if($_SERVER['REQUEST_METHOD'] != 'POST')
+            return false;
+
         $album = $this->getAlbum();
         $tracks = $this->getTracks();
         $result = Engine::api(IEditor::class)->insertUpdateAlbum($album, $tracks, $this->getLabel());
@@ -658,6 +661,9 @@ class Editor extends MenuItem {
     }
 
     private function insertUpdateLabel() {
+        if($_SERVER['REQUEST_METHOD'] != 'POST')
+            return false;
+
         $label = $this->getLabel();
         $result = Engine::api(IEditor::class)->insertUpdateLabel($label);
         if($result) {

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2019 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -153,7 +153,7 @@ class Editor extends MenuItem {
 
     public static function emitQueueHook($session) {
         if(Engine::api(ILibrary::class)->getNumQueuedTags($session->getUser()))
-            echo "<P>You have <A HREF=\"?session=".$session->getSessionID()."&amp;action=editor&amp;subaction=tagq\" CLASS=\"nav\">tags queued for printing</A>.</P>";
+            echo "<P>You have <A HREF=\"?action=editor&amp;subaction=tagq\" CLASS=\"nav\">tags queued for printing</A>.</P>";
     }
 
     private static function isEmpty($var) {
@@ -449,7 +449,7 @@ class Editor extends MenuItem {
         $this->emitHidden("selcount", $selCount);
         $merged = implode(",", $selLabels);
         echo "        <SCRIPT TYPE=\"text/javascript\" LANGUAGE=\"JavaScript\"><!--\n";
-        echo "        window.open('?target=print&session=".$this->session->getSessionID()."&form=".$form["code"]."&tags=$merged', '_blank', 'toolbar=no,location=no,width=800,height=800');\n";
+        echo "        window.open('?target=print&form=".$form["code"]."&tags=$merged', '_blank', 'toolbar=no,location=no,width=800,height=800');\n";
         echo "        // -->\n";
         echo "        </SCRIPT>\n";
     }

--- a/ui/Home.php
+++ b/ui/Home.php
@@ -40,7 +40,7 @@ class Home extends MenuItem {
 
         $musicDirEmail = Engine::param('email')['md'];
         $musicDirName = Engine::param('md_name');
-        echo "<div class='home-hdr'><label>Music Director:</label> <A HREF='mailto: $musicDirEmail'>$musicDirName</A></div>";
+        echo "<div class='home-hdr'><label>Music Director:</label> <A HREF='mailto:$musicDirEmail'>$musicDirName</A></div>";
 
         $this->emitWhatsOnNow();
         $this->emitTopPlays();

--- a/ui/Home.php
+++ b/ui/Home.php
@@ -45,7 +45,7 @@ class Home extends MenuItem {
         $this->emitWhatsOnNow();
         $this->emitTopPlays();
         echo "<div style='border:0; position:absolute; bottom:0px' CLASS='subhead'>For complete album charting, see our ";
-        echo "<A CLASS='subhead' HREF='?session=".$this->session->getSessionID()."&amp;action=viewChart'><B>Airplay Charts</B></A></div>";
+        echo "<A CLASS='subhead' HREF='?action=viewChart'><B>Airplay Charts</B></A></div>";
     }
 
     private function emitTopPlays($numweeks=1, $limit=10) {
@@ -105,7 +105,7 @@ class Home extends MenuItem {
              // Album
              echo "<TD>" .
                   "<A CLASS='nav' HREF='?s=byAlbumKey&amp;n=" . UI::URLify($tagId).
-                  "&amp;action=search&amp;session=" . $this->session->getSessionID(). "'>".
+                  "&amp;action=search'>".
                   "$album</A> / $label </TD>";
              echo "</TR>\n";
           }
@@ -116,14 +116,13 @@ class Home extends MenuItem {
     private function emitWhatsOnNow() {
         echo "<div class='subhead'>On Now:<div class='home-onnow'>\n";
         $record = Engine::api(IPlaylist::class)->getWhatsOnNow();
-        $sessionId = $this->session->getSessionID();
         if($record && ($row = $record->fetch())) {
             $airId = $row["airid"];
             $airName = htmlentities($row["airname"]);
             $description = htmlentities($row["description"]);
             $showDateTime = Playlists::makeShowDateAndTime($row);
-            $hrefAirName =  "?action=viewDJ&amp;seq=selUser&amp;viewuser=$airId&amp;session=$sessionId";
-            $hrefPL = "?action=viewDate&amp;seq=selList&amp;playlist=$row[0]&amp;session=$sessionId";
+            $hrefAirName =  "?action=viewDJ&amp;seq=selUser&amp;viewuser=$airId";
+            $hrefPL = "?action=viewDate&amp;seq=selList&amp;playlist=$row[0]";
             echo "<A HREF='$hrefPL' CLASS='nav'>$description</A>&nbsp;with&nbsp;";
             echo "<A HREF='$hrefAirName' CLASS='calNav'>$airName</A>";
             echo "<div class='home-datetime'>$showDateTime</div>";

--- a/ui/Home.php
+++ b/ui/Home.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2019 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/Main.php
+++ b/ui/Main.php
@@ -87,7 +87,7 @@ class Main implements IController {
         $station = Engine::param('station');
         $station_full = Engine::param('station_full');
     ?>
-<!DOCTYPE html>
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <HTML>
 <HEAD>
   <TITLE><?php echo $banner;?></TITLE>

--- a/ui/Main.php
+++ b/ui/Main.php
@@ -87,7 +87,7 @@ class Main implements IController {
         $station = Engine::param('station');
         $station_full = Engine::param('station_full');
     ?>
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <HTML>
 <HEAD>
   <TITLE><?php echo $banner;?></TITLE>

--- a/ui/Main.php
+++ b/ui/Main.php
@@ -129,20 +129,19 @@ class Main implements IController {
     }
     
     protected function emitNavbar($dispatcher, $action) {
-        echo "    <P CLASS=\"zktitle\"><A HREF=\"?session=".$this->session->getSessionID()."\">".Engine::param('application')."</A></P>\n";
+        echo "    <P CLASS=\"zktitle\"><A HREF=\"?\">".Engine::param('application')."</A></P>\n";
         echo "    <TABLE CELLPADDING=0>\n";
         $menu = $dispatcher->composeMenu($action, $this->session);
         foreach($menu as $item) {
             echo  "      <TR><TD></TD>" .
                   "<TD><A CLASS=\"" . ($item['selected']?"nav2sel":"nav2") .
                   "\" HREF=\"" .
-                  "?session=".$this->session->getSessionID()."&amp;" .
-                  "action=".$item['action']."\"><B>".$item['label'] .
+                  "?action=".$item['action']."\"><B>".$item['label'] .
                   "</B></A></TD></TR>\n";
         }
         #echo "      <TR><TD COLSPAN=2>&nbsp;</TD></TR>\n";
         if($this->session->isAuth("u")) {
-            $logoutDiv = "<DIV style='margin-top:8px'><A CLASS='nav3' HREF='" .  "?session=".$this->session->getSessionID()."&amp;action=logout'><B>Logout</B></A></DIV>";
+            $logoutDiv = "<DIV style='margin-top:8px'><A CLASS='nav3' HREF='" .  "?action=logout'><B>Logout</B></A></DIV>";
             $userNameDiv = "<DIV class='nav3s'>(". $this->session->getDN() . ")</DIV>";
             echo "<TR><TD></TD><TD>" . $logoutDiv . $userNameDiv . "</TD></TR>\n";
         } else if(!empty(Engine::param('sso')['client_id'])) {
@@ -279,7 +278,7 @@ class Main implements IController {
             $_SERVER['REQUEST_SCHEME']."://".$_SERVER['SERVER_NAME'].
             "/' and try again.</P>".
             "<P>For information on how we use cookies, see the ".
-            "<A HREF='PRIVACY.md'>Privacy Policy</A>.</TD></TR></TABLE>\n";
+            "<A HREF='PRIVACY.md' TARGET='_blank'>Privacy Policy</A>.</TD></TR></TABLE>\n";
             return;
         case "":
             echo "  <TR><TD></TD><TD CLASS=\"sub\">AUTHORIZED USE ONLY!<BR>\n";
@@ -445,7 +444,6 @@ class Main implements IController {
             if($location) {
                 $rq = array(
                     "action" => $action,
-                    "session" => Engine::session()->getSessionID(),
                     "access" => $access
                 );
                 SSOCommon::zkHttpRedirect($location, $rq);

--- a/ui/Main.php
+++ b/ui/Main.php
@@ -357,7 +357,7 @@ class Main implements IController {
                 // the cookie test was successful!
 
                 // clear the test cookie
-                setcookie("testcookie", "", time() - 3600, "/", $_SERVER['SERVER_NAME']);
+                setcookie("testcookie", "", time() - 3600);
                 return false;
             } else {
                 // cookies are not enabled; alert user

--- a/ui/MenuItem.php
+++ b/ui/MenuItem.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/MenuItem.php
+++ b/ui/MenuItem.php
@@ -68,7 +68,7 @@ abstract class MenuItem extends CommandTarget {
         $selected = (($subActionLen?(substr($subAction, 0, $subActionLen) == $menuSubAction):($subAction == $menuSubAction))?" CLASS=\"secSel\"":" CLASS=\"secNorm\"");
         echo "      <TD ALIGN=CENTER$selected>&nbsp;&nbsp;&nbsp;" .
              "<A CLASS=\"linkhead\" HREF=\"" .
-             "?session=".$this->session->getSessionID()."&amp;action=$action&amp;subaction=$menuSubAction\">$description</A>&nbsp;&nbsp;&nbsp;</TD>\n";
+             "?action=$action&amp;subaction=$menuSubAction\">$description</A>&nbsp;&nbsp;&nbsp;</TD>\n";
         echo "      <TD WIDTH=1 BGCOLOR=\"#c0c0c0\"><IMG SRC=\"img/blank.gif\" WIDTH=1 HEIGHT=1 ALT=\"\"></TD>\n";
     }
 }

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -202,7 +202,7 @@ class Playlists extends MenuItem {
     // add track from an ajax post from client. return new track row
     // upon success else 400 response.
     public function handleAddTrack() {
-        $playlistId = trim($_REQUEST["playlist"]);
+        $playlistId = trim($_POST["playlist"]);
         $playlistApi = Engine::api(IPlaylist::class);
         $playlist = $playlistApi->getPlaylist($playlistId, 1);
         $isLiveShow = $playlistApi->IsNowWithinShow($playlist);
@@ -266,7 +266,7 @@ class Playlists extends MenuItem {
 
             if ($updateStatus === 0) {
                 $retMsg = $status == '' ? "DB update error" : $status;
-             } else {
+            } else {
                 // JM 2019-08-15 action and id need to be set
                 // for hyperlinks genereated by makePlaylistObserver (#54)
                 $this->action = $_REQUEST["oaction"];
@@ -292,7 +292,7 @@ class Playlists extends MenuItem {
 
     public function handleMoveTrack() {
         $retVal = [];
-        $list = $_REQUEST["playlist"];
+        $list = $_POST["playlist"];
         $from = $_REQUEST["fromId"];
         $to = $_REQUEST["toId"];
 
@@ -455,7 +455,7 @@ class Playlists extends MenuItem {
     
     // handles post for playlist creation and edit
     public function handleListPost() {
-        $description = $_REQUEST["description"];
+        $description = $_POST["description"];
         $date = $_REQUEST["date"];
         $fromtime = substr($_REQUEST["fromtime"], 0, 5);
         $totime   = substr($_REQUEST["totime"], 0, 5);
@@ -606,13 +606,13 @@ class Playlists extends MenuItem {
     }
 
     public function handleDeleteListPost() {
-        $playlistId = $_REQUEST["playlist"];
+        $playlistId = $_POST["playlist"];
         Engine::api(IPlaylist::class)->deletePlaylist($playlistId);
         $this->emitEditListPicker();
     }
 
     public function handleRestoreListPost() {
-        $playlistId = $_REQUEST["playlist"];
+        $playlistId = $_POST["playlist"];
         $this->restorePlaylist($playlistId);
         $this->emitEditListPicker();
     }
@@ -1272,7 +1272,7 @@ class Playlists extends MenuItem {
     }
     
     public function emitImportList() {
-        $validate = $_REQUEST["validate"];
+        $validate = $_POST["validate"];
         $description = $_REQUEST["description"];
         $date = $_REQUEST["date"];
         $time = $_REQUEST["time"];
@@ -1463,7 +1463,7 @@ class Playlists extends MenuItem {
             }
             // echo "<B>Imported $count tracks.</B>\n";
             fclose($fd);
-            unset($_REQUEST["validate"]);
+            unset($_POST["validate"]);
 
             $_REQUEST["playlist"] = $playlist;
             $this->action = "newListEditor";
@@ -1567,7 +1567,7 @@ class Playlists extends MenuItem {
     public function updateDJInfo() {
         UI::emitJS("js/playlists.pick.js");
 
-        $validate = $_REQUEST["validate"];
+        $validate = $_POST["validate"];
         $multi = $_REQUEST["multi"];
         $url = $_REQUEST["url"];
         $email = $_REQUEST["email"];
@@ -1654,7 +1654,7 @@ class Playlists extends MenuItem {
     public function emitShowLink() {
         UI::emitJS("js/playlists.pick.js");
 
-        $validate = $_REQUEST["validate"];
+        $validate = $_POST["validate"];
         $playlist = $_REQUEST["playlist"];
         $airname = $_REQUEST["airname"];
     

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -447,7 +447,6 @@ class Playlists extends MenuItem {
             <INPUT TYPE=HIDDEN NAME=action VALUE="<?php echo $this->action.$suffix; ?>">
             <INPUT id='playlist-id' TYPE=HIDDEN NAME=playlist VALUE="<?php echo $playlistId;?>">
             <INPUT id='timezone-offset' type=hidden value='<?php echo round(date('Z')/-60, 2); /* server TZ equivalent of javascript now.getTimezoneOffset() */ ?>'>
-            <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
         </FORM>
 
     <?php
@@ -513,8 +512,7 @@ class Playlists extends MenuItem {
                     echo "<SCRIPT TYPE=\"text/javascript\"><!--\n".
                          "\$().ready(function(){".
                          "location.href='?action=newListEditor&playlist=".
-                         Engine::lastInsertId()."&session=".
-                         $this->session->getSessionID()."';});\n".
+                         Engine::lastInsertId()."';});\n".
                          "// -->\n</SCRIPT>\n";
                     return;
                 } else {
@@ -659,7 +657,6 @@ class Playlists extends MenuItem {
             <input TYPE=SUBMIT VALUE=" Restore ">
         </div>
         <input TYPE=hidden name=action VALUE="editListRestore">
-        <input TYPE=hidden name=session VALUE="<?php echo $this->session->getSessionID();?>">
         </form>
       
         <form class='pl-form' id='active-form' ACTION="?" METHOD=POST>
@@ -671,15 +668,13 @@ class Playlists extends MenuItem {
                 <input TYPE=SUBMIT VALUE=" Edit ">&nbsp;&nbsp;&nbsp;
                 <input id='delete-list' TYPE=BUTTON VALUE="Delete">
             </div>
-            <input TYPE=hidden name=session VALUE="<?php echo $this->session->getSessionID();?>">
             <input id='action-type' TYPE=hidden name=action VALUE="editListDetails">
         </form>
         <?php
     }
     
     private function makeEditDiv($entry, $playlist) {
-        $sessionId = $this->session->getSessionID();
-        $href = "?session=" . $sessionId . "&amp;playlist=" . $playlist . "&amp;id=" . 
+        $href = "?playlist=" . $playlist . "&amp;id=" .
                 $entry->getId() . "&amp;action=" . $this->action . "&amp;";
         $editLink = "<A CLASS='songEdit' HREF='" . $href ."seq=editTrack'>&#x270f;</a>";
         //NOTE: in edit mode the list is ordered new to old, so up makes it 
@@ -720,7 +715,6 @@ class Playlists extends MenuItem {
     ?>
         <div class='pl-form-entry'>
             <input id='show-date' name='edate' type='hidden' value="<?php echo $playlist['showdate']; ?>" >
-            <input id='track-session' type='hidden' value='<?php echo $this->session->getSessionID(); ?>'>
             <input id='track-playlist' type='hidden' value='<?php echo $playlistId; ?>'>
             <input id='track-action' type='hidden' value='<?php echo $this->action; ?>'>
             <input id='const-prefix' type='hidden' value='<?php echo self::NME_PREFIX; ?>'>
@@ -882,7 +876,6 @@ class Playlists extends MenuItem {
           break;
       } ?></DIV>
       <FORM ACTION="?" id='edit' METHOD=POST>
-      <input id='track-session' type='hidden' value='<?php echo $this->session->getSessionID(); ?>'>
       <input id='track-playlist' type='hidden' value='<?php echo $playlistId; ?>'>
       <TABLE>
     <?php if($sep) { ?>
@@ -964,7 +957,6 @@ class Playlists extends MenuItem {
     <?php } else { ?>
               <INPUT TYPE=SUBMIT VALUE="  Next &gt;&gt;  ">
     <?php } ?>
-              <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
               <INPUT TYPE=HIDDEN NAME=playlist VALUE="<?php echo $playlistId;?>">
               <INPUT TYPE=HIDDEN NAME=action VALUE="<?php echo $this->action;?>">
               <INPUT TYPE=HIDDEN NAME=tag VALUE="<?php echo $album["tag"];?>">
@@ -1011,7 +1003,6 @@ class Playlists extends MenuItem {
           <INPUT TYPE=SUBMIT VALUE="  Next &gt;&gt;  ">
     <?php } ?>
           <INPUT TYPE=HIDDEN NAME=tag VALUE="<?php echo $album["tag"];?>">
-          <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
           <INPUT TYPE=HIDDEN NAME=action VALUE="<?php echo $this->action;?>">
           <INPUT TYPE=HIDDEN NAME=playlist VALUE="<?php echo $playlist;?>">
           <INPUT TYPE=HIDDEN NAME=seq VALUE="editForm">
@@ -1041,7 +1032,7 @@ class Playlists extends MenuItem {
         $showDateTime = self::makeShowDateAndTime($row);
         echo "<TABLE CELLPADDING=0 CELLSPACING=0 WIDTH=\"100%\">\n    <TR>\n      <TH ALIGN=LEFT>";
         echo "$row[0]</TH>\n      <TH ALIGN=RIGHT>$showDateTime</TH>\n";
-        echo "      <TH ALIGN=RIGHT VALIGN=TOP><A CLASS=\"sub\" HREF=\"#top\" onClick='window.open(\"$script&amp;session=".$this->session->getSessionID()."&amp;playlist=$playlist&amp;format=html\")'>Print</A></TH>\n    </TR>\n  </TABLE>\n";
+        echo "      <TH ALIGN=RIGHT VALIGN=TOP><A CLASS=\"sub\" HREF=\"#top\" onClick='window.open(\"$script&amp;playlist=$playlist&amp;format=html\")'>Print</A></TH>\n    </TR>\n  </TABLE>\n";
     }
     
     private function insertSetSeparator($playlist) {
@@ -1199,7 +1190,6 @@ class Playlists extends MenuItem {
     </TD></TR>
     <TR><TD>
     <INPUT TYPE=SUBMIT VALUE=" Export Playlist ">
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=target VALUE="export">
     </TD></TR></TABLE>
     </FORM>
@@ -1324,7 +1314,6 @@ class Playlists extends MenuItem {
       </TR>
     </TABLE>
     <INPUT TYPE=HIDDEN NAME=button VALUE=" Setup New Airname... ">
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=action VALUE="importExport">
     <INPUT TYPE=HIDDEN NAME=subaction VALUE="importCSV">
     <INPUT TYPE=HIDDEN NAME=playlist VALUE="<?php echo $playlist;?>">
@@ -1353,7 +1342,6 @@ class Playlists extends MenuItem {
       <FORM ENCTYPE="multipart/form-data" ACTION="?" METHOD=post>
         <INPUT TYPE=HIDDEN NAME=action VALUE="importExport">
         <INPUT TYPE=HIDDEN NAME=subaction VALUE="importCSV">
-        <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
         <INPUT TYPE=HIDDEN NAME=validate VALUE="edit">
         <INPUT TYPE=HIDDEN NAME=MAX_FILE_SIZE VALUE=100000>
         <TABLE CELLPADDING=2 CELLSPACING=0>
@@ -1557,7 +1545,6 @@ class Playlists extends MenuItem {
       <FORM ENCTYPE="multipart/form-data" ACTION="?" METHOD=post>
         <INPUT TYPE=HIDDEN NAME=action VALUE="importExport">
         <INPUT TYPE=HIDDEN NAME=subaction VALUE="importJSON">
-        <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
         <INPUT TYPE=HIDDEN NAME=MAX_FILE_SIZE VALUE=100000>
         <TABLE CELLPADDING=2 CELLSPACING=0>
           <TR>
@@ -1633,7 +1620,6 @@ class Playlists extends MenuItem {
     ?>
       <TR><TD COLSPAN=2>&nbsp;</TD></TR>
       <TR><TD>&nbsp;</TD><TD><INPUT TYPE=SUBMIT VALUE="  Update  ">
-              <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
               <INPUT TYPE=HIDDEN NAME=airname VALUE="<?php echo $airnames[0]['id'];?>">
               <INPUT TYPE=HIDDEN id='oldname' VALUE="<?php echo $airnames[0]['airname'];?>">
               <INPUT TYPE=HIDDEN NAME=action VALUE="updateDJInfo">
@@ -1657,7 +1643,6 @@ class Playlists extends MenuItem {
     </SELECT></TD></TR>
     <TR><TD>
     <INPUT TYPE=SUBMIT VALUE=" Next &gt;&gt; ">
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=action VALUE="updateDJInfo">
     <INPUT TYPE=HIDDEN NAME=multi VALUE="y">
     </TD></TR></TABLE>
@@ -1703,7 +1688,6 @@ class Playlists extends MenuItem {
     </SELECT></TD></TR>
     <TR><TD>
     <INPUT TYPE=SUBMIT VALUE=" Show URL ">
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=action VALUE="showLink">
     <INPUT TYPE=HIDDEN NAME=validate VALUE="y">
     </TD></TR></TABLE>
@@ -1745,7 +1729,6 @@ class Playlists extends MenuItem {
     </SELECT></TD></TR>
     <TR><TD>
     <INPUT TYPE=SUBMIT VALUE=" Show URL ">
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=action VALUE="showLink">
     <INPUT TYPE=HIDDEN NAME=validate VALUE="y">
     </TD></TR></TABLE>
@@ -1768,8 +1751,7 @@ class Playlists extends MenuItem {
         $labelSpan = "<span class='songLabel'> / " . $this->smartURL($labelName) . "</span>";
         if($entry->getTag()) {
             $albumTitle = "<A HREF='?s=byAlbumKey&amp;n=" . UI::URLify($entry->getTag()) .
-                          "&amp;q=&amp;action=search&amp;session=" . $this->session->getSessionID() .
-                          "' CLASS='nav'>".$albumName ."</A>";
+                          "&amp;q=&amp;action=search' CLASS='nav'>".$albumName ."</A>";
 
             if ($includeLabel) {
                 $albumTitle = $albumTitle . $labelSpan;
@@ -1875,8 +1857,7 @@ class Playlists extends MenuItem {
         $showDateTime = self::makeShowDateAndTime($playlist);
 
         $dateDiv = "<DIV>".$showDateTime."&nbsp;</DIV>";
-        $djLink = "<A HREF='?action=viewDJ&amp;seq=selUser&amp;session=" . 
-        $this->session->getSessionID() . "&amp;viewuser=$djId' CLASS='nav2'>$djName</A>";
+        $djLink = "<A HREF='?action=viewDJ&amp;seq=selUser&amp;viewuser=$djId' CLASS='nav2'>$djName</A>";
 
         echo "<DIV CLASS='playlistBanner'>&nbsp;" . $showName . " with " . $djLink.$dateDiv . "</DIV>\n";
     }
@@ -1917,8 +1898,7 @@ class Playlists extends MenuItem {
                  echo "<A CLASS=\"nav\" HREF=\"".
                       "?s=byAlbumKey&amp;n=". UI::URLify($result[$i]["tag"]).
                       "&amp;q=". $maxresults.
-                      "&amp;action=search&amp;session=".$this->session->getSessionID().
-                      "\">";
+                      "&amp;action=search\">";
     
             echo $this->smartURL($result[$i]["album"], !$result[$i]["tag"]);
             if($result[$i]["tag"])
@@ -2001,7 +1981,7 @@ class Playlists extends MenuItem {
             echo "      <TR><TH COLSPAN=2 ALIGN=LEFT CLASS=\"subhead\">&nbsp;${blname}Recent reviews</TH></TR>\n";
             $this->emitViewDJAlbum($recentReviews, $block?" CLASS=\"sub\"":"");
             if(sizeof($recentReviews) == $count - 1)
-                echo "  <TR><TD></TD><TD ALIGN=LEFT CLASS=\"sub\"><A HREF=\"?s=byReviewer&amp;n=$viewuser&amp;p=0&amp;q=50&amp;action=viewDJReviews&amp;session=".$this->session->getSessionID()."\" CLASS=\"nav\">More reviews...</A></TD></TR>\n";
+                echo "  <TR><TD></TD><TD ALIGN=LEFT CLASS=\"sub\"><A HREF=\"?s=byReviewer&amp;n=$viewuser&amp;p=0&amp;q=50&amp;action=viewDJReviews\" CLASS=\"nav\">More reviews...</A></TD></TR>\n";
             echo "    </TABLE></TD>\n";
         }
     
@@ -2021,7 +2001,6 @@ class Playlists extends MenuItem {
         </SELECT></TD></TR>
       <TR><TD>
         <INPUT TYPE=SUBMIT VALUE=" View Playlist ">
-        <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
         <INPUT TYPE=HIDDEN NAME=viewuser VALUE="<?php echo $viewuser;?>">
         <INPUT TYPE=HIDDEN NAME=action VALUE="viewDJ">
         <INPUT TYPE=HIDDEN NAME=seq VALUE="selList">
@@ -2082,8 +2061,7 @@ class Playlists extends MenuItem {
                 $dot = 1;
             
             echo "<A CLASS=\"nav\" HREF=\"".
-                 "?action=viewDJ&amp;seq=selUser&amp;viewuser=$row[0]&amp;session=".$this->session->getSessionID().
-                 "\">";
+                 "?action=viewDJ&amp;seq=selUser&amp;viewuser=$row[0]\">";
     
             $displayName = str_replace(" ", "&nbsp;", htmlentities($row[1]));
             echo "$displayName</A>";
@@ -2144,8 +2122,8 @@ class Playlists extends MenuItem {
                     echo "<TR><TD ALIGN=\"RIGHT\" CLASS=\"sub\">" . self::timeToAMPM($row[2]) . "&nbsp;</TD>\n";
                     echo "    <TD><A HREF=\"".
                          "?action=viewDate&amp;seq=selList&amp;playlist=".$row[0].
-                         "&amp;session=".$this->session->getSessionID()."\" CLASS=\"nav\">" .
-                          htmlentities($row[3]) . "</A>&nbsp;&nbsp;";
+                         "\" CLASS=\"nav\">" .
+                         htmlentities($row[3]) . "</A>&nbsp;&nbsp;";
                     echo "(" . htmlentities($row[5]) . ")</TD></TR>\n";
                     $i += 1;
             }
@@ -2192,7 +2170,7 @@ class Playlists extends MenuItem {
                     echo "<TD ALIGN=LEFT VALIGN=TOP CLASS=\"sub\">".$plays[$idx]["airname"]."<BR>";
                     echo "<A HREF=\"".
                          "?action=viewDJ&amp;playlist=".$plays[$idx]["id"].
-                         "&amp;seq=selList&amp;session=".$this->session->getSessionID()."\">".$plays[$idx]["description"]."</A></TD>";
+                         "&amp;seq=selList\">".$plays[$idx]["description"]."</A></TD>";
                 } else
                     echo "<TD COLSPAN=3></TD>";
                 if($i%2)
@@ -2213,14 +2191,14 @@ class ZKCalendar extends \Calendar {
         $this->dates = $dates;
     }
     function getCalendarLink($month, $year) {
-        return "?session=".$this->session->getSessionID()."&amp;action=viewDate&amp;month=$month&amp;year=$year";
+        return "?action=viewDate&amp;month=$month&amp;year=$year";
     }
     function getDateLink($day, $month, $year) {
         $link = "";
         $testDate = date("Y-m-d", mktime(0,0,0,$month,$day,$year));
 
         if(strstr($this->dates, $testDate))
-            $link = "?session=".$this->session->getSessionID()."&amp;action=viewDate&amp;seq=selDate&amp;viewdate=$testDate&amp;month=$month&amp;year=$year";
+            $link = "?action=viewDate&amp;seq=selDate&amp;viewdate=$testDate&amp;month=$month&amp;year=$year";
 
         return $link;
     }

--- a/ui/Reviews.php
+++ b/ui/Reviews.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/Reviews.php
+++ b/ui/Reviews.php
@@ -47,14 +47,14 @@ class Reviews extends MenuItem {
         if(!$tag)
             $tag = $_REQUEST["n"];
         if($this->session->isAuth("u"))
-            echo "<A HREF=\"?session=".$this->session->getSessionID()."&amp;action=searchReviewEdit&amp;tag=$tag\" CLASS=\"nav\"><B>Write a review of this album</B></A>";
+            echo "<A HREF=\"?action=searchReviewEdit&amp;tag=$tag\" CLASS=\"nav\"><B>Write a review of this album</B></A>";
     }
     
     private function emitReviewRow($row, $album) {
         // Album
         echo "  <TR CLASS=\"hborder\"><TD>";
         echo "<A HREF=\"".
-                           "?session=".$this->session->getSessionID()."&amp;action=viewRecentReview&amp;tag=$row[0]\">";
+                           "?action=viewRecentReview&amp;tag=$row[0]\">";
         echo htmlentities($album[0]["album"]);
         echo "</A></TD><TD>";
     
@@ -181,7 +181,7 @@ class Reviews extends MenuItem {
                 echo "</SPAN></TD></TR>\n";
     
                 if($this->session->getUser() == $row[4])
-                    echo "  <TR COLSPAN=3><TD><FONT SIZE=-1><A HREF=\"?session=".$this->session->getSessionID()."&amp;action=searchReviewEdit&amp;tag=$tag\">[This is my review and I want to edit it]</A></FONT></TD></TR>\n";
+                    echo "  <TR COLSPAN=3><TD><FONT SIZE=-1><A HREF=\"?action=searchReviewEdit&amp;tag=$tag\">[This is my review and I want to edit it]</A></FONT></TD></TR>\n";
                 echo "  <TR><TD COLSPAN=3 CLASS=\"review\">\n";
                 echo nl2br(htmlentities($row[2]));
                 echo "\n  </TD></TR>\n";
@@ -295,7 +295,6 @@ class Reviews extends MenuItem {
       </TR>
     </TABLE>
     <INPUT TYPE=HIDDEN NAME=button VALUE=" Setup New Airname... ">
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=created VALUE="<?php echo $_REQUEST["created"];?>">
     <INPUT TYPE=HIDDEN NAME=tag VALUE="<?php echo $_REQUEST["tag"];?>">
     <INPUT TYPE=HIDDEN NAME=action VALUE="searchReviewEdit">
@@ -395,7 +394,6 @@ class Reviews extends MenuItem {
         <INPUT TYPE=CHECKBOX NAME=noise<?php echo $email;?>>E-mail review to Noise
       </TD></TR>
     </TABLE>
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=created VALUE="<?php echo $_REQUEST["created"];?>">
     <INPUT TYPE=HIDDEN NAME=tag VALUE="<?php echo $_REQUEST["tag"];?>">
     <INPUT TYPE=HIDDEN NAME=action VALUE="searchReviewEdit">

--- a/ui/Reviews.php
+++ b/ui/Reviews.php
@@ -264,7 +264,7 @@ class Reviews extends MenuItem {
     public function editReview() {
         $airname = $_REQUEST["airname"];
     
-        if($_REQUEST["validate"]) {
+        if($_POST["validate"]) {
             switch($_REQUEST["button"]) {
             case " Setup New Airname... ":
                 $displayForm = 1;

--- a/ui/Search.php
+++ b/ui/Search.php
@@ -86,10 +86,10 @@ class Search extends MenuItem {
 
 
     // return link to artist or track info.
-    private function makeTrackLink($name, $length) {
+    private function makeTrackLink($searchBy, $name, $length) {
         $linkUrl = UI::URLify($name);
         $linkHtml = $this->HTMLify($name, $length);
-        $link = "<A HREF='?s=byTrack&amp;n=$linkUrl" .
+        $link = "<A HREF='?s=${searchBy}&amp;n=$linkUrl" .
                       "&amp;q=". $this->maxresults.
                       "&amp;action=search&amp;session=".$this->session->getSessionID().
                       "'>$linkHtml</A>";
@@ -108,11 +108,11 @@ class Search extends MenuItem {
         echo "<TD>${trackInfo['seq']}.</TD>";
 
         if ($showArtist) { // collection only
-            $artistLink = $this->makeTrackLink($trackInfo['artist'], 20);
+            $artistLink = $this->makeTrackLink('byArtist', $trackInfo['artist'], 20);
             echo "<TD>$artistLink</TD>";
         }
 
-        $titleLink = $this->makeTrackLink($trackInfo['track'], 32);
+        $titleLink = $this->makeTrackLink('byTrack', $trackInfo['track'], 32);
         echo "<TD>$titleLink</TD>";
     }
 

--- a/ui/Search.php
+++ b/ui/Search.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2019 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/Search.php
+++ b/ui/Search.php
@@ -69,7 +69,6 @@ class Search extends MenuItem {
         echo "<FORM ACTION=\"?\" METHOD=\"POST\">\n";
         echo "<P><B>Find It:</B>&nbsp;&nbsp;<INPUT TYPE=TEXT CLASS=text STYLE=\"width:214px;\" NAME=search id='search' VALUE=\"$search\" autocomplete=off>&nbsp;&nbsp;<SPAN ID=\"total\"></SPAN></P>\n";
         echo "<INPUT TYPE=HIDDEN NAME=action VALUE=\"find\">\n";
-        echo "<INPUT TYPE=HIDDEN NAME=session id='session' VALUE=\"".$this->session->getSessionID()."\">\n";
         echo "<INPUT TYPE=HIDDEN NAME=key id='key' VALUE=''>\n";
         echo "</FORM>\n";
         echo "<SPAN ID=\"results\">Search the database for music, reviews, and playlists.";
@@ -91,8 +90,7 @@ class Search extends MenuItem {
         $linkHtml = $this->HTMLify($name, $length);
         $link = "<A HREF='?s=${searchBy}&amp;n=$linkUrl" .
                       "&amp;q=". $this->maxresults.
-                      "&amp;action=search&amp;session=".$this->session->getSessionID().
-                      "'>$linkHtml</A>";
+                      "&amp;action=search'>$linkHtml</A>";
         return $link;
     }
 
@@ -141,8 +139,7 @@ class Search extends MenuItem {
         echo "<A HREF=\"".
                      "?s=byAlbum&amp;n=". UI::URLify($albums[0]["album"]).
                      "&amp;q=". $this->maxresults.
-                     "&amp;action=search&amp;session=".$this->session->getSessionID().
-                     "\" CLASS=\"nav\">";
+                     "&amp;action=search\" CLASS=\"nav\">";
         echo htmlentities($albums[0]["album"]) . "</A></B></TD>";
     
         $medium = " " . ILibrary::MEDIA[$albums[0]["medium"]];
@@ -190,8 +187,7 @@ class Search extends MenuItem {
             echo "<A HREF=\"".
                          "?s=byArtist&amp;n=". UI::URLify($artist).
                          "&amp;q=". $this->maxresults.
-                         "&amp;action=search&amp;session=".$this->session->getSessionID().
-                         "\" CLASS=\"nav\">";
+                         "&amp;action=search\" CLASS=\"nav\">";
             echo htmlentities($artist) . "</A></B></TD>";
         } else
             echo htmlentities($artist) . "</B></TD>";
@@ -207,8 +203,7 @@ class Search extends MenuItem {
                 echo "<A HREF=\"".
                                "?s=byLabelKey&amp;n=". UI::URLify($albums[0]["pubkey"]).
                                "&amp;q=". $this->maxresults.
-                               "&amp;action=search&amp;session=".$this->session->getSessionID().
-                               "\" CLASS=\"nav\">";
+                               "&amp;action=search\" CLASS=\"nav\">";
                 echo htmlentities($label[0]["name"]) . "</A>";
             } else
                 echo "(Unknown)";
@@ -372,7 +367,6 @@ class Search extends MenuItem {
         </TABLE>
       </TD></TR>
     </TABLE>
-    <INPUT TYPE=HIDDEN id='session' VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN id='sortBy' value=''>
     <INPUT TYPE=HIDDEN id='type' value='<?php echo $labelKey?"albumsByPubkey":""; ?>'>
     <INPUT TYPE=HIDDEN id='key' value='<?php echo $labelKey?htmlspecialchars($this->searchText):""; ?>'>
@@ -381,7 +375,7 @@ class Search extends MenuItem {
     <BR>
     <TABLE class='searchTable' CELLPADDING=2 CELLSPACING=0 BORDER=0>
     <TR><TD><B>Tip:  For a more extensive search,
-               try <A HREF="?session=<?php echo $this->session->getSessionID(); ?>&amp;action=find" CLASS="nav">Find It!</A></B></TD></TR>
+               try <A HREF="?action=find" CLASS="nav">Find It!</A></B></TD></TR>
     </TABLE>
     <?php 
     }
@@ -399,7 +393,7 @@ class Search extends MenuItem {
         if($name) {
             UI::emitJS('js/jquery.bahashchange.min.js');
             UI::emitJS('js/search.library.js');
-            echo "<FORM>\n<INPUT id='session' type='hidden' value='" . $this->session->getSessionID() . "'>\n";
+            echo "<FORM>\n<INPUT id='showTag' type='hidden' value='" . ($this->session->isAuth('u')?'true':'false') . "'>\n";
             echo "<INPUT id='type' type='hidden' value='reviews'>\n";
             echo "<INPUT id='sortBy' type='hidden' value='".$sortBy."'>\n";
             echo "<INPUT id='key' type='hidden' value='" . $this->searchText . "'>\n";

--- a/ui/UserAdmin.php
+++ b/ui/UserAdmin.php
@@ -54,7 +54,7 @@ class UserAdmin extends MenuItem {
         $auGroups = $_REQUEST["auGroups"];
         $auExpire = $_REQUEST["auExpire"];
 
-        if($seq == "editUser") {
+        if($seq == "editUser" && $_SERVER['REQUEST_METHOD'] == 'POST') {
             // Commit the changes
             $user = Engine::api(ILibrary::class)->search(ILibrary::PASSWD_NAME, 0, 1, $uid);
             if(sizeof($user)) {
@@ -64,7 +64,7 @@ class UserAdmin extends MenuItem {
                     echo "<B><FONT COLOR=\"#ff0000\">Update user failed.  Try again later.</FONT></B>\n";
             } else
                 echo "<B><FONT COLOR=\"#ff0000\">Invalid user.  Update failed.</FONT></B>\n";
-        } else if($seq == "addUser") {
+        } else if($seq == "addUser" && $_SERVER['REQUEST_METHOD'] == 'POST') {
           if($uid) {
              if(Engine::api(IUser::class)->insertUser($uid, $auPass, $auName, $auGroups, $auExpire))
                echo "<B><FONT CLASS=\"subhead2\">$uid successfully added</FONT></B>\n";
@@ -212,7 +212,7 @@ class UserAdmin extends MenuItem {
         $auGroups = $_REQUEST["auGroups"];
         $auExpire = $_REQUEST["auExpire"];
     
-        if($seq == "editAirname") {
+        if($seq == "editAirname" && $_SERVER['REQUEST_METHOD'] == 'POST') {
            if($uid) {
               // Get the airname
               $result = Engine::api(IDJ::class)->getAirnames(0, $aid);

--- a/ui/UserAdmin.php
+++ b/ui/UserAdmin.php
@@ -109,7 +109,6 @@ class UserAdmin extends MenuItem {
            x = administrator</TD>
       </TR>
     </TABLE>
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=action VALUE="adminUsers">
     <INPUT TYPE=HIDDEN NAME=seq VALUE="addUser">
     </FORM>
@@ -158,7 +157,6 @@ class UserAdmin extends MenuItem {
       </TR>
     </TABLE>
     <INPUT TYPE=HIDDEN NAME=uid VALUE="<?php echo $uid;?>">
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=action VALUE="adminUsers">
     <INPUT TYPE=HIDDEN NAME=seq VALUE="editUser">
     </FORM>
@@ -170,7 +168,6 @@ class UserAdmin extends MenuItem {
     <P>
     <FORM ACTION="?" METHOD=POST>
     <INPUT TYPE=SUBMIT CLASS=submit VALUE="  New User  ">
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=action VALUE="adminUsers">
     <INPUT TYPE=HIDDEN NAME=seq VALUE="newUser">
     <INPUT TYPE=HIDDEN id='nameCol' VALUE='1'>
@@ -197,7 +194,7 @@ class UserAdmin extends MenuItem {
                 $class = "noQuota";
             else
                 $class = "hborder"; 
-            echo "  <TR CLASS=\"$class\"><TD><A CLASS=\"nav\" HREF=\"?session=".$this->session->getSessionID()."&amp;action=adminUsers&amp;seq=selUser&amp;uid=" . $users[$j]["name"] . "\">" . $users[$j]["name"] . "</A></TD><TD>" .
+            echo "  <TR CLASS=\"$class\"><TD><A CLASS=\"nav\" HREF=\"?action=adminUsers&amp;seq=selUser&amp;uid=" . $users[$j]["name"] . "\">" . $users[$j]["name"] . "</A></TD><TD>" .
                         $users[$j]["realname"] . "</TD><TD>" .
                         $users[$j]["groups"] . "&nbsp;</TD><TD>" .
                         $users[$j]["expires"] . "&nbsp;</TD><TD>" .
@@ -265,7 +262,6 @@ class UserAdmin extends MenuItem {
       </TR>
     </TABLE>
     <INPUT TYPE=HIDDEN NAME=aid VALUE="<?php echo $aid;?>">
-    <INPUT TYPE=HIDDEN NAME=session VALUE="<?php echo $this->session->getSessionID();?>">
     <INPUT TYPE=HIDDEN NAME=action VALUE="adminUsers">
     <INPUT TYPE=HIDDEN NAME=subaction VALUE="airnames">
     <INPUT TYPE=HIDDEN NAME=seq VALUE="editAirname">
@@ -294,7 +290,7 @@ class UserAdmin extends MenuItem {
                 $class = "noQuota";
             else
                 $class = "hborder"; 
-            echo "  <TR CLASS=\"$class\"><TD><A CLASS=\"nav\" HREF=\"?session=".$this->session->getSessionID()."&amp;subaction=airnames&amp;action=adminUsers&amp;seq=selAirname&amp;aid=" . $users[$j]["id"] . "\">" . $users[$j]["airname"] . "</A></TD><TD>" .
+            echo "  <TR CLASS=\"$class\"><TD><A CLASS=\"nav\" HREF=\"?subaction=airnames&amp;action=adminUsers&amp;seq=selAirname&amp;aid=" . $users[$j]["id"] . "\">" . $users[$j]["airname"] . "</A></TD><TD>" .
                         $users[$j]["name"] . "</TD><TD>" .
                         $users[$j]["realname"] . "&nbsp;</TD></TR>\n";
         }

--- a/ui/UserAdmin.php
+++ b/ui/UserAdmin.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *


### PR DESCRIPTION
Historically, zookeeper sessions have been persisted via IDs passed as request parameters.  An optional session cookie was used in the event the user left the site and returned; in this case, he would still be logged in by virtue of the cookie.  However, the cookie was not required and zookeeper would function without it.

This PR makes the following changes:
1. The session cookie is now mandatory;
2. A check is made before login to ensure the user has cookies enabled.  The user is messaged to enable cookies if they are not enabled;
3. Session cookies are scoped to the port of the specific zookeeper instance, thus allowing multiple zookeeper instances to run on the same server without session cookie collision;
4. The session cookie is now the only source of the session ID; any session request parameters are ignored;
5. Session request parameters have been removed from all query strings, forms, and JavaScript;
6. The SameSite flag is used to ensure the session cookie is not cross-site submitted for POST requests;
7. All state-changing operations have been updated to require POST.

The user experience should be exactly the same as it was previously.  Only in the event the user has cookies disabled will there be any difference, and in this case, the user will be messaged to enable cookies and try again.

CSRF attempts to redirect the user's browser to perform state-changing operations should now be more difficult, because of the SameSite cookie flag.  In addition, the session cookie now has HttpOnly and Secure flags as well.
