### PR TITLE
Add cache control for external assets

### DIFF
--- a/controllers/RSS.php
+++ b/controllers/RSS.php
@@ -344,7 +344,18 @@ class RSS extends CommandTarget implements IController {
     }
 
     private function emitXSLT() {
+        $mtime = max(filemtime(realpath(__FILE__)),
+                     filemtime(realpath(__DIR__."/../css/zoostyle.css")));
+        header("ETag: \"${mtime}\""); // RFC 2616 requires ETag in 304 response
+        if(isset($_SERVER['HTTP_IF_NONE_MATCH']) &&
+                strstr($_SERVER['HTTP_IF_NONE_MATCH'], "\"${mtime}\"") !== false ||
+                isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) &&
+                strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $mtime) {
+            http_response_code(304); // Not Modified
+            return;
+        }
         header("Content-type: application/xslt+xml");
+        header("Last-Modified: ".gmdate('D, d M Y H:i:s', $mtime)." GMT");
         ob_start("ob_gzhandler"); ?>
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Zookeeper Online (C) 1997-2021 Jim Mason <jmason@ibinx.com> | @source: https://zookeeper.ibinx.com/ | @license: magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3.0 -->

--- a/css/.csshandler.php
+++ b/css/.csshandler.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2019 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -28,9 +28,19 @@ if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
     http_response_code(404);
     return;
 }
-    
+
+$mtime = filemtime($target);
+header("ETag: \"${mtime}\""); // RFC 2616 requires ETag in 304 response
+if(isset($_SERVER['HTTP_IF_NONE_MATCH']) &&
+        strstr($_SERVER['HTTP_IF_NONE_MATCH'], "\"${mtime}\"") !== false ||
+        isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) &&
+        strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $mtime) {
+    http_response_code(304); // Not Modified
+    return;
+}
+
 header("Content-Type: text/css");
-header("Last-Modified: ".gmdate('D, d M Y H:i:s', filemtime($target))." GMT");
+header("Last-Modified: ".gmdate('D, d M Y H:i:s', $mtime)." GMT");
 
 // for HEAD requests, there is nothing more to do
 if($_SERVER['REQUEST_METHOD'] == "HEAD")

--- a/js/.jshandler.php
+++ b/js/.jshandler.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2019 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -30,9 +30,19 @@ if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
     http_response_code(404);
     return;
 }
-    
+
+$mtime = filemtime($target);
+header("ETag: \"${mtime}\""); // RFC 2616 requires ETag in 304 response
+if(isset($_SERVER['HTTP_IF_NONE_MATCH']) &&
+        strstr($_SERVER['HTTP_IF_NONE_MATCH'], "\"${mtime}\"") !== false ||
+        isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) &&
+        strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $mtime) {
+    http_response_code(304); // Not Modified
+    return;
+}
+
 header("Content-Type: application/javascript");
-header("Last-Modified: ".gmdate('D, d M Y H:i:s', filemtime($target))." GMT");
+header("Last-Modified: ".gmdate('D, d M Y H:i:s', $mtime)." GMT");
 
 // only announce source maps on files which are not already minified
 if(substr_compare($target, ".min.js", -7)) {

--- a/js/.mapgenerator.php
+++ b/js/.mapgenerator.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -32,9 +32,19 @@ if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
     http_response_code(404);
     return;
 }
-    
+
+$mtime = filemtime($target);
+header("ETag: \"${mtime}\""); // RFC 2616 requires ETag in 304 response
+if(isset($_SERVER['HTTP_IF_NONE_MATCH']) &&
+        strstr($_SERVER['HTTP_IF_NONE_MATCH'], "\"${mtime}\"") !== false ||
+        isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) &&
+        strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $mtime) {
+    http_response_code(304); // Not Modified
+    return;
+}
+
 header("Content-Type: application/json");
-header("Last-Modified: ".gmdate('D, d M Y H:i:s', filemtime($target))." GMT");
+header("Last-Modified: ".gmdate('D, d M Y H:i:s', $mtime)." GMT");
 
 // for HEAD requests, there is nothing more to do
 if($_SERVER['REQUEST_METHOD'] == "HEAD")


### PR DESCRIPTION
Zookeeper already ensures that changes to external assets (such as css and js files) propagate to the client by means of URI asset decoration (7fd2e6a). Specifically, if an asset changes on the server, its resource locator/URI also changes.  From the point of view of the client, the asset is different, as it has a different address/URI; hence, the client is guaranteed to issue a new request to retrieve the latest revision.  In this way, the webpage and its external assets are always guaranteed to be in-sync.

However, we do not provide any means to prevent re-delivery of assets which are *not* stale. That is to say, if the client requests an asset that it already has cached, and the cached copy is up-to-date, we return the asset rather than returning the HTTP 304 Not Modified status.

This PR implements If-Modified-Since and If-None-Match (ETag) semantics. These request header fields allow the client to indicate versions of assets it already has cached.  This PR checks the assets against the supplied cache control headers; if the assets are unchanged, it returns HTTP 304 Not Modified.