### PR TITLE
Add playlist create API (simplified authentication)

### DIFF
--- a/config/ui_config.php
+++ b/config/ui_config.php
@@ -42,7 +42,7 @@ $menu = [
     [ 'u', 'editList%',    'Edit Playlist',         ZK\UI\Playlists::class ],
     [ 'u', 'importExport', 'Import/Export',         ZK\UI\Playlists::class ],
     [ 'u', 'showLink',     'Link to Playlist',      ZK\UI\Playlists::class ],
-    [ 'u', 'updateDJInfo', 'Update Airname',        ZK\UI\Playlists::class ],
+    [ 'u', 'updateDJInfo', 'Edit Profile',          ZK\UI\Playlists::class ],
     [ 'a', 'viewDJ%',      'DJ Zone!',              ZK\UI\Playlists::class ],
     [ 'a', 'viewList%',    'Playlists by Date',     ZK\UI\Playlists::class ],
     [ 'u', 'addTrack',     0,                       ZK\UI\Playlists::class ],

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -42,7 +42,7 @@ abstract class Serializer {
     public abstract function endDocument();
     public abstract function startResponse($name, $attrs=null);
     public abstract function endResponse($name);
-    public abstract function emitDataSetArray($name, $fields, &$data);
+    public abstract function emitDataSetArray($name, $fields, $data);
 
     protected function getCatCodes() {
         if(!isset($this->catCodes))
@@ -117,7 +117,7 @@ class JSONSerializer extends Serializer {
         return $result;
     }
 
-    public function emitDataSetArray($name, $fields, &$data) {
+    public function emitDataSetArray($name, $fields, $data) {
         $nextToken = "";
         foreach($data as $row) {
             echo "$nextToken{";
@@ -216,7 +216,7 @@ class XMLSerializer extends Serializer {
         return $result;
     }
 
-    public function emitDataSetArray($name, $fields, &$data) {
+    public function emitDataSetArray($name, $fields, $data) {
         foreach($data as $row) {
             echo "<$name>\n";
             foreach($fields as $field) {
@@ -633,7 +633,7 @@ class API extends CommandTarget implements IController {
             $id = $api->importPlaylist($file, $this->session->getUser(), $this->session->isAuth("v"));
 
             $this->serializer->startResponse("importPlaylistRs");
-            $this->serializer->emitData("id", $id);
+            $this->serializer->emitDataSetArray("playlists", ["id"], [["id" => $id]]);
             $this->serializer->endResponse("importPlaylistRs");
         } catch (\Exception $e) {
             $this->serializer->emitError("importPlaylistRs", 200, $e->getMessage());

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -633,7 +633,10 @@ class API extends CommandTarget implements IController {
             $id = $api->importPlaylist($file, $this->session->getUser(), $this->session->isAuth("v"));
 
             $this->serializer->startResponse("importPlaylistRs");
-            $this->serializer->emitDataSetArray("playlists", ["id"], [["id" => $id]]);
+            $attrs = [];
+            $attrs["id"] = $id;
+            $this->serializer->startResponse("show", $attrs);
+            $this->serializer->endResponse("show");
             $this->serializer->endResponse("importPlaylistRs");
         } catch (\Exception $e) {
             $this->serializer->emitError("importPlaylistRs", 200, $e->getMessage());

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -331,6 +331,7 @@ class API extends CommandTarget implements IController {
         [ "getChartsRq", "getCharts" ],
         [ "getPlaylistsRq", "getPlaylists" ],
         [ "getTracksRq", "getTracks" ],
+        [ "importPlaylistRq", "importPlaylist" ],
     ];
 
     /*
@@ -620,6 +621,23 @@ class API extends CommandTarget implements IController {
         $this->serializer->startResponse("getCurrentsRs");
         $this->serializer->emitDataSet("albumrec", $currentfields, $records);
         $this->serializer->endResponse("getCurrentsRs");
+    }
+
+    public function importPlaylist() {
+        try {
+            if(!$this->session->isAuth("u"))
+                throw new \Exception("Operation requires authentication");
+
+            $file = file_get_contents("php://input");
+            $api = Engine::api(IPlaylist::class);
+            $id = $api->importPlaylist($file, $this->session->getUser(), $this->session->isAuth("v"));
+
+            $this->serializer->startResponse("importPlaylistRs");
+            $this->serializer->emitData("id", $id);
+            $this->serializer->endResponse("importPlaylistRs");
+        } catch (\Exception $e) {
+            $this->serializer->emitError("importPlaylistRs", 200, $e->getMessage());
+        }
     }
 
     private function emitHeader($method) {

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -633,9 +633,7 @@ class API extends CommandTarget implements IController {
             $id = $api->importPlaylist($file, $this->session->getUser(), $this->session->isAuth("v"));
 
             $this->serializer->startResponse("importPlaylistRs");
-            $attrs = [];
-            $attrs["id"] = $id;
-            $this->serializer->startResponse("show", $attrs);
+            $this->serializer->startResponse("show", ["id" => $id]);
             $this->serializer->endResponse("show");
             $this->serializer->endResponse("importPlaylistRs");
         } catch (\Exception $e) {

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -875,3 +875,10 @@ a.calLink {
 .date, .time {
     white-space: nowrap;
 }
+
+a:hover.copy {
+    text-decoration: none;
+}
+.apikey {
+    font-family: monospace;
+}

--- a/db/convert_v2_10_0_to_v2_11_0.sql
+++ b/db/convert_v2_10_0_to_v2_11_0.sql
@@ -45,7 +45,7 @@ CREATE TABLE `apikeys` (
   `apikey` varchar(40) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `user` (`user`),
-  KEY `apikey` (`apikey`)
+  UNIQUE KEY `apikey` (`apikey`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT;

--- a/db/convert_v2_10_0_to_v2_11_0.sql
+++ b/db/convert_v2_10_0_to_v2_11_0.sql
@@ -42,7 +42,7 @@ SET NAMES utf8mb4;
 CREATE TABLE `apikeys` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user` varchar(8) NOT NULL,
-  `apikey` varchar(40) DEFAULT NULL,
+  `apikey` varchar(40) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `user` (`user`),
   UNIQUE KEY `apikey` (`apikey`)

--- a/db/convert_v2_10_0_to_v2_11_0.sql
+++ b/db/convert_v2_10_0_to_v2_11_0.sql
@@ -1,0 +1,53 @@
+/*
+ * Zookeeper Online
+ *
+ * @author Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
+ * @link https://zookeeper.ibinx.com/
+ * @license GPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3, along with this program.  If not, see
+ * http://www.gnu.org/licenses/
+ */
+
+/**
+ * IMPORTANT NOTE:
+ *
+ * Run this script ONLY if you are converting an existing Zookeeper Online
+ * v2_10_0 database for use with the current codebase.
+ *
+ * If you are creating a new database, run zkdbSchema.sql and then populate
+ * the resulting db using the various bootstrap scripts as appropriate.
+ */
+
+--
+-- Database: `zkdb`
+--
+
+SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT;
+SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS;
+SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION;
+SET NAMES utf8mb4;
+
+CREATE TABLE `apikeys` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user` varchar(8) NOT NULL,
+  `apikey` varchar(40) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `user` (`user`),
+  KEY `apikey` (`apikey`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
+
+SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT;
+SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS;
+SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION;

--- a/db/zkdbSchema.sql
+++ b/db/zkdbSchema.sql
@@ -91,6 +91,21 @@ CREATE TABLE IF NOT EXISTS `albumvol` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `apikeys`
+--
+
+CREATE TABLE `apikeys` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user` varchar(8) NOT NULL,
+  `apikey` varchar(40) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `user` (`user`),
+  KEY `apikey` (`apikey`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `categories`
 --
 

--- a/db/zkdbSchema.sql
+++ b/db/zkdbSchema.sql
@@ -100,7 +100,7 @@ CREATE TABLE `apikeys` (
   `apikey` varchar(40) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `user` (`user`),
-  KEY `apikey` (`apikey`)
+  UNIQUE KEY `apikey` (`apikey`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------

--- a/db/zkdbSchema.sql
+++ b/db/zkdbSchema.sql
@@ -97,7 +97,7 @@ CREATE TABLE IF NOT EXISTS `albumvol` (
 CREATE TABLE `apikeys` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user` varchar(8) NOT NULL,
-  `apikey` varchar(40) DEFAULT NULL,
+  `apikey` varchar(40) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `user` (`user`),
   UNIQUE KEY `apikey` (`apikey`)

--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -71,4 +71,5 @@ interface IPlaylist {
     function getDeletedPlaylistCount($user);
     function getListsSelNormal($user);
     function getListsSelDeleted($user);
+    function importPlaylist($file, $user, $allAirnames=false);
 }

--- a/engine/IUser.php
+++ b/engine/IUser.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2018 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -44,4 +44,8 @@ interface IUser {
     function updateUser($user, $password, $realname="XXZZ", $groups="XXZZ", $expiration="XXZZ");
     function insertUser($user, $password, $realname, $groups, $expiration);
     function deleteUser($user);
+    function getAPIKeys($user);
+    function addAPIKey($user, $apikey);
+    function deleteAPIKeys($user, array $apikeys);
+    function lookupAPIKey($apikey);
 }

--- a/engine/Session.php
+++ b/engine/Session.php
@@ -26,6 +26,8 @@ namespace ZK\Engine;
 
 
 class Session extends DBO {
+    private const TOKEN_AUTH = "apikey";
+
     private $user;
     private $displayName;
     private $access = null;
@@ -59,6 +61,8 @@ class Session extends DBO {
         // it must be delievered in the request header as a cookie.
         if(!empty($_COOKIE[$this->sessionCookieName]))
             $this->validate($_COOKIE[$this->sessionCookieName]);
+        else if(!empty($_SERVER['HTTP_X_APIKEY']))
+            $this->authorizeApiKey($_SERVER['HTTP_X_APIKEY']);
     }
 
     public function getDN() { return $this->displayName; }
@@ -150,6 +154,19 @@ class Session extends DBO {
         $this->setSessionCookie($sessionID);
     }
 
+    public function authorizeApiKey($apikey) {
+        // invalidate apikey with invalid characters (injection control)
+        $user = preg_match("/^[0-9a-f]+$/", $apikey) ?
+                    Engine::api(IUser::class)->lookupAPIKey($apikey) : null;
+        if($user) {
+            $this->user = $user['user'];
+            $this->access = $user['groups'] . (self::checkLocal()?'l':'');
+	    error_log("access: ". $this->access);
+            $this->displayName = $user['realname'];
+            $this->sessionID = self::TOKEN_AUTH;
+        }
+    }
+
     public function validate($sessionID) {
         // invalidate session with invalid characters (injection control)
         $row = preg_match("/^[0-9a-f]+$/", $sessionID) ?
@@ -183,6 +200,9 @@ class Session extends DBO {
         case "a":    // all
             $allow = true;
             break;
+        case "T":    // token authentication
+            $allow = $this->sessionID == self::TOKEN_AUTH;
+            break;
         case "u":    // authenticated users only
             $allow = !empty($this->sessionID);
             break;
@@ -210,6 +230,7 @@ class Session extends DBO {
         case "a":    // all
             $allow = true;
             break;
+        case "T":    // token authentication (invalid for checkAccess)
         case "u":    // authenticated user (invalid for checkAccess)
         case "U":    // local (not SSO) user (invalid for checkAccess)
         case "":     // empty mode is invalid

--- a/engine/Session.php
+++ b/engine/Session.php
@@ -159,8 +159,16 @@ class Session extends DBO {
         $user = preg_match("/^[0-9a-f]+$/", $apikey) ?
                     Engine::api(IUser::class)->lookupAPIKey($apikey) : null;
         if($user) {
+            $access = $user['groups'] . (self::checkLocal()?'l':'');
+
+            // Reject disabled and non-local guest accounts
+            if(self::checkAccess('d', $access) ||
+                   self::checkAccess('g', $access) &&
+                       !self::checkAccess('l', $access))
+                return;
+
             $this->user = $user['user'];
-            $this->access = $user['groups'] . (self::checkLocal()?'l':'');
+            $this->access = $access;
             $this->displayName = $user['realname'];
             $this->sessionID = self::TOKEN_AUTH;
         }

--- a/engine/Session.php
+++ b/engine/Session.php
@@ -161,7 +161,6 @@ class Session extends DBO {
         if($user) {
             $this->user = $user['user'];
             $this->access = $user['groups'] . (self::checkLocal()?'l':'');
-	    error_log("access: ". $this->access);
             $this->displayName = $user['realname'];
             $this->sessionID = self::TOKEN_AUTH;
         }

--- a/engine/impl/User.php
+++ b/engine/impl/User.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -277,5 +277,37 @@ class UserImpl extends DBO implements IUser {
         $stmt = $this->prepare($query);
         $stmt->bindValue(1, $user);
         return $stmt->execute();
+    }
+
+    public function getAPIKeys($user) {
+        $query = "SELECT id, apikey FROM apikeys WHERE user = ? ORDER BY id";
+        $stmt = $this->prepare($query);
+        $stmt->bindValue(1, $user);
+        return $stmt->iterate();
+    }
+
+    public function addAPIKey($user, $apikey) {
+        $query = "INSERT INTO apikeys (user, apikey) VALUES (?, ?)";
+        $stmt = $this->prepare($query);
+        $stmt->bindValue(1, $user);
+        $stmt->bindValue(2, $apikey);
+        return $stmt->execute();
+    }
+
+    public function deleteAPIKeys($user, array $ids) {
+        $in = str_repeat("?, ", sizeof($ids) - 1) . "?";
+        $query = "DELETE FROM apikeys WHERE user=? AND id IN ($in)";
+        $stmt = $this->prepare($query);
+        $params = array_merge([$user], $ids);
+        return $stmt->execute($params);
+    }
+
+    public function lookupAPIKey($apikey) {
+        $query = "SELECT user, groups, realname FROM apikeys a ".
+                 "LEFT JOIN users u ON a.user = u.name ".
+                 "WHERE apikey=?";
+        $stmt = $this->prepare($query);
+        $stmt->bindValue(1, $apikey);
+        return $stmt->executeAndFetch();
     }
 }

--- a/js/user.api.js
+++ b/js/user.api.js
@@ -1,0 +1,49 @@
+//
+// Zookeeper Online
+//
+// @author Jim Mason <jmason@ibinx.com>
+// @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
+// @link https://zookeeper.ibinx.com/
+// @license GPL-3.0
+//
+// This code is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License,
+// version 3, along with this program.  If not, see
+// http://www.gnu.org/licenses/
+//
+
+/*! Zookeeper Online (C) 1997-2020 Jim Mason <jmason@ibinx.com> | @source: https://zookeeper.ibinx.com/ | @license: magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3.0 */
+
+function copyToClipboard(text) {
+    var temp = $("<INPUT>");
+    $("BODY").append(temp);
+    temp.val(text).select();
+    document.execCommand("copy");
+    temp.remove();
+}
+
+$().ready(function() {
+    $("INPUT:checkbox#all").click(function() {
+        var all = $(this).is(":checked");
+        $("INPUT:checkbox").prop('checked', all);
+    });
+    $("A.copy").click(function() {
+        var key = $(this).closest("tr").data("key");
+        copyToClipboard(key);
+        alert('Key copied to clipboard!');
+    });
+    $("INPUT[name=deleteKey]").click(function(e) {
+        if($("INPUT:checkbox:checked").length == 0 ||
+           !confirm('Delete the selected keys?\n\nCAUTION: THIS CANNOT BE UNDONE.')) {
+            return false;
+        }
+    });
+});

--- a/js/user.api.js
+++ b/js/user.api.js
@@ -36,7 +36,7 @@ $().ready(function() {
         $("INPUT:checkbox").prop('checked', all);
     });
     $("A.copy").click(function() {
-        var key = $(this).closest("tr").data("key");
+        var key = $(this).closest("TR").children("TD.apikey").html();
         copyToClipboard(key);
         alert('Key copied to clipboard!');
     });

--- a/js/user.apikey.js
+++ b/js/user.apikey.js
@@ -20,7 +20,7 @@
 // http://www.gnu.org/licenses/
 //
 
-/*! Zookeeper Online (C) 1997-2020 Jim Mason <jmason@ibinx.com> | @source: https://zookeeper.ibinx.com/ | @license: magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3.0 */
+/*! Zookeeper Online (C) 1997-2021 Jim Mason <jmason@ibinx.com> | @source: https://zookeeper.ibinx.com/ | @license: magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3.0 */
 
 function copyToClipboard(text) {
     var temp = $("<INPUT>");

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1229,49 +1229,6 @@ class Playlists extends MenuItem {
     <?php 
     }
 
-    /**
-     * scrub imported timestamp
-     *
-     * @param timestamp target
-     * @param window DateTime array from IPlaylist::getTimestampWindow
-     * @return scrubbed timestamp or null if not in show window
-     */
-    private static function fixupTimestamp(\DateTime $timestamp, array $window) {
-        // normalize for non-local timezone
-        $timestamp->setTimezone($window['start']->getTimezone());
-
-        // transpose timestamp to show date
-        $showDate = $window['start']->format("Y-m-d");
-        if($timestamp->format("Y-m-d") != $showDate) {
-            list($h, $m, $s) = explode(":", $timestamp->format("H:i:s"));
-            $timestamp = new \DateTime($showDate);
-            $timestamp->setTime($h, $m, $s);
-        }
-
-        // if playlist spans midnight, adjust post-midnight timestamp date
-        if($window['end']->format("G") < $window['start']->format("G") &&
-                $timestamp < $window['start'])
-            $timestamp->modify("+1 day");
-
-        // validate timestamp is within the show time range
-        $valid = false;
-        for($i=2; $i>0; $i--) {
-            if($timestamp >= $window['start'] &&
-                    $timestamp <= $window['end']) {
-                $valid = true;
-                break;
-            }
-
-            // try again on 12-hour clock (e.g., treat 03:30 as 15:30)
-            $timestamp->modify("+12 hour");
-        }
-
-        if(!$valid)
-            error_log("Spin time is outside of show start/end times.");
-
-        return $valid?$timestamp:null;
-    }
-
     public function emitImportExportList() {
        $subactions = [
            [ "u", "", "Export Playlist", "emitExportList" ],
@@ -1539,7 +1496,7 @@ class Playlists extends MenuItem {
 
                     if(count($line) == 6 && $line[5]) {
                         try {
-                            $timestamp = self::fixupTimestamp(
+                            $timestamp = PlaylistEntry::scrubTimestamp(
                                             new \DateTime($line[5]), $window);
                         } catch(\Exception $e) {
                             error_log("failed to parse timestamp: {$line[5]}");
@@ -1576,73 +1533,17 @@ class Playlists extends MenuItem {
             // read the JSON file
             $file = file_get_contents($userfile);
 
-            // parse the file
-            $json = json_decode($file);
+            try {
+                $api = Engine::api(IPlaylist::class);
+                $id = $api->importPlaylist($file, $this->session->getUser());
 
-            // validate json root node is type 'show'
-            if(!$json || $json->type != "show") {
-                // also allow for 'show' encapsulated within a 'getPlaylistsRs'
-                if($json && $json->data[0]->type == "show")
-                    $json = $json->data[0];
-                else
-                    echo "<B><FONT CLASS='error'>File is not in the expected format.  Ensure file is a valid JSON playlist.</FONT></B><BR>\n";
-            }
-
-            if($json && $json->type == "show") {
-                // validate the show's properties
-                $valid = false;
-                list($year, $month, $day) = explode("-", $json->date);
-                if($json->airname && $json->name && $json->time &&
-                        checkdate($month, $day, $year))
-                    $valid = true;
-
-                // lookup the airname
-                if($valid) {
-                    $djapi = Engine::api(IDJ::class);
-                    $airname = $djapi->getAirname($json->airname, $this->session->getUser());
-                    if(!$airname) {
-                        // airname does not exist; try to create it
-                        $success = $djapi->insertAirname(mb_substr($json->airname, 0, IDJ::MAX_AIRNAME_LENGTH), $this->session->getUser());
-                        if($success > 0) {
-                            // success!
-                            $airname = $djapi->lastInsertId();
-                        } else
-                            $valid = false;
-                    }
-                }
-
-                // create the playlist
-                if($valid) {
-                    $papi = Engine::api(IPlaylist::class);
-                    $papi->insertPlaylist($this->session->getUser(), $json->date, $json->time, mb_substr($json->name, 0, IPlaylist::MAX_DESCRIPTION_LENGTH), $airname);
-                    $playlist = $papi->lastInsertId();
-
-                    // insert the tracks
-                    $status = '';
-                    $window = $papi->getTimestampWindow($playlist);
-                    foreach($json->data as $pentry) {
-                        $entry = PlaylistEntry::fromJSON($pentry);
-                        $created = $entry->getCreated();
-                        if($created) {
-                            try {
-                                $stamp = self::fixupTimestamp(
-                                            new \DateTime($created), $window);
-                                $entry->setCreated($stamp?$stamp->format(IPlaylist::TIME_FORMAT_SQL):null);
-                            } catch(\Exception $e) {
-                                error_log("failed to parse timestamp: $created");
-                                $entry->setCreated(null);
-                            }
-                        }
-                        $success = $papi->insertTrackEntry($playlist, $entry, $status);
-                    }
-
-                    // display the editor
-                    $_REQUEST["playlist"] = $playlist;
-                    $this->action = "newListEditor";
-                    $this->emitEditor();
-                    $displayForm = false;
-                } else
-                    echo "<B><FONT CLASS='error'>Show details are invalid.</FONT></B><BR>\n";
+                // display the editor
+                $_REQUEST["playlist"] = $id;
+                $this->action = "newListEditor";
+                $this->emitEditor();
+                $displayForm = false;
+            } catch(\Exception $e) {
+                echo "<B><FONT CLASS='error'>".$e->getMessage()."</FONT></B><BR>\n";
             }
         }
 

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1609,15 +1609,16 @@ class Playlists extends MenuItem {
        <tr><th><input name=all id='all' type=checkbox></th><th align=right>API Key</th><th></th></tr>
    <?php
        foreach($keys as $key) {
-           echo "<tr><td><input name=id{$key['id']} type=checkbox></td>";
-           echo "<td class='apikey'>{$key['apikey']}</td><td><a href='#' title='Copy Key to Clipboard' class='copy'>&#x1f4cb;</a></td></tr>";
+           echo "<tr><td><input name=id{$key['id']} type=checkbox></td>".
+                "<td class='apikey'>{$key['apikey']}</td>".
+                "<td><a href='#' title='Copy Key to Clipboard' class='copy'>&#x1f4cb;</a></td></tr>";
        }
        echo "</table>";
        echo "<P><INPUT TYPE=submit CLASS=submit NAME=deleteKey VALUE=' Remove Key '>&nbsp;&nbsp;&nbsp;\n";
        } else
-           echo "<p><b>Your have no API Keys.</b></p>\n";
+           echo "<p><b>You have no API Keys.</b></p><p>\n";
 
-       echo "<INPUT TYPE=submit CLASS=submit NAME=newKey VALUE=' Generate New Key '>&nbsp;&nbsp;&nbsp;\n";
+       echo "<INPUT TYPE=submit CLASS=submit NAME=newKey VALUE=' Generate New Key '></p>\n";
        echo "<input type=hidden name=action value='{$this->action}'>\n";
        echo "<input type=hidden name=subaction value='{$this->subaction}'>\n";
        echo "</form>\n";

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1621,7 +1621,7 @@ class Playlists extends MenuItem {
        echo "<input type=hidden name=action value='{$this->action}'>\n";
        echo "<input type=hidden name=subaction value='{$this->subaction}'>\n";
        echo "</form>\n";
-       UI::emitJS('js/user.api.js');
+       UI::emitJS('js/user.apikey.js');
     }
 
     public function updateAirname() {

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -30,6 +30,7 @@ use ZK\Engine\IDJ;
 use ZK\Engine\ILibrary;
 use ZK\Engine\IPlaylist;
 use ZK\Engine\IReview;
+use ZK\Engine\IUser;
 use ZK\Engine\PlaylistEntry;
 use ZK\Engine\PlaylistObserver;
 
@@ -1670,6 +1671,59 @@ class Playlists extends MenuItem {
     }
 
     public function updateDJInfo() {
+       $subactions = [
+           [ "u", "", "Update Airname", "updateAirname" ],
+           [ "u", "manageKeys", "Manage API Keys", "manageKeys" ],
+       ];
+       $this->dispatchSubaction($this->action, $this->subaction, $subactions);
+    }
+
+    public function manageKeys() {
+       $api = Engine::api(IUser::class);
+       if($_REQUEST["newKey"]) {
+           $newKey = sha1(uniqid(rand()));
+           $api->addAPIKey($this->session->getUser(), $newKey);
+       } else if($_REQUEST["deleteKey"]) {
+           $selKeys = [];
+           foreach($_POST as $key => $value) {
+               if(substr($key, 0, 2) == "id" && $value == "on")
+                   $selKeys[] = substr($key, 2);
+           }
+           if(sizeof($selKeys))
+               $api->deleteAPIKeys($this->session->getUser(), $selKeys);
+       }
+    ?>
+       <div class='user-tip' style='display: block; max-width: 550px;'>
+       <p>API Keys allow external applications access to your playlists
+       and other personal details.</p><p>Generate and share an API Key only
+       if you trust the external application.</p>
+       </div>
+    <?php
+       $keys = Engine::api(IUser::class)->getAPIKeys($this->session->getUser())->asArray();
+       echo "       <form action=\"?\" method=post>\n";
+       if(sizeof($keys)) {
+    ?>
+       <p><b>Your API Keys:</b></p>
+       <table border=0>
+       <tr><th><input name=all id='all' type=checkbox></th><th align=right>API Key</th><th></th></tr>
+   <?php
+       foreach($keys as $key) {
+           echo "<tr data-key={$key['apikey']}><td><input name=id{$key['id']} type=checkbox".($_POST["id".key['id']] == "on"?" checked":"")."></td>";
+           echo "<td>{$key['apikey']}</td><td><a href='#' title='Copy Key to Clipboard' class='copy' style='text-decoration: none'>&#x1f4cb;</a></td></tr>";
+       }
+       echo "</table>";
+       echo "<P><INPUT TYPE=submit CLASS=submit NAME=deleteKey VALUE=\" Remove Key \">&nbsp;&nbsp;&nbsp;\n";
+       } else
+           echo "<p><b>Your have no API Keys.</b></p>\n";
+
+       echo "<INPUT TYPE=submit CLASS=submit NAME=newKey VALUE=\" Generate New Key \">&nbsp;&nbsp;&nbsp;\n";
+       echo "<input type=hidden name=action value=\"{$this->action}\">\n";
+       echo "<input type=hidden name=subaction value=\"{$this->subaction}\">\n";
+       echo "</form>\n";
+       UI::emitJS('js/user.api.js');
+    }
+
+    public function updateAirname() {
         UI::emitJS("js/playlists.pick.js");
 
         $validate = $_POST["validate"];

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1601,7 +1601,7 @@ class Playlists extends MenuItem {
        </div>
     <?php
        $keys = Engine::api(IUser::class)->getAPIKeys($this->session->getUser())->asArray();
-       echo "       <form action=\"?\" method=post>\n";
+       echo "       <form action='?' method=post>\n";
        if(sizeof($keys)) {
     ?>
        <p><b>Your API Keys:</b></p>
@@ -1609,17 +1609,17 @@ class Playlists extends MenuItem {
        <tr><th><input name=all id='all' type=checkbox></th><th align=right>API Key</th><th></th></tr>
    <?php
        foreach($keys as $key) {
-           echo "<tr data-key={$key['apikey']}><td><input name=id{$key['id']} type=checkbox".($_POST["id".key['id']] == "on"?" checked":"")."></td>";
-           echo "<td>{$key['apikey']}</td><td><a href='#' title='Copy Key to Clipboard' class='copy' style='text-decoration: none'>&#x1f4cb;</a></td></tr>";
+           echo "<tr><td><input name=id{$key['id']} type=checkbox></td>";
+           echo "<td class='apikey'>{$key['apikey']}</td><td><a href='#' title='Copy Key to Clipboard' class='copy'>&#x1f4cb;</a></td></tr>";
        }
        echo "</table>";
-       echo "<P><INPUT TYPE=submit CLASS=submit NAME=deleteKey VALUE=\" Remove Key \">&nbsp;&nbsp;&nbsp;\n";
+       echo "<P><INPUT TYPE=submit CLASS=submit NAME=deleteKey VALUE=' Remove Key '>&nbsp;&nbsp;&nbsp;\n";
        } else
            echo "<p><b>Your have no API Keys.</b></p>\n";
 
-       echo "<INPUT TYPE=submit CLASS=submit NAME=newKey VALUE=\" Generate New Key \">&nbsp;&nbsp;&nbsp;\n";
-       echo "<input type=hidden name=action value=\"{$this->action}\">\n";
-       echo "<input type=hidden name=subaction value=\"{$this->subaction}\">\n";
+       echo "<INPUT TYPE=submit CLASS=submit NAME=newKey VALUE=' Generate New Key '>&nbsp;&nbsp;&nbsp;\n";
+       echo "<input type=hidden name=action value='{$this->action}'>\n";
+       echo "<input type=hidden name=subaction value='{$this->subaction}'>\n";
        echo "</form>\n";
        UI::emitJS('js/user.api.js');
     }

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1600,7 +1600,7 @@ class Playlists extends MenuItem {
        if you trust the external application.</p>
        </div>
     <?php
-       $keys = Engine::api(IUser::class)->getAPIKeys($this->session->getUser())->asArray();
+       $keys = $api->getAPIKeys($this->session->getUser())->asArray();
        echo "       <form action='?' method=post>\n";
        if(sizeof($keys)) {
     ?>


### PR DESCRIPTION
This is the second iteration of a PR to implement programmatic playlist creation, this time with simiplified authentication.

The new API accepts playlists in JSON format. The format is the same as the existing playlist export function.

Access the API by calling `zkapi.php?method=importPlaylistRq` with the JSON playlist in the request body. You will need to authenticate with an API key (see below) in the X-APIKEY request header.

**Note:** If your authenticating account has vaultkeeper privileges (belongs to the 'v' group), **then you may create playlists for any user.** Such playlists will belong to your account (you can edit or delete them) but they will display under the target airname of the other user.

**To get an API key**, login into your account, go to Edit Profile, Manage API Keys.  There you can generate, view, and delete your API keys.  API keys are valid until you explicitly delete them.

Satisfies #253