### PR TITLE
Improve URL highlighter

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -275,26 +275,6 @@ want to support the optional push notification service, you will need to:
      (e.g., wss://example.org/push/onair);
    * 'http_endpoints' is an array of targets to receive the HTTP requests
 
-### URL highlighter (optional)
-
-By default, Zookeeper provides rudimentary highlighting of URLs in
-playlist entries.  Improved URL highlighting can be obtained by
-installing the
-[url-highlight](https://github.com/vstelmakh/url-highlight) package.
-
-To install url-highlight, first install Composer, if you do not
-already have it installed somewhere on your system.  (For information
-on installing Composer, see 'Install PHP Composer' in [Push
-Notification](#user-content-push-notification-optional), above.)
-
-Once you have Composer, install url-highlight as follows:
-
-        cd /example/path/to/zookeeper
-        php <Composer directory>/composer.phar require vstelmakh/url-highlight
-
-Zookeeper will automatically use url-highlight, if it is installed in
-this way; if not, it will fall back to the built-in legacy highlighter.
-
 #### Example systemd file for push notification service
 
 This file goes into the /etc/systemd/system directory of Debian:
@@ -319,6 +299,26 @@ This file goes into the /etc/systemd/system directory of Debian:
     WantedBy=default.target
 
 See systemctl(1) for information on how to control the service.
+
+### URL highlighter (optional)
+
+By default, Zookeeper provides rudimentary highlighting of URLs in
+playlist entries.  Improved URL highlighting can be obtained by
+installing the
+[url-highlight](https://github.com/vstelmakh/url-highlight) package.
+
+To install url-highlight, first install Composer, if you do not
+already have it installed somewhere on your system.  (For information
+on installing Composer, see 'Install PHP Composer' in [Push
+Notification](#user-content-push-notification-optional), above.)
+
+Once you have Composer, install url-highlight as follows:
+
+        cd /example/path/to/zookeeper
+        php <Composer directory>/composer.phar require vstelmakh/url-highlight
+
+Zookeeper will automatically use url-highlight, if it is installed in
+this way; if not, it will fall back to the built-in legacy highlighter.
 
 ___
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -275,6 +275,26 @@ want to support the optional push notification service, you will need to:
      (e.g., wss://example.org/push/onair);
    * 'http_endpoints' is an array of targets to receive the HTTP requests
 
+### URL highlighter (optional)
+
+By default, Zookeeper provides rudimentary highlighting of URLs in
+playlist entries.  Improved URL highlighting can be obtained by
+installing the
+[url-highlight](https://github.com/vstelmakh/url-highlight) package.
+
+To install url-highlight, first install Composer, if you do not
+already have it installed somewhere on your system.  (For information
+on installing Composer, see 'Install PHP Composer' in [Push
+Notification](#user-content-push-notification-optional), above.)
+
+Once you have Composer, install url-highlight as follows:
+
+        cd /example/path/to/zookeeper
+        php <Composer directory>/composer.phar require vstelmakh/url-highlight
+
+Zookeeper will automatically use url-highlight, if it is installed in
+this way; if not, it will fall back to the built-in legacy highlighter.
+
 #### Example systemd file for push notification service
 
 This file goes into the /etc/systemd/system directory of Debian:

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -143,6 +143,15 @@ $config = [
      ],
 
     /**
+     * enable push notification
+     *
+     * dependencies must be installed for this setting to take effect
+     *
+     * see INSTALLATION.md for details
+     */
+    'push_enabled' => true,
+
+    /**
      * push notification proxy
      *
      * see INSTALLATION.md for details

--- a/config/config.kzsu.php
+++ b/config/config.kzsu.php
@@ -140,6 +140,15 @@ $config = [
      ],
 
     /**
+     * enable push notification
+     *
+     * dependencies must be installed for this setting to take effect
+     *
+     * see INSTALLATION.md for details
+     */
+    'push_enabled' => true,
+
+    /**
      * push notification proxy
      *
      * see INSTALLATION.md for details

--- a/controllers/Dispatcher.php
+++ b/controllers/Dispatcher.php
@@ -24,6 +24,9 @@
 
 namespace ZK\Controllers;
 
+if(file_exists(__DIR__."/../vendor/autoload.php"))
+    include __DIR__."/../vendor/autoload.php";
+
 include __DIR__."/../engine/Engine.php";
 
 use ZK\Engine\Engine;

--- a/controllers/PushServer.php
+++ b/controllers/PushServer.php
@@ -39,9 +39,7 @@ use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
-if(file_exists(__DIR__."/../vendor/autoload.php")) {
-    include(__DIR__."/../vendor/autoload.php");
-
+if(interface_exists(MessageComponentInterface::class)) {
     class NowAiringServer implements MessageComponentInterface {
         const TIME_FORMAT_INTERNAL = "Y-m-d Hi"; // eg, 2019-01-01 1234
 

--- a/controllers/PushServer.php
+++ b/controllers/PushServer.php
@@ -39,7 +39,8 @@ use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
-if(interface_exists(MessageComponentInterface::class)) {
+if(interface_exists(MessageComponentInterface::class) &&
+        Engine::param('push_enabled', true)) {
     class NowAiringServer implements MessageComponentInterface {
         const TIME_FORMAT_INTERNAL = "Y-m-d Hi"; // eg, 2019-01-01 1234
 
@@ -281,7 +282,7 @@ if(interface_exists(MessageComponentInterface::class)) {
                 return;
             }
 
-            echo "Push notification dependencies are missing.\n\n";
+            echo "Push notification is disabled or dependencies are missing.\n\n";
             echo "See INSTALLATION.md for more information.\n";
         }
     }

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -35,6 +35,9 @@ use ZK\Engine\PlaylistObserver;
 
 use ZK\UI\UICommon as UI;
 
+use VStelmakh\UrlHighlight\UrlHighlight;
+
+
 class Playlists extends MenuItem {
     /* private */ const NME_PREFIX = "nme-";
 
@@ -61,6 +64,7 @@ class Playlists extends MenuItem {
 
     private $action;
     private $subaction;
+    private $urlHighlighter;
 
     public function processLocal($action, $subaction) {
         $this->action = $action;
@@ -70,9 +74,14 @@ class Playlists extends MenuItem {
     
     private function smartURL($name, $detect=true) {
         if($detect) {
-            //$name = UI::HTMLify($name, 20);
+            if(!isset($this->urlHighlighter))
+                $this->urlHighlighter = class_exists(UrlHighlight::class)?new UrlHighlight():false;
+
             $name = htmlentities($name);
-    
+
+            if($this->urlHighlighter)
+                return $this->urlHighlighter->highlightUrls($name);
+
             $words = explode(" ", $name);
             for($i=0; $i<sizeof($words); $i++) {
                 $word = $words[$i];


### PR DESCRIPTION
Zookeeper has historically provided rudimentary highlighting of URLs in playlist entries.  This PR implements optional enhanced URL highlighting via the [url-highlight](https://github.com/vstelmakh/url-highlight) package.

At the same time, the PR refactors PHP Composer autoload to the Dispatcher, to facilitate additional Composer dependencies going forward.
