### PR TITLE
RewriteRule with target path info can result in error under fastcgi

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,7 +21,7 @@ RewriteRule ^zk-feed-reader\.xslt$ controllers/RSS.xslt [QSA,L]
 RewriteRule ^zkapi\.php$ index.php?target=api [QSA,L]
 RewriteRule ^ssoLogin\.php$ index.php?target=sso [QSA,L]
 RewriteCond $0 !^\.mdhandler.php/.*$
-RewriteRule ^(.+)\.md$ .mdhandler.php/$1.md [L]
+RewriteRule ^(.+)\.md$ .mdhandler.php?/$1.md [L]
 RewriteRule ^zk$ - [R=404,L]
 # The URI below is an arbitrary endpoint for internal use.
 # It can be any available localhost port.  There should be

--- a/.htaccess
+++ b/.htaccess
@@ -21,7 +21,7 @@ RewriteRule ^zk-feed-reader\.xslt$ controllers/RSS.xslt [QSA,L]
 RewriteRule ^zkapi\.php$ index.php?target=api [QSA,L]
 RewriteRule ^ssoLogin\.php$ index.php?target=sso [QSA,L]
 RewriteCond $0 !^\.mdhandler.php/.*$
-RewriteRule ^(.+)\.md$ .mdhandler.php [L,E=ASSET:/$1.md]
+RewriteRule ^(.+)\.md$ .mdhandler.php?asset=/$1.md [L]
 RewriteRule ^zk$ - [R=404,L]
 # The URI below is an arbitrary endpoint for internal use.
 # It can be any available localhost port.  There should be

--- a/.htaccess
+++ b/.htaccess
@@ -21,7 +21,7 @@ RewriteRule ^zk-feed-reader\.xslt$ controllers/RSS.xslt [QSA,L]
 RewriteRule ^zkapi\.php$ index.php?target=api [QSA,L]
 RewriteRule ^ssoLogin\.php$ index.php?target=sso [QSA,L]
 RewriteCond $0 !^\.mdhandler.php/.*$
-RewriteRule ^(.+)\.md$ .mdhandler.php?/$1.md [L]
+RewriteRule ^(.+)\.md$ .mdhandler.php [L,E=ASSET:/$1.md]
 RewriteRule ^zk$ - [R=404,L]
 # The URI below is an arbitrary endpoint for internal use.
 # It can be any available localhost port.  There should be

--- a/.mdhandler.php
+++ b/.mdhandler.php
@@ -28,7 +28,7 @@ use ZK\UI\UICommon as UI;
 
 $stylesheet = "css/zoostyle.css";
 
-$target = realpath(__DIR__.$_SERVER['REDIRECT_ASSET']);
+$target = realpath(__DIR__.$_GET['asset']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target) || substr($target, -3) != '.md' )  {
     http_response_code(404);

--- a/.mdhandler.php
+++ b/.mdhandler.php
@@ -28,7 +28,7 @@ use ZK\UI\UICommon as UI;
 
 $stylesheet = "css/zoostyle.css";
 
-$target = realpath(__DIR__.($_SERVER['PATH_INFO'] ?? $_SERVER['QUERY_STRING']));
+$target = realpath(__DIR__.$_SERVER['QUERY_STRING']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target) || substr($target, -3) != '.md' )  {
     http_response_code(404);

--- a/.mdhandler.php
+++ b/.mdhandler.php
@@ -28,7 +28,7 @@ use ZK\UI\UICommon as UI;
 
 $stylesheet = "css/zoostyle.css";
 
-$target = realpath(__DIR__.$_SERVER['PATH_INFO']);
+$target = realpath(__DIR__.($_SERVER['PATH_INFO'] ?? $_SERVER['QUERY_STRING']));
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target) || substr($target, -3) != '.md' )  {
     http_response_code(404);

--- a/.mdhandler.php
+++ b/.mdhandler.php
@@ -28,7 +28,7 @@ use ZK\UI\UICommon as UI;
 
 $stylesheet = "css/zoostyle.css";
 
-$target = realpath(__DIR__.$_SERVER['QUERY_STRING']);
+$target = realpath(__DIR__.$_SERVER['REDIRECT_ASSET']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target) || substr($target, -3) != '.md' )  {
     http_response_code(404);

--- a/css/.csshandler.php
+++ b/css/.csshandler.php
@@ -22,7 +22,7 @@
  *
  */
  
-$target = realpath(__DIR__.$_SERVER['QUERY_STRING']);
+$target = realpath(__DIR__.$_SERVER['REDIRECT_ASSET']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);

--- a/css/.csshandler.php
+++ b/css/.csshandler.php
@@ -22,7 +22,7 @@
  *
  */
  
-$target = realpath(__DIR__.$_SERVER['REDIRECT_ASSET']);
+$target = realpath(__DIR__.$_GET['asset']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);

--- a/css/.csshandler.php
+++ b/css/.csshandler.php
@@ -22,7 +22,7 @@
  *
  */
  
-$target = realpath(__DIR__.$_SERVER['PATH_INFO']);
+$target = realpath(__DIR__.($_SERVER['PATH_INFO'] ?? $_SERVER['QUERY_STRING']));
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);

