### PR TITLE
Deprecate CMJ chart export

### DIFF
--- a/ui/UserAdmin.php
+++ b/ui/UserAdmin.php
@@ -101,7 +101,6 @@ class UserAdmin extends MenuItem {
       </TR><TR>
         <TD>&nbsp;</TD>
         <TD>Groups:<BR>
-           c = CMJ chart builder<BR>
            d = disabled account<BR>
            g = station-only login<BR>
            m = music library editor<BR>
@@ -148,7 +147,6 @@ class UserAdmin extends MenuItem {
       </TR><TR>
         <TD>&nbsp;</TD>
         <TD>Groups:<BR>
-           c = CMJ chart builder<BR>
            d = disabled account<BR>
            g = station-only login<BR>
            m = music library editor<BR>


### PR DESCRIPTION
The CMJ New Music Report ceased operation some years ago.

CMJ had a rather byzantine format for weekly reporting.  Zookeeper has historically provided a feature to export weekly charts in a format specifically suitable for upload to CMJ.

This PR removes CMJ chart export functionality.

There is a related e-mail chart called 'Trades'.  This PR does **not** affect the Trades chart.
