### PR TITLE
Account for non-music entries in push feed

### DIFF
--- a/controllers/PushServer.php
+++ b/controllers/PushServer.php
@@ -87,10 +87,13 @@ if(file_exists(__DIR__."/../vendor/autoload.php")) {
             $show['description'] = $val['name'];
             $show['airname'] = $val['airname'];
             $show['id'] = $val['show_id'];
-            $spin['id'] = $val['id'];
-            $spin['track'] = $val['track_title'];
-            $spin['artist'] = $val['track_artist'];
-            $spin['album'] = $val['track_album'];
+            if($val['id']) {
+                $spin['id'] = $val['id'];
+                $spin['track'] = $val['track_title'];
+                $spin['artist'] = $val['track_artist'];
+                $spin['album'] = $val['track_album'];
+            } else
+                $spin = null;
         }
 
         public function __construct($loop) {
@@ -184,9 +187,16 @@ if(file_exists(__DIR__."/../vendor/autoload.php")) {
         }
 
         public function sendNotification($msg = null, $client = null) {
-            if($msg)
-                self::fromJson($msg, $this->show, $this->spin);
-            else
+            if($msg) {
+                self::fromJson($msg, $show, $spin);
+                if(!$this->show || $this->show['id'] != $show['id'] ||
+                        $this->spin && $spin && $this->spin['id'] != $spin['id'] ||
+                        ($spin xor $this->spin)) {
+                    $this->show = $show;
+                    $this->spin = $spin;
+                } else
+                    return;
+            } else
                 $msg = self::toJson($this->show, $this->spin);
 
             if($client)

--- a/controllers/PushServer.php
+++ b/controllers/PushServer.php
@@ -116,11 +116,17 @@ if(file_exists(__DIR__."/../vendor/autoload.php")) {
                         $spin = $entry->asArray();
                         $spin['artist'] = UI::swapNames($spin['artist']);
                         $event = $spin;
+                    })->onComment(function($entry) use(&$event) {
+                        $event = null;
+                    })->onLogEvent(function($entry) use(&$event) {
+                        $event = null;
+                    })->onSetSeparator(function($entry) use(&$event) {
+                        $event = null;
                     }), 0, OnNowFilter::class);
                 if($event && $this->spin && $event['id'] != $this->spin['id'] ||
                         ($event xor $this->spin)) {
                     $this->spin = $event;
-                    $this->nextSpin = $filter->peek(PlaylistEntry::TYPE_SPIN);
+                    $this->nextSpin = $filter->peek();
                     $changed = true;
                 }
             } else if($this->show) {
@@ -221,8 +227,7 @@ if(file_exists(__DIR__."/../vendor/autoload.php")) {
         const WSSERVER_PORT = 32080;
 
         public static function sendAsyncNotification($show = null, $spin = null) {
-            $data = ($show != null && $spin != null)?
-                    NowAiringServer::toJson($show, $spin):"";
+            $data = ($show != null)?NowAiringServer::toJson($show, $spin):"";
             $socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
             socket_sendto($socket, $data, strlen($data), 0,
                             PushServer::WSSERVER_HOST, PushServer::WSSERVER_PORT);

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -283,10 +283,13 @@ class Playlists extends MenuItem {
                 //   > 0    ordinal of inserted entry
                 $retVal['seq'] = $size ? $size : $playlistApi->getSeq(0, $entry->getId());
 
-                if($isLiveShow && $type == PlaylistEntry::TYPE_SPIN) {
+                if($isLiveShow) {
                     $playlist['id'] = $playlistId;
-                    $spin = $entry->asArray();
-                    $spin['artist'] = UI::swapNames($spin['artist']);
+                    if($type == PlaylistEntry::TYPE_SPIN) {
+                        $spin = $entry->asArray();
+                        $spin['artist'] = UI::swapNames($spin['artist']);
+                    } else
+                        $spin = null;
                     PushServer::sendAsyncNotification($playlist, $spin);
                 }
             }

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -259,7 +259,7 @@ class Playlists extends MenuItem {
             }
 
             if ($spinDateTime != null)
-                $entry->setCreated($spinDateTime->format('D M d, Y G:i'));
+                $entry->setCreated($spinDateTime->format(IPlaylist::TIME_FORMAT_SQL));
 
             $updateStatus = $playlistApi->insertTrackEntry($playlistId, $entry, $status);
 
@@ -854,7 +854,7 @@ class Playlists extends MenuItem {
       $timepickerClass = "timepicker";
       if($isLive && !$entry->getCreated()) {
           // pre-fill empty time in live playlist with 'now'
-          $entry->setCreated($nowTime->format("Y-m-d H:i:s"));
+          $entry->setCreated($nowTime->format(IPlaylist::TIME_FORMAT_SQL));
           $timepickerClass .= " prefilled-input";
       }
       $timepickerTime = $this->getTimepickerTime($entry->getCreated());

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -224,11 +224,9 @@ class Playlists extends MenuItem {
             $spinDateTime = new \DateTime("${spinDate} ${spinTime}");
 
         $entry = null;
-        $wantTimestamp = true;
         switch($type) {
         case PlaylistEntry::TYPE_SET_SEPARATOR:
             $entry = (new PlaylistEntry())->setSetSeparator();
-            $wantTimestamp = false; // only type that does not get a time val.
             break;
         case PlaylistEntry::TYPE_COMMENT:
             $entry = (new PlaylistEntry())->setComment(mb_substr(trim(str_replace("\r\n", "\n", $_REQUEST["comment"])), 0, PlaylistEntry::MAX_COMMENT_LENGTH));
@@ -256,7 +254,7 @@ class Playlists extends MenuItem {
             $retMsg = 'success';
             $id = '';
             $status = '';
-            if ($wantTimestamp && $isLiveShow) {
+            if ($isLiveShow) {
                 $spinDateTime = new \DateTime("now");
             }
 


### PR DESCRIPTION
Non-music entries (PSAs, Promos, LIDs, set separators) interrupt the flow of music.  This PR sends a show-only notification (show details but blank track info) upon the commencement of one or more non-music entries.  Usual notifications resume with the next music track, where a full notification with track details is sent.

This PR also adds second-level resolution to new live entries added through the UI, and as well, adds a timestamp to UI-entered live set separators.


