### PR TITLE
optimize album info retrieval, deprecate redundant APIs

### DIFF
--- a/engine/IEditor.php
+++ b/engine/IEditor.php
@@ -38,8 +38,5 @@ interface IEditor {
     function dequeueTag($tag, $user);
     function getNumQueuedTags($user);
     function getQueuedTags($user);
-    function getAlbum($tag);
-    function getTracks($tag, $isColl);
-    function getLabel($key);
     function setLocation($tag, $location, $bin=null);
 }

--- a/engine/IEditor.php
+++ b/engine/IEditor.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/engine/impl/Editor.php
+++ b/engine/impl/Editor.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/engine/impl/Editor.php
+++ b/engine/impl/Editor.php
@@ -309,28 +309,6 @@ class EditorImpl extends DBO implements IEditor {
         return $stmt->iterate();
     }
 
-    public function getAlbum($tag) {
-        $query = "SELECT * FROM albumvol a LEFT JOIN publist p ON a.pubkey = p.pubkey WHERE tag = ?";
-        $stmt = $this->prepare($query);
-        $stmt->bindValue(1, $tag);
-        return $stmt->executeAndFetch();
-    }
-
-    public function getTracks($tag, $isColl) {
-        $table = $isColl?"colltracknames":"tracknames";
-        $query = "SELECT * FROM $table WHERE tag = ? ORDER BY seq";
-        $stmt = $this->prepare($query);
-        $stmt->bindValue(1, $tag);
-        return $stmt->iterate();
-    }
-
-    public function getLabel($key) {
-        $query = "SELECT * FROM publist WHERE pubkey = ?";
-        $stmt = $this->prepare($query);
-        $stmt->bindValue(1, $key);
-        return $stmt->executeAndFetch();
-    }
-
     public function setLocation($tag, $location, $bin=null) {
         $query = "UPDATE albumvol SET location = ?, " .
                  "updated = now(), bin = ? WHERE tag = ?";

--- a/engine/impl/Library.php
+++ b/engine/impl/Library.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/engine/impl/Library.php
+++ b/engine/impl/Library.php
@@ -157,7 +157,7 @@ class LibraryImpl extends DBO implements ILibrary {
             break;
         case ILibrary::ALBUM_KEY:
             settype($search, "integer");
-            $query = "SELECT * FROM albumvol WHERE tag=? LIMIT ?, ?";
+            $query = "SELECT * FROM albumvol a LEFT JOIN publist p ON a.pubkey = p.pubkey WHERE tag=? LIMIT ?, ?";
             $bindType = 3;
             break;
         case ILibrary::ALBUM_NAME:

--- a/ui/AddManager.php
+++ b/ui/AddManager.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/AddManager.php
+++ b/ui/AddManager.php
@@ -412,16 +412,8 @@ class AddManager extends MenuItem {
         if(sizeof($albumrec) > 0) {
             echo "          <TR><TD ALIGN=RIGHT>Artist:</TD><TH>" . htmlentities($albumrec[0]["artist"]) . "&nbsp;&nbsp;</TH></TR>\n";
             echo "          <TR><TD ALIGN=RIGHT>Album:</TD><TH>" . htmlentities($albumrec[0]["album"]) . "&nbsp;&nbsp;</TH></TR>\n";
-            $labelKey = $albumrec[0]["pubkey"];
-            if(!$labelCache[$labelKey]) {
-                // Secondary search for label name
-                $label = $libraryAPI->search(ILibrary::LABEL_PUBKEY, 0, 1, $labelKey);
-                if(sizeof($label)){
-                    $labelCache[$labelKey] = $label[0]["name"];
-                } else
-                    $labelCache[$labelKey] = "(Unknown)";
-            }
-            echo "          <TR><TD ALIGN=RIGHT>Label:</TD><TH>" . htmlentities($labelCache[$labelKey]) . "</TH></TR>\n";
+            $name = isset($albumrec[0]["name"])?$albumrec[0]["name"]:"(Unknown)";
+            echo "          <TR><TD ALIGN=RIGHT>Label:</TD><TH>" . htmlentities($name) . "</TH></TR>\n";
             $this->emitHidden("artist", $artist = $albumrec[0]["artist"]);
             $this->emitHidden("album", $album = $albumrec[0]["album"]);
         }

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -827,7 +827,7 @@ class Editor extends MenuItem {
             $this->skipVar("seltag");
             $this->skipVar("selpubkey");
         } else {
-            $row = Engine::api(IEditor::class)->getAlbum($_REQUEST["seltag"]);
+            $row = Engine::api(ILibrary::class)->search(ILibrary::ALBUM_KEY, 0, 1, $_REQUEST["seltag"])[0];
             $artist = stripslashes($row["artist"]);
             $album = stripslashes($row["album"]);
             $agenre = $row["category"];
@@ -839,7 +839,7 @@ class Editor extends MenuItem {
             $name = $_REQUEST["name"];
             if(!$name) {
                 if($_REQUEST["selpubkey"]) {
-                    $row = Engine::api(IEditor::class)->getLabel($_REQUEST["selpubkey"]);
+                    $row = Engine::api(ILibrary::class)->search(ILibrary::LABEL_PUBKEY, 0, 1, $_REQUEST["selpubkey"])[0];
                     $name = $row["name"];
                     $address = $row["address"];
                     $city = $row["city"];
@@ -975,7 +975,7 @@ class Editor extends MenuItem {
             echo "  <TR><TD></TD><TD>&nbsp;</TD></TR>\n";
             $this->skipVar("selpubkey");
         } else {
-            $row = Engine::api(IEditor::class)->getLabel($_REQUEST["selpubkey"]);
+            $row = Engine::api(ILibrary::class)->search(ILibrary::LABEL_PUBKEY, 0, 1, $_REQUEST["selpubkey"])[0];
             $foreign = $row["international"] == "T";
             echo "  <TR><TD></TD><TD>&nbsp;</TD></TR>\n";
             echo "  <TR><TD ALIGN=RIGHT>Label&nbsp;ID:</TD><TH ALIGN=LEFT ID=\"pubkey\">".$row["pubkey"]."</TH></TR>\n";
@@ -1059,8 +1059,8 @@ class Editor extends MenuItem {
         $isCollection = $_REQUEST["coll"];
 
         if($_REQUEST["seltag"] && !$_REQUEST["tdb"]) {
-            $tracks = Engine::api(IEditor::class)->getTracks($_REQUEST["seltag"], $isCollection);
-            while($row = $tracks->fetch()) {
+            $tracks = Engine::api(ILibrary::class)->search($isCollection?ILibrary::COLL_KEY:ILibrary::TRACK_KEY, 0, 2000, $_REQUEST["seltag"]);
+            foreach($tracks as $row) {
                 $this->emitHidden("track".$row["seq"], $row["track"]);
                 $_POST["url".$row["seq"]] = $row["url"];
                 $_POST["track".$row["seq"]] = $row["track"];
@@ -1102,7 +1102,7 @@ class Editor extends MenuItem {
 
     public static function makeLabel($tag, $charset, $dark=1,
                                         $boxEscape="", $textEscape="") {
-        $al = Engine::api(IEditor::class)->getAlbum($tag);
+        $al = Engine::api(ILibrary::class)->search(ILibrary::ALBUM_KEY, 0, 1, $tag)[0];
       
         while($tag) {
            $digits[] = $tag % 10;

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1073,12 +1073,8 @@ class Playlists extends MenuItem {
                     // invalid tag
                     $this->emitTagForm($playlist, "Invalid Tag");
                 } else {
-                    // Secondary search for label name
-                    $lab = Engine::api(ILibrary::class)->search(ILibrary::LABEL_PUBKEY, 0, 1, $albumrec[0]["pubkey"]);
-                    if(sizeof($lab)){
-                        $albumrec[0]["label"] = $lab[0]["name"];
-                    } else
-                        $albumrec[0]["label"] = "(Unknown)";
+                    $albumrec[0]["label"] = isset($albumrec[0]["name"])?
+                          $albumrec[0]["name"]:"(Unknown)";
                     $this->emitEditForm($playlist, $id, $albumrec[0], $track);
                 }
             } else
@@ -1466,12 +1462,9 @@ class Playlists extends MenuItem {
                             $line[0] = $albumrec[0]["artist"];
                             $line[2] = $albumrec[0]["album"];
     
-                            // Secondary search for label name
-                            $lab = Engine::api(ILibrary::class)->search(ILibrary::LABEL_PUBKEY, 0, 1, $albumrec[0]["pubkey"]);
-                            if(sizeof($lab))
-                                $line[4] = $lab[0]["name"];
-                            else
-                                $line[4] = "(Unknown)";
+                            // update label name
+                            $line[4] = isset($albumrec[0]["name"])?
+                                $albumrec[0]["name"]:"(Unknown)";
                         }
                     }
 

--- a/ui/Reviews.php
+++ b/ui/Reviews.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/Reviews.php
+++ b/ui/Reviews.php
@@ -285,10 +285,8 @@ class Reviews extends MenuItem {
             // Emit the review
             $body = "$artist / $album\r\n";
     
-            $label = $libAPI->search(ILibrary::LABEL_PUBKEY, 0, 1, $albums[0]["pubkey"]);
-    
-            if(sizeof($label)) {
-                $labeln = str_replace(" Records", "", $label[0]["name"]);
+            if(isset($albums[0]["name"])) {
+                $labeln = str_replace(" Records", "", $albums[0]["name"]);
                 $labeln = str_replace(" Recordings", "", $labeln);
                 $body .= "Label: " . UI::deLatin1ify($labeln) . "\r\n";
             } else

--- a/ui/Search.php
+++ b/ui/Search.php
@@ -197,16 +197,12 @@ class Search extends MenuItem {
     
         echo "$month/$year</B></TD></TR>\n";
         echo "  <TR><TD ALIGN=RIGHT>Label:</TD><TD><B>";
-        if($albums[0]["pubkey"] != 0) {
-            $label = Engine::api(ILibrary::class)->search(ILibrary::LABEL_PUBKEY, 0, 1, $albums[0]["pubkey"]);
-            if(sizeof($label)) {
-                echo "<A HREF=\"".
-                               "?s=byLabelKey&amp;n=". UI::URLify($albums[0]["pubkey"]).
-                               "&amp;q=". $this->maxresults.
-                               "&amp;action=search\" CLASS=\"nav\">";
-                echo htmlentities($label[0]["name"]) . "</A>";
-            } else
-                echo "(Unknown)";
+        if(isset($albums[0]["name"])) {
+            echo "<A HREF=\"".
+                           "?s=byLabelKey&amp;n=". UI::URLify($albums[0]["pubkey"]).
+                           "&amp;q=". $this->maxresults.
+                           "&amp;action=search\" CLASS=\"nav\">";
+            echo htmlentities($albums[0]["name"]) . "</A>";
         } else
             echo "(Unknown)";
         echo "</B></TD><TD COLSPAN=2>&nbsp;</TD><TD>";

--- a/ui/Search.php
+++ b/ui/Search.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *


### PR DESCRIPTION
This PR updates the ILibrary::search by ALBUM_KEY API to include label information in the result, so that client does not have to call a second time to get the label info.  All callers previously doing two calls have been updated accordingly.

In addition, several redundant APIs in IEditor have been deprecated in favour of ILibrary equivalents.