--- a/css/.csshandler.php
+++ b/css/.csshandler.php
@@ -22,7 +22,7 @@
  *
  */
  
-$target = realpath(__DIR__.($_SERVER['PATH_INFO'] ?? $_SERVER['QUERY_STRING']));
+$target = realpath(__DIR__.$_SERVER['QUERY_STRING']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);

--- a/css/.htaccess
+++ b/css/.htaccess
@@ -2,5 +2,5 @@
 RewriteEngine on
 # rewrite asset-numericStamp.ext to asset.ext and minify
 RewriteCond $1 !^\..*$
-RewriteRule ^([^-]+)(-[0-9]+)?\.(.+)$ .csshandler.php [L,E=ASSET:/$1.$3]
+RewriteRule ^([^-]+)(-[0-9]+)?\.(.+)$ .csshandler.php?asset=/$1.$3 [L]
 </IfModule>

--- a/css/.htaccess
+++ b/css/.htaccess
@@ -2,5 +2,5 @@
 RewriteEngine on
 # rewrite asset-numericStamp.ext to asset.ext and minify
 RewriteCond $1 !^\..*$
-RewriteRule ^([^-]+)(-[0-9]+)?\.(.+)$ .csshandler.php/$1.$3 [L]
+RewriteRule ^([^-]+)(-[0-9]+)?\.(.+)$ .csshandler.php?/$1.$3 [L]
 </IfModule>

--- a/css/.htaccess
+++ b/css/.htaccess
@@ -2,5 +2,5 @@
 RewriteEngine on
 # rewrite asset-numericStamp.ext to asset.ext and minify
 RewriteCond $1 !^\..*$
-RewriteRule ^([^-]+)(-[0-9]+)?\.(.+)$ .csshandler.php?/$1.$3 [L]
+RewriteRule ^([^-]+)(-[0-9]+)?\.(.+)$ .csshandler.php [L,E=ASSET:/$1.$3]
 </IfModule>

--- a/js/.htaccess
+++ b/js/.htaccess
@@ -5,11 +5,11 @@ RewriteEngine on
 RewriteCond $0 !^\..*$
 RewriteCond $0 !\.src\.js$
 RewriteCond %{ENV:REDIRECT_done} "!=1"
-RewriteRule ^([^-]+)(-[0-9]+)?\.js$ .jshandler.php [L,E=ASSET:/$1.js]
+RewriteRule ^([^-]+)(-[0-9]+)?\.js$ .jshandler.php?asset=/$1.js [L]
 
 # rewrite asset-numericStamp.src.js to asset.js
 RewriteRule ^([^-]+)(-[0-9]+)?\.src\.js $1.js [E=done:1]
 
 # rewrite asset-numericStamp.map to source map for asset.js
