### PR TITLE
Rebase spin timestamps on playlist time change

### DIFF
--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -42,6 +42,7 @@ interface IPlaylist {
     function getWhatsOnNow();
     function insertPlaylist($user, $date, $time, $description, $airname);
     function updatePlaylist($playlist, $date, $time, $description, $airname);
+    function duplicatePlaylist($playlist);
     function getSeq($list, $id);
     function moveTrack($list, $id, $toId, $clearTimestamp=true);
     function getTrack($id);

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -211,11 +211,9 @@ class PlaylistImpl extends DBO implements IPlaylist {
                 if($from != $wasFrom && $to != $wasTo) {
                     $wasFromStamp = \DateTime::createFromFormat(self::TIME_FORMAT,
                                     $date . " " . $wasFrom);
-                    $fromMinute = $wasFromStamp->format("G") * 60 +
-                                $wasFromStamp->format("i");
-                    $toMinute = $fromStamp->format("G") * 60 +
-                                $fromStamp->format("i");
-                    $offset = $toMinute - $fromMinute;
+                    $diff = $wasFromStamp->diff($fromStamp);
+                    $offset = $diff->h * 60 + $diff->i;
+                    $offset *= $diff->invert?-1:1;
 
                     if($offset) {
                         $query = "UPDATE tracks " .

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -570,18 +570,19 @@ class Playlists extends MenuItem {
         $airName = '';
 
         $sourcePlaylist = null;
+        $api = Engine::api(IPlaylist::class);
         if(isset($playlistId) && $playlistId > 0) {
             if($_POST["duplicate"])
-                $playlistId = Engine::api(IPlaylist::class)->duplicatePlaylist($playlistId);
+                $playlistId = $api->duplicatePlaylist($playlistId);
             if($playlistId)
-                $sourcePlaylist = Engine::api(IPlaylist::class)->getPlaylist($playlistId, 1);
+                $sourcePlaylist = $api->getPlaylist($playlistId, 1);
         } else {
             $WEEK_SECONDS = 60 *60 * 24 * 7;
             $nowDateStr =  (new \DateTime())->format("Y-m-d");
             $nowDateTimestamp =  (new \DateTime($nowDateStr))->getTimestamp();
 
             // see if there is a PL on this day last week. if so use it.
-            $playlists = Engine::api(IPlaylist::class)->getPlaylists(1, 1, "", 1, $this->session->getUser(), 1, 10);
+            $playlists = $api->getPlaylists(1, 1, "", 1, $this->session->getUser(), 1, 10);
             while ($playlists && ($playlist = $playlists->fetch())) {
                 $showDate = new \DateTime($playlist['showdate']);
                 $dateInterval = $nowDateTimestamp - $showDate->getTimestamp();

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -571,7 +571,10 @@ class Playlists extends MenuItem {
 
         $sourcePlaylist = null;
         if(isset($playlistId) && $playlistId > 0) {
-            $sourcePlaylist = Engine::api(IPlaylist::class)->getPlaylist($playlistId, 1);
+            if($_POST["duplicate"])
+                $playlistId = Engine::api(IPlaylist::class)->duplicatePlaylist($playlistId);
+            if($playlistId)
+                $sourcePlaylist = Engine::api(IPlaylist::class)->getPlaylist($playlistId, 1);
         } else {
             $WEEK_SECONDS = 60 *60 * 24 * 7;
             $nowDateStr =  (new \DateTime())->format("Y-m-d");
@@ -668,6 +671,7 @@ class Playlists extends MenuItem {
             </select>
             <div style='margin-top:4px'>
                 <input TYPE=SUBMIT VALUE=" Edit ">&nbsp;&nbsp;&nbsp;
+                <input TYPE=SUBMIT NAME="duplicate" VALUE="Duplicate">&nbsp;&nbsp;&nbsp;
                 <input id='delete-list' TYPE=BUTTON VALUE="Delete">
             </div>
             <input id='action-type' TYPE=hidden name=action VALUE="editListDetails">


### PR DESCRIPTION
If the playlist is moved to another time of day, such as for a rebroadcast, this PR rebases the spin timestamps relative to the new start time.

If the playlist end time is not altered, we consider it an in-place edit of an existing playlist.  In this case, we do not rebase the timestamps.

In addition, this PR adds a new `Duplicate` button to the Edit Playlist screen, to provide single-step playlist duplication for rebroadcast, etc.

Fixes #193