### PR TITLE
Add playlist creation API

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,7 +18,7 @@ AddDefaultCharset UTF-8
 RewriteEngine on
 RewriteRule ^zkrss\.php$ index.php?target=rss [QSA,L]
 RewriteRule ^zk-feed-reader\.xslt$ controllers/RSS.xslt [QSA,L]
-RewriteRule ^zkapi\.php$ index.php?target=api [QSA,L]
+RewriteRule ^zkapi\.php$ index.php?target=api [QSA,L,E=AUTH:%{HTTP:Authorization}]
 RewriteRule ^ssoLogin\.php$ index.php?target=sso [QSA,L]
 RewriteCond $0 !^\.mdhandler.php/.*$
 RewriteRule ^(.+)\.md$ .mdhandler.php/$1.md [L]

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
 	"react/datagram": "^1.5",
 	"react/http": "^1.2",
 	"ratchet/pawl": "^0.3.5",
+	"rbdwllr/reallysimplejwt": "^4.0",
 	"rocketman/pdf-label": "^1.6+rocketman.1",
 	"vstelmakh/url-highlight": "^3.0"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de344bfd1cb29bb31f95ff957e2f7b43",
+    "content-hash": "7add8c22de5c9c8cde1dd6c9152381df",
     "packages": [
         {
             "name": "axy/backtrace",
@@ -695,6 +695,64 @@
                 "source": "https://github.com/ratchetphp/RFC6455/tree/v0.3"
             },
             "time": "2020-05-15T18:31:24+00:00"
+        },
+        {
+            "name": "rbdwllr/reallysimplejwt",
+            "version": "4.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/RobDWaller/ReallySimpleJWT.git",
+                "reference": "2b92aba98c71cfc4046dea895659450bfce530ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/RobDWaller/ReallySimpleJWT/zipball/2b92aba98c71cfc4046dea895659450bfce530ed",
+                "reference": "2b92aba98c71cfc4046dea895659450bfce530ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.20",
+                "phpbench/phpbench": "^1.0",
+                "phploc/phploc": "^7.0",
+                "phpmd/phpmd": "^2.9",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^9.5",
+                "sebastian/phpcpd": "^6.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ReallySimpleJWT\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Waller",
+                    "email": "rdwaller1984@gmail.com"
+                }
+            ],
+            "description": "A really simple library to generate user authentication JSON Web Tokens.",
+            "keywords": [
+                "Authentication",
+                "json",
+                "json web tokens",
+                "jwt",
+                "php",
+                "tokens"
+            ],
+            "support": {
+                "issues": "https://github.com/RobDWaller/ReallySimpleJWT/issues",
+                "source": "https://github.com/RobDWaller/ReallySimpleJWT/tree/4.0.3"
+            },
+            "time": "2021-07-12T10:12:22+00:00"
         },
         {
             "name": "react/cache",
@@ -2169,5 +2227,5 @@
         "php": ">=7.2.5"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -96,6 +96,16 @@ $config = [
     ],
 
     /**
+     * JWT secret
+     *
+     * set this value if you want to use JSON Web Tokens
+     *
+     * secret must be at least 12 characters in length and contain a number,
+     * an upper and a lowercase letter, and a special character *&!@%^#$.
+     */
+    'jwt_secret' => '',
+
+    /**
      * database settings
      */
     'db' => [

--- a/config/config.kzsu.php
+++ b/config/config.kzsu.php
@@ -93,6 +93,16 @@ $config = [
     ],
 
     /**
+     * JWT secret
+     *
+     * set this value if you want to use JSON Web Tokens
+     *
+     * secret must be at least 12 characters in length and contain a number,
+     * an upper and a lowercase letter, and a special character *&!@%^#$.
+     */
+    'jwt_secret' => '',
+
+    /**
      * database settings
      */
     'db' => [

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -349,6 +349,7 @@ class API extends CommandTarget implements IController {
         [ "getChartsRq", "getCharts" ],
         [ "getPlaylistsRq", "getPlaylists" ],
         [ "getTracksRq", "getTracks" ],
+        [ "importPlaylistRq", "importPlaylist" ],
         [ "tokenRq", "getToken" ],
     ];
 
@@ -639,6 +640,23 @@ class API extends CommandTarget implements IController {
         $this->serializer->startResponse("getCurrentsRs");
         $this->serializer->emitDataSet("albumrec", $currentfields, $records);
         $this->serializer->endResponse("getCurrentsRs");
+    }
+
+    public function importPlaylist() {
+        try {
+            if(!$this->session->isAuth("u"))
+                throw new \Exception("Operation requires authentication");
+
+            $file = file_get_contents("php://input");
+            $api = Engine::api(IPlaylist::class);
+            $id = $api->importPlaylist($file, $this->session->getUser(), $this->session->isAuth("v"));
+
+            $this->serializer->startResponse("importPlaylistRs");
+            $this->serializer->emitData("id", $id);
+            $this->serializer->endResponse("importPlaylistRs");
+        } catch (\Exception $e) {
+            $this->serializer->emitError("importPlaylistRs", 200, $e->getMessage());
+        }
     }
 
     public function getToken() {

--- a/engine/Engine.php
+++ b/engine/Engine.php
@@ -87,6 +87,30 @@ class Engine {
     }
 
     /**
+     * return the URL of the current request, less leaf filename, if any
+     */
+    public static function getBaseUrl() {
+        if(php_sapi_name() == "cli")
+            return "";
+
+        $uri = $_SERVER['REQUEST_URI'];
+
+        // strip the query string, if any
+        $qpos = strpos($uri, "?");
+        if($qpos !== false)
+            $uri = substr($uri, 0, $qpos);
+
+        $port = ":" . $_SERVER['SERVER_PORT'];
+        if($port == ":443" || $port == ":80")
+            $port = "";
+
+        // compose the URL
+        return $_SERVER['REQUEST_SCHEME'] . "://" .
+               $_SERVER['SERVER_NAME'] . $port .
+               preg_replace("{/[^/]+$}", "/", $uri);
+    }
+
+    /**
      * instantiate an API
      * @param intf interface
      * @return implementation

--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -71,4 +71,5 @@ interface IPlaylist {
     function getDeletedPlaylistCount($user);
     function getListsSelNormal($user);
     function getListsSelDeleted($user);
+    function importPlaylist($file, $user, $allAirnames=false);
 }

--- a/ui/UICommon.php
+++ b/ui/UICommon.php
@@ -24,6 +24,8 @@
 
 namespace ZK\UI;
 
+use ZK\Engine\Engine;
+
 class UICommon {
     const CHARSET_ASCII = 0;
     const CHARSET_LATIN1 = 1;
@@ -98,27 +100,10 @@ class UICommon {
     ];
 
     /**
-     * return the URL of the current request, less leaf filename, if any
+     * @deprecated use Engine::getBaseUrl
      */
     public static function getBaseUrl() {
-        if(php_sapi_name() == "cli")
-            return "";
-
-        $uri = $_SERVER['REQUEST_URI'];
-    
-        // strip the query string, if any
-        $qpos = strpos($uri, "?");
-        if($qpos !== false)
-            $uri = substr($uri, 0, $qpos);
-
-        $port = ":" . $_SERVER['SERVER_PORT'];
-        if($port == ":443" || $port == ":80")
-            $port = "";
-    
-        // compose the URL
-        return $_SERVER['REQUEST_SCHEME'] . "://" .
-               $_SERVER['SERVER_NAME'] . $port .
-               preg_replace("{/[^/]+$}", "/", $uri);
+        return Engine::getBaseUrl();
     }
     
     /**


### PR DESCRIPTION
This PR implements a new playlist creation API.

The API accepts playlists in JSON format.  The format is the same as the existing playlist export function.

Access the API by calling `zkapi.php?method=importPlaylistRq` with the JSON playlist in the request body.  You will need to authenticate with a JWT bearer token.

How do you get the JWT?  Call the new `zkapi.php?method=tokenRq` API **with your credentials in the request body** as x-www-form-urlencoded data (user=xxx&password=yyy).  Not only is it insecure to send credentials in the URL, such a request will be rejected even if the credentials are correct.  The resulting token can be supplied in the subsequent API request header as `Authorization: Bearer zzz` where zzz is the token you got from tokenRq.  Tokens are valid for 5 minutes.

If your authenticating account has vaultkeeper privileges (belongs to the 'v' group), then you may create playlists for any user.  Such playlists will belong to your account (you can edit or delete them) but they will display under the target airname of the other user.

Authenticate with your local username and password; (google) SSO is not supported.  You can set a local password on your existing account, or create a new account specifically for integration purposes and set a password on it.

Satisfies #253
