### PR TITLE
Revise timestamp handling in playlist import/export

### DIFF
--- a/controllers/API.php
+++ b/controllers/API.php
@@ -145,6 +145,8 @@ class JSONSerializer extends Serializer {
                         $nextProp = ",";
                         continue 2;
                     }
+                } else if($field == "created") {
+                    $val = ExportPlaylist::extractTime($val);
                 }
                 echo "$nextProp\"$field\":\"".
                      self::jsonspecialchars(stripslashes($val)).
@@ -239,6 +241,8 @@ class XMLSerializer extends Serializer {
                         echo "<charts>$val</charts>\n";
                         continue 2;
                     }
+                } else if($field == "created") {
+                    $val = ExportPlaylist::extractTime($val);
                 }
                 echo "<$field>".
                      self::spec2hex(stripslashes($val)).

--- a/controllers/ExportPlaylist.php
+++ b/controllers/ExportPlaylist.php
@@ -143,6 +143,13 @@ class ExportPlaylist extends CommandTarget implements IController {
         echo "</playlist>\n";
     }
     
+    public static function extractTime($datetime) {
+        // yyyy-mm-dd hh:mm:ss
+        if(strlen($datetime) == 19)
+            $datetime = substr($datetime, 11, 5);
+        return $datetime;
+    }
+
     public function emitCSV() {
         header("Content-type: application/csv");
         header("Content-disposition: attachment; filename=playlist.csv");
@@ -156,13 +163,14 @@ class ExportPlaylist extends CommandTarget implements IController {
         echo "Date\n$this->date\n\n";
     
         // emit the tracks
-        echo "Artist\tTrack\tAlbum\tTag\tLabel\n";
+        echo "Artist\tTrack\tAlbum\tTag\tLabel\tTimestamp\n";
         $observer = (new PlaylistObserver())->onSpin(function($entry) {
             echo $entry->getArtist()."\t".
                  $entry->getTrack()."\t".
                  $entry->getAlbum()."\t".
                  $entry->getTag()."\t".
-                 $entry->getLabel()."\n";
+                 $entry->getLabel()."\t".
+                 self::extractTime($entry->getCreated())."\n";
         });
         while($row = $this->records->fetch()) {
             $observer->observe(new PlaylistEntry($row));

--- a/controllers/ExportPlaylist.php
+++ b/controllers/ExportPlaylist.php
@@ -142,7 +142,13 @@ class ExportPlaylist extends CommandTarget implements IController {
         }
         echo "</playlist>\n";
     }
-    
+
+    /**
+     * extract the time component of a datetime string
+     *
+     * @param datetime string in IPlaylist::TIME_FORMAT_SQL format
+     * @return time component on success; original input value otherwise
+     */
     public static function extractTime($datetime) {
         // yyyy-mm-dd hh:mm:ss
         if(strlen($datetime) == 19)

--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -28,6 +28,9 @@ namespace ZK\Engine;
  * Playlist operations
  */
 interface IPlaylist {
+    const TIME_FORMAT = "Y-m-d Hi"; // eg, 2019-01-01 1234
+    const TIME_FORMAT_SQL = "Y-m-d H:i:s"; // 2019-01-01 12:34:56
+
     const SPECIAL_TRACK = "~~~~~~~~";
     const COMMENT_FLAG = "C";
     const LOG_FLAG = "L";

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -29,8 +29,6 @@ namespace ZK\Engine;
  * Playlist operations
  */
 class PlaylistImpl extends DBO implements IPlaylist {
-    const TIME_FORMAT = "Y-m-d Hi"; // eg, 2019-01-01 1234
-    const TIME_FORMAT_SQL = "Y-m-d H:i:s"; // 2019-01-01 12:34:56
     const GRACE_START = "-15 minutes";
     const GRACE_END = "+30 minutes";
     const DUPLICATE_PREFIX = "Rebroadcast: ";

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1317,7 +1317,7 @@ class Playlists extends MenuItem {
             // We hit either CR or LF alone, or neither
             $pos = $posn + $posr;
     
-        if(strlen($tempbuf)) {
+        if(is_int($posn) || is_int($posr)) {
             // We hit a CR or LF; return the line
             $out = substr($tempbuf, 0, $pos);
     

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -317,25 +317,11 @@ class Playlists extends MenuItem {
         echo json_encode($retVal);
     }
 
-    public static function showStartTime($timeRange) {
-        $retVal = "??";
-        $timeAr = explode("-", $timeRange);
-        if (count($timeAr) == 2)
-           $retVal = self::hourToAMPM($timeAr[0]);
-
-        return $retVal;
-    }
-
-    public static function showEndTime($timeRange) {
-        $retVal = "??";
-        $timeAr = explode("-", $timeRange);
-        if (count($timeAr) == 2)
-           $retVal = self::hourToAMPM($timeAr[1]);
-
-        return $retVal;
-    }
-    
     public static function hourToAMPM($hour, $full=0) {
+        // account for legacy, free-format time encoding
+        if(!is_numeric($hour))
+            return $hour;
+
         $h = (int)floor($hour/100);
         $m = (int)$hour % 100;
         $min = $m || $full?(":" . sprintf("%02d", $m)):"";
@@ -1897,13 +1883,9 @@ class Playlists extends MenuItem {
             UI::emitJS('js/playlists.track.js');
     }
 
-
     public static function makeShowDateAndTime($row) {
-        $showStart = self::showStartTime($row[2]);
-        $showEnd = self::showEndTime($row[2]);
-        $showDate = self::timestampToDate($row[1]);
-        $showDateTime = $showDate . " " . $showStart . "-" . $showEnd;
-        return $showDateTime;
+        return self::timestampToDate($row['showdate']) . " " .
+               self::timeToAMPM($row['showtime']);
     }
 
     private function emitPlaylistBanner($playlistId, $playlist) {

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1178,9 +1178,16 @@ class Playlists extends MenuItem {
     <?php 
     }
 
-    private static function fixupTimestamp($timestamp, $window) {
+    /**
+     * scrub imported timestamp
+     *
+     * @param timestamp target
+     * @param window DateTime array from IPlaylist::getTimestampWindow
+     * @return scrubbed timestamp or null if not in show window
+     */
+    private static function fixupTimestamp(\DateTime $timestamp, array $window) {
         // normalize for non-local timezone
-        $timestamp->setTimezone((new \DateTime())->getTimezone());
+        $timestamp->setTimezone($window['start']->getTimezone());
 
         // transpose timestamp to show date
         $showDate = $window['start']->format("Y-m-d");

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1524,11 +1524,7 @@ class Playlists extends MenuItem {
         $userfile = $_FILES['userfile']['tmp_name'];
         if($userfile) {
             // read the JSON file
-            $file = "";
-            $fd = new \SplFileObject($userfile, "r");
-            while($fd->valid())
-                $file .= $fd->fgets();
-            $fd = null; // close
+            $file = file_get_contents($userfile);
 
             // parse the file
             $json = json_decode($file);

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -317,11 +317,25 @@ class Playlists extends MenuItem {
         echo json_encode($retVal);
     }
 
-    public static function hourToAMPM($hour, $full=0) {
-        // account for legacy, free-format time encoding
-        if(!is_numeric($hour))
-            return $hour;
+    public static function showStartTime($timeRange) {
+        $retVal = "??";
+        $timeAr = explode("-", $timeRange);
+        if (count($timeAr) == 2)
+           $retVal = self::hourToAMPM($timeAr[0]);
 
+        return $retVal;
+    }
+
+    public static function showEndTime($timeRange) {
+        $retVal = "??";
+        $timeAr = explode("-", $timeRange);
+        if (count($timeAr) == 2)
+           $retVal = self::hourToAMPM($timeAr[1]);
+
+        return $retVal;
+    }
+    
+    public static function hourToAMPM($hour, $full=0) {
         $h = (int)floor($hour/100);
         $m = (int)$hour % 100;
         $min = $m || $full?(":" . sprintf("%02d", $m)):"";
@@ -1883,9 +1897,13 @@ class Playlists extends MenuItem {
             UI::emitJS('js/playlists.track.js');
     }
 
+
     public static function makeShowDateAndTime($row) {
-        return self::timestampToDate($row['showdate']) . " " .
-               self::timeToAMPM($row['showtime']);
+        $showStart = self::showStartTime($row[2]);
+        $showEnd = self::showEndTime($row[2]);
+        $showDate = self::timestampToDate($row[1]);
+        $showDateTime = $showDate . " " . $showStart . "-" . $showEnd;
+        return $showDateTime;
     }
 
     private function emitPlaylistBanner($playlistId, $playlist) {


### PR DESCRIPTION
This PR makes the following changes:

* adds track timestamp values to csv export and import
* uses correct date on import for timestamps in time-only format
* simplifies track timestamp value to time-only format on export
* supports 12-hour clock on import
* normalizes for non-local timezone on import
* fixes csv import not to terminate on the first empty line

Fixes #201