### PR TITLE
Allow administrator to duplicate playlist of any user

### DIFF
--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -46,6 +46,7 @@ interface IPlaylist {
     function insertPlaylist($user, $date, $time, $description, $airname);
     function updatePlaylist($playlist, $date, $time, $description, $airname);
     function duplicatePlaylist($playlist);
+    function reparentPlaylist($playlist, $user);
     function getSeq($list, $id);
     function moveTrack($list, $id, $toId, $clearTimestamp=true);
     function getTrack($id);

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -313,6 +313,14 @@ class PlaylistImpl extends DBO implements IPlaylist {
         return $success?$newListId:false;
     }
 
+    public function reparentPlaylist($playlist, $user) {
+        $query = "UPDATE lists SET dj=? WHERE id=?";
+        $stmt = $this->prepare($query);
+        $stmt->bindValue(1, $user);
+        $stmt->bindValue(2, $playlist);
+        return $stmt->execute();
+    }
+
     private function populateSeq($list) {
         $query = "SET @seq = 0; ".
                  "UPDATE tracks SET seq = (@seq := @seq + 1) ".

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -31,7 +31,7 @@ namespace ZK\Engine;
 class PlaylistImpl extends DBO implements IPlaylist {
     const GRACE_START = "-15 minutes";
     const GRACE_END = "+30 minutes";
-    const DUPLICATE_PREFIX = "Rebroadcast: ";
+    const DUPLICATE_SUFFIX = " (rebroadcast from %F j, Y%)";
     const DUPLICATE_COMMENT =
         "Rebroadcast of an episode originally aired on %F j, Y%.";
 
@@ -272,9 +272,17 @@ class PlaylistImpl extends DBO implements IPlaylist {
         $stmt->bindValue(1, $playlist);
         $from = $stmt->executeAndFetch();
 
+        $description = $from['description'] .
+            preg_replace_callback("/%([^%]*)%/",
+                function($matches) use ($from) {
+                    return \DateTime::createFromFormat(
+                        self::TIME_FORMAT,
+                        $from['showdate'] . " 0000")->format($matches[1]);
+                }, self::DUPLICATE_SUFFIX);
+
         $success = $from?$this->insertPlaylist($from['dj'],
                                      $from['showdate'], $from['showtime'],
-                                     self::DUPLICATE_PREFIX . $from['description'],
+                                     $description,
                                      $from['airname']):false;
         if($success) {
             $newListId = $this->lastInsertId();

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -31,7 +31,7 @@ namespace ZK\Engine;
 class PlaylistImpl extends DBO implements IPlaylist {
     const GRACE_START = "-15 minutes";
     const GRACE_END = "+30 minutes";
-    const DUPLICATE_SUFFIX = " (rebroadcast from %F j, Y%)";
+    const DUPLICATE_SUFFIX = " (rebroadcast from %M j, Y%)";
     const DUPLICATE_COMMENT =
         "Rebroadcast of an episode originally aired on %F j, Y%.";
 

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -31,7 +31,6 @@ namespace ZK\Engine;
 class PlaylistImpl extends DBO implements IPlaylist {
     const GRACE_START = "-15 minutes";
     const GRACE_END = "+30 minutes";
-    const DUPLICATE_SUFFIX = " (rebroadcast from %M j, Y%)";
     const DUPLICATE_COMMENT =
         "Rebroadcast of an episode originally aired on %F j, Y%.";
 
@@ -272,17 +271,9 @@ class PlaylistImpl extends DBO implements IPlaylist {
         $stmt->bindValue(1, $playlist);
         $from = $stmt->executeAndFetch();
 
-        $description = $from['description'] .
-            preg_replace_callback("/%([^%]*)%/",
-                function($matches) use ($from) {
-                    return \DateTime::createFromFormat(
-                        self::TIME_FORMAT,
-                        $from['showdate'] . " 0000")->format($matches[1]);
-                }, self::DUPLICATE_SUFFIX);
-
         $success = $from?$this->insertPlaylist($from['dj'],
                                      $from['showdate'], $from['showtime'],
-                                     $description,
+                                     $from['description'],
                                      $from['airname']):false;
         if($success) {
             $newListId = $this->lastInsertId();

--- a/js/playlists.info.js
+++ b/js/playlists.info.js
@@ -40,7 +40,7 @@ $().ready(function(){
     }
 
     var isUpdate = $("#playlist-id").val().length > 0;
-    if (isUpdate) {
+    if (isUpdate && $("#duplicate").val() != 1) {
         $('#edit-submit-but').prop('value' ,'Next >');
     } else {
         var roundedDateTime = getRoundedDateTime(15);

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -439,9 +439,9 @@ class Playlists extends MenuItem {
                 <INPUT id='show-airname' TYPE='text' LIST='airnames' NAME='airname' required autocomplete="off" VALUE='<?php echo !is_null($airName)?$airName:($description?"None":""); ?>'/>
                 <DATALIST id='airnames'>
                   <?php
-                      // if an administrator has reparented a playlist,
+                      // if a vaultkeeper has reparented a playlist,
                       // allow it to keep the existing airname
-                      if($this->session->isAuth("x") && !is_null($airName) && !preg_match("/\'$airName\'/", $airNames))
+                      if($this->session->isAuth("v") && !is_null($airName) && !preg_match("/\'$airName\'/", $airNames))
                           echo "<OPTION VALUE='$airName'>";
                       echo $airNames; ?>
                 </DATALIST>
@@ -600,7 +600,7 @@ class Playlists extends MenuItem {
                 $playlistId = $api->duplicatePlaylist($playlistId);
             if($playlistId) {
                 $sourcePlaylist = $api->getPlaylist($playlistId, 1);
-                if($this->session->isAuth("x") && $this->session->getUser() != $sourcePlaylist["dj"])
+                if($this->session->isAuth("v") && $this->session->getUser() != $sourcePlaylist["dj"])
                     $api->reparentPlaylist($playlistId, $this->session->getUser());
             }
         } else {
@@ -1921,7 +1921,7 @@ class Playlists extends MenuItem {
         $djName = $playlist['airname'];
         $showDateTime = self::makeShowDateAndTime($playlist);
 
-        if(!$editMode && $this->session->isAuth("x"))
+        if(!$editMode && $this->session->isAuth("v"))
             $showDateTime .= "&nbsp;<A HREF='javascript:document.duplist.submit();' TITLE='Duplicate Playlist'>&#x1f4cb;</A><FORM NAME='duplist' ACTION='?' METHOD='POST'><INPUT TYPE='hidden' NAME='action' VALUE='editListDetails'><INPUT TYPE='hidden' NAME='duplicate' VALUE='1'><INPUT TYPE='hidden' NAME='playlist' VALUE='$playlistId'></FORM>";
 
         $dateDiv = "<DIV>".$showDateTime."&nbsp;</DIV>";

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -412,6 +412,7 @@ class Playlists extends MenuItem {
         $isoDate = $date ? str_replace("/", "-", $date) : '';
         $isoTimeAr = $this->zkTimeRangeToISOTimeAr($zkTimeRange);
         $airNames = $this->getDJAirNames();
+        $foreignAirname = !empty($airName) && !preg_match("/\'$airName\'/", $airNames);
         $duplicate = isset($_POST["duplicate"]) && $_POST["duplicate"];
         $userAction = $duplicate ? "Create Duplicate " : ($playlistId ? "Edit " : "Create ");
         ?>
@@ -438,12 +439,12 @@ class Playlists extends MenuItem {
             </div>
             <div>
                 <label>Air Name:</label>
-                <INPUT id='show-airname' TYPE='text' LIST='airnames' NAME='airname' required autocomplete="off" VALUE='<?php echo !is_null($airName)?$airName:($description?"None":""); ?>'/>
+                <INPUT id='show-airname' TYPE='text' LIST='airnames' NAME='airname' required autocomplete="off" VALUE='<?php echo (!empty($airName)?$airName:($description?"None":""))."'"; /*if($foreignAirname) echo " readonly";*/ ?> />
                 <DATALIST id='airnames'>
                   <?php
                       // if a vaultkeeper has reparented a playlist,
                       // allow it to keep the existing airname
-                      if($this->session->isAuth("v") && !is_null($airName) && !preg_match("/\'$airName\'/", $airNames))
+                      if($foreignAirname)
                           echo "<OPTION VALUE='$airName'>";
                       echo $airNames; ?>
                 </DATALIST>

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -491,7 +491,7 @@ class Playlists extends MenuItem {
             } else {
                 // if airname is unchanged, use it as-is
                 //
-                // this allows an administrator who has reparented another
+                // this allows a vaultkeeper who has reparented another
                 // user's playlist to keep the existing airname on the list
                 if(isset($playlistId) && $playlistId > 0) {
                     $playlist = Engine::api(IPlaylist::class)->getPlaylist($playlistId, 1);

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -439,7 +439,18 @@ class Playlists extends MenuItem {
             </div>
             <div>
                 <label>Air Name:</label>
-                <INPUT id='show-airname' TYPE='text' LIST='airnames' NAME='airname' required autocomplete="off" VALUE='<?php echo (!empty($airName)?$airName:($description?"None":""))."'"; /*if($foreignAirname) echo " readonly";*/ ?> />
+                <INPUT id='show-airname' TYPE='text' LIST='airnames' NAME='airname' required autocomplete="off" VALUE='<?php
+                      echo (!is_null($airName)?
+                              $airName:($description?"None":"")) . "'";
+
+                      // disable airname field when reparenting
+                      //
+                      // we could use 'readonly', but it doesn't grey out
+                      // and is still focusable.  'disabled' gives what
+                      // we want, but as it does not submit its value, we
+                      // include the airname in an extra hidden field.
+                      if($foreignAirname)
+                          echo " disabled /><INPUT name='airname' type='hidden' value='$airName'"; ?> />
                 <DATALIST id='airnames'>
                   <?php
                       // if a vaultkeeper has reparented a playlist,

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -471,7 +471,6 @@ class Playlists extends MenuItem {
     
     // handles post for playlist creation and edit
     public function handleListPost() {
-        $duplicate = isset($_POST["duplicate"]) && $_POST["duplicate"];
         $description = $_POST["description"];
         $date = $_REQUEST["date"];
         $fromtime = substr($_REQUEST["fromtime"], 0, 5);
@@ -490,12 +489,6 @@ class Playlists extends MenuItem {
             $playlistId = $_REQUEST["playlist"];
 
             $api = Engine::api(IPlaylist::class);
-            if(isset($playlistId) && $playlistId > 0 && $duplicate) {
-                $playlistId = $_REQUEST["playlist"] = $api->duplicatePlaylist($playlistId);
-                $playlist = $api->getPlaylist($playlistId, 1);
-                if($this->session->isAuth("v") && $this->session->getUser() != $playlist["dj"])
-                    $api->reparentPlaylist($playlistId, $this->session->getUser());
-            }
 
             // process the airname
             if(!strcasecmp($airname, "None")) {
@@ -507,8 +500,7 @@ class Playlists extends MenuItem {
                 // this allows a vaultkeeper who has reparented another
                 // user's playlist to keep the existing airname on the list
                 if(isset($playlistId) && $playlistId > 0) {
-                    if(!isset($playlist))
-                        $playlist = $api->getPlaylist($playlistId, 1);
+                    $playlist = $api->getPlaylist($playlistId, 1);
                     if($playlist["airname"] == $airname)
                         $aid = $playlist["id"];
                 }
@@ -534,6 +526,13 @@ class Playlists extends MenuItem {
             }
 
             if(isset($playlistId) && $playlistId > 0) {
+                if(isset($_POST["duplicate"]) && $_POST["duplicate"]) {
+                    $playlistId = $_REQUEST["playlist"] = $api->duplicatePlaylist($playlistId);
+                    $playlist = $api->getPlaylist($playlistId, 1);
+                    if($this->session->isAuth("v") && $this->session->getUser() != $playlist["dj"])
+                        $api->reparentPlaylist($playlistId, $this->session->getUser());
+                }
+
                 // update existing playlist
                 $success = $api->updatePlaylist(
                         $playlistId, $date, $showTime, $description, $aid);

--- a/ui/UserAdmin.php
+++ b/ui/UserAdmin.php
@@ -106,6 +106,7 @@ class UserAdmin extends MenuItem {
            g = station-only login<BR>
            m = music library editor<BR>
            n = a-file add manager<BR>
+           v = vaultkeeper (duplicate any playlist)<BR>
            x = administrator</TD>
       </TR>
     </TABLE>
@@ -153,6 +154,7 @@ class UserAdmin extends MenuItem {
            g = station-only login<BR>
            m = music library editor<BR>
            n = a-file add manager<BR>
+           v = vaultkeeper (duplicate any playlist)<BR>
            x = administrator</TD>
       </TR>
     </TABLE>


### PR DESCRIPTION
This PR provides an administrator with the ability to duplicate the playlist of any user for subsequent rebroadcast.

The duplicate function is exposed to administrator users as a tiny clipboard icon in the playlist header of any playlist accessed through 'Playlists by Date' or 'DJ Zone!':

![Screenshot from 2021-06-11 18-02-24](https://user-images.githubusercontent.com/6860356/121724439-ccf41c80-cadf-11eb-92fd-2d802aab27e6.png)

The resulting duplicate maintains the airname of the original list, but it becomes 'owned' by the administrator; that is, 'Edit Playlist' of the administrator and not the original user has access to the duplicate list.

Known Issues/Limitations:
* Lists duplicated in this way appear in Edit Playlist together with the administrator's own playlists.  We might want to partition them into another view, analogous to the deleted view.  In the interim, I suggest using a separate account to do the duplication, to avoid comingling the lists;
* ~~Clearing the playlist date and time fields is not currently done.  The administrator must set these appropriately~~;
* ~~There should probably be a confirmation dialog when the duplicate button is pressed **because the duplication happens immediately**~~;
* The duplication icon is subtle; we may want to revisit appearance and placement;
* There is a new role 'v' (vaultkeeper) for this functionality.  This allows delegation of the role to a non-administrator user responsible for automation, etc.  If an administrator wants the functionality, he needs to add the 'v' role in addition to 'x'.

Fixes #223 

[edit: Date and time fields are now cleared upon duplication; these fields are partly smart filled as with New Playlist.  As well, the duplication action no longer occurs immediately, but instead is delayed until after the form is submitted.  Hence, no pressing need for a confirmation, since one can cancel out at that point with no unwanted dup.]

[edit: New role 'v']