-RewriteRule ^([^-]+)(-[0-9]+)?\.map$ .mapgenerator.php [L,E=ASSET:/$1.js]
+RewriteRule ^([^-]+)(-[0-9]+)?\.map$ .mapgenerator.php?asset=/$1.js [L]
 </IfModule>

--- a/js/.htaccess
+++ b/js/.htaccess
@@ -5,11 +5,11 @@ RewriteEngine on
 RewriteCond $0 !^\..*$
 RewriteCond $0 !\.src\.js$
 RewriteCond %{ENV:REDIRECT_done} "!=1"
-RewriteRule ^([^-]+)(-[0-9]+)?\.js$ .jshandler.php/$1.js
+RewriteRule ^([^-]+)(-[0-9]+)?\.js$ .jshandler.php?/$1.js
 
 # rewrite asset-numericStamp.src.js to asset.js
 RewriteRule ^([^-]+)(-[0-9]+)?\.src\.js $1.js [E=done:1]
 
 # rewrite asset-numericStamp.map to source map for asset.js
-RewriteRule ^([^-]+)(-[0-9]+)?\.map$ .mapgenerator.php/$1.js
+RewriteRule ^([^-]+)(-[0-9]+)?\.map$ .mapgenerator.php?/$1.js
 </IfModule>

--- a/js/.htaccess
+++ b/js/.htaccess
@@ -5,11 +5,11 @@ RewriteEngine on
 RewriteCond $0 !^\..*$
 RewriteCond $0 !\.src\.js$
 RewriteCond %{ENV:REDIRECT_done} "!=1"
-RewriteRule ^([^-]+)(-[0-9]+)?\.js$ .jshandler.php?/$1.js
+RewriteRule ^([^-]+)(-[0-9]+)?\.js$ .jshandler.php [L,E=ASSET:/$1.js]
 
 # rewrite asset-numericStamp.src.js to asset.js
 RewriteRule ^([^-]+)(-[0-9]+)?\.src\.js $1.js [E=done:1]
 
 # rewrite asset-numericStamp.map to source map for asset.js
-RewriteRule ^([^-]+)(-[0-9]+)?\.map$ .mapgenerator.php?/$1.js
+RewriteRule ^([^-]+)(-[0-9]+)?\.map$ .mapgenerator.php [L,E=ASSET:/$1.js]
 </IfModule>

--- a/js/.htaccess
+++ b/js/.htaccess
@@ -5,11 +5,11 @@ RewriteEngine on
 RewriteCond $0 !^\..*$
 RewriteCond $0 !\.src\.js$
 RewriteCond %{ENV:REDIRECT_done} "!=1"
-RewriteRule ^([^-]+)(-[0-9]+)?\.js$ .jshandler.php?asset=/$1.js [L]
+RewriteRule ^([^-]+)(-[0-9]+)?\.js$ .jshandler.php?asset=/$1.js
 
 # rewrite asset-numericStamp.src.js to asset.js
 RewriteRule ^([^-]+)(-[0-9]+)?\.src\.js $1.js [E=done:1]
 
 # rewrite asset-numericStamp.map to source map for asset.js
-RewriteRule ^([^-]+)(-[0-9]+)?\.map$ .mapgenerator.php?asset=/$1.js [L]
+RewriteRule ^([^-]+)(-[0-9]+)?\.map$ .mapgenerator.php?asset=/$1.js
 </IfModule>

--- a/js/.jshandler.php
+++ b/js/.jshandler.php
@@ -26,7 +26,7 @@ require_once __DIR__."/../vendor/autoload.php";
 
 use JSMin\JSMin;
 
-$target = realpath(__DIR__.($_SERVER['PATH_INFO'] ?? $_SERVER['QUERY_STRING']));
+$target = realpath(__DIR__.$_SERVER['QUERY_STRING']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);

--- a/js/.jshandler.php
+++ b/js/.jshandler.php
@@ -26,7 +26,7 @@ require_once __DIR__."/../vendor/autoload.php";
 
 use JSMin\JSMin;
 
-$target = realpath(__DIR__.$_SERVER['PATH_INFO']);
+$target = realpath(__DIR__.($_SERVER['PATH_INFO'] ?? $_SERVER['QUERY_STRING']));
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);

--- a/js/.jshandler.php
+++ b/js/.jshandler.php
@@ -26,7 +26,7 @@ require_once __DIR__."/../vendor/autoload.php";
 
 use JSMin\JSMin;
 
-$target = realpath(__DIR__.$_SERVER['QUERY_STRING']);
+$target = realpath(__DIR__.$_SERVER['REDIRECT_ASSET']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);

--- a/js/.jshandler.php
+++ b/js/.jshandler.php
@@ -26,7 +26,7 @@ require_once __DIR__."/../vendor/autoload.php";
 
 use JSMin\JSMin;
 
-$target = realpath(__DIR__.$_SERVER['REDIRECT_ASSET']);
+$target = realpath(__DIR__.$_GET['asset']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);

--- a/js/.mapgenerator.php
+++ b/js/.mapgenerator.php
@@ -28,7 +28,7 @@ use axy\sourcemap\SourceMap;
 use JSMin\JSMin;
 
 // ensure target exists and is descendant of this directory
-$target = realpath(__DIR__.$_SERVER['PATH_INFO']);
+$target = realpath(__DIR__.($_SERVER['PATH_INFO'] ?? $_SERVER['QUERY_STRING']));
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);

--- a/js/.mapgenerator.php
+++ b/js/.mapgenerator.php
@@ -28,7 +28,7 @@ use axy\sourcemap\SourceMap;
 use JSMin\JSMin;
 
 // ensure target exists and is descendant of this directory
-$target = realpath(__DIR__.$_SERVER['QUERY_STRING']);
+$target = realpath(__DIR__.$_SERVER['REDIRECT_ASSET']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);

--- a/js/.mapgenerator.php
+++ b/js/.mapgenerator.php
@@ -28,7 +28,7 @@ use axy\sourcemap\SourceMap;
 use JSMin\JSMin;
 
 // ensure target exists and is descendant of this directory
-$target = realpath(__DIR__.$_SERVER['REDIRECT_ASSET']);
+$target = realpath(__DIR__.$_GET['asset']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);

--- a/js/.mapgenerator.php
+++ b/js/.mapgenerator.php
@@ -28,7 +28,7 @@ use axy\sourcemap\SourceMap;
 use JSMin\JSMin;
 
 // ensure target exists and is descendant of this directory
-$target = realpath(__DIR__.($_SERVER['PATH_INFO'] ?? $_SERVER['QUERY_STRING']));
+$target = realpath(__DIR__.$_SERVER['QUERY_STRING']);
 if(strncmp($target, __DIR__.DIRECTORY_SEPARATOR, strlen(__DIR__)+1) ||
         !file_exists($target)) {
     http_response_code(404);


### PR DESCRIPTION
When running php under fastcgi, Apache mod_rewrite RewriteRules which contain path info in their target can result in the error message, 'No input file specified'.  Note this affects only internal-redirect URIs constructed via Apache mod_rewrite; URIs from the client with path info work fine, as do client-based RewriteRule redirects (flag R) with path info.

Searching online, it seems many others have encountered this situation, but no one has identified the root cause of the issue, nor devised a definitive fix.  The usual suggested work-around is to replace path info in internal-redirect URI targets with a query string, which works as expected.

Inspecting a couple other PHP apps, namely owncloud and rainloop, to see how they handle the situation, it seems they don't use path info in internal-redirect RewriteRule targets, only query strings, thus avoiding the situation.

This change replaces all occurances of path info in RewriteRule targets with a query string.  There should be no impact to performance or functionaly across all stacks.

[Edit: added clarification that this error affects only internal-redirect RewriteRule targets]