### PR TITLE
Add music library album creation API

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -20,6 +20,7 @@ RewriteRule ^zkrss\.php$ index.php?target=rss [QSA,L]
 RewriteRule ^zk-feed-reader\.xslt$ controllers/RSS.xslt [QSA,L]
 RewriteRule ^zkapi\.php$ index.php?target=api [QSA,L]
 RewriteRule ^ssoLogin\.php$ index.php?target=sso [QSA,L]
+RewriteRule ^api/v([0-9]+(\.[0-9]+)*)/(.+)$ index.php?target=api&method=$3Rq&apiver=$1 [QSA,L]
 RewriteCond $0 !^\.mdhandler.php/.*$
 RewriteRule ^(.+)\.md$ .mdhandler.php?asset=/$1.md [L]
 RewriteRule ^zk$ - [R=404,L]

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -26,6 +26,7 @@ namespace ZK\Controllers;
 
 use ZK\Engine\Engine;
 use ZK\Engine\IChart;
+use ZK\Engine\IEditor;
 use ZK\Engine\ILibrary;
 use ZK\Engine\IPlaylist;
 use ZK\Engine\IReview;
@@ -332,6 +333,7 @@ class API extends CommandTarget implements IController {
         [ "getPlaylistsRq", "getPlaylists" ],
         [ "getTracksRq", "getTracks" ],
         [ "importPlaylistRq", "importPlaylist" ],
+        [ "importAlbumRq", "importAlbum" ],
     ];
 
     /*
@@ -638,6 +640,26 @@ class API extends CommandTarget implements IController {
             $this->serializer->endResponse("importPlaylistRs");
         } catch (\Exception $e) {
             $this->serializer->emitError("importPlaylistRs", 200, $e->getMessage());
+        }
+    }
+
+    public function importAlbum() {
+        try {
+            if(!$this->session->isAuth("m"))
+                throw new \Exception("Operation requires authentication");
+
+            $file = file_get_contents("php://input");
+            $api = Engine::api(IEditor::class);
+            $tag = $api->importAlbum($file);
+            if(!$tag)
+                throw new \Exception("import failed");
+
+            $this->serializer->startResponse("importAlbumRs");
+            $this->serializer->startResponse("album", ["tag" => $tag]);
+            $this->serializer->endResponse("album");
+            $this->serializer->endResponse("importAlbumRs");
+        } catch (\Exception $e) {
+            $this->serializer->emitError("importAlbumRs", 200, $e->getMessage());
         }
     }
 

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -344,8 +344,8 @@ class API extends CommandTarget implements IController {
         [ "getChartsRq", "getCharts" ],
         [ "getPlaylistsRq", "getPlaylists" ],
         [ "getTracksRq", "getTracks" ],
-        [ "importPlaylistRq", "importPlaylist" ],
-        [ "importAlbumRq", "importAlbum" ],
+        [ "importPlaylistsRq", "importPlaylist" ],
+        [ "importAlbumsRq", "importAlbum" ],
     ];
 
     /*

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -200,7 +200,10 @@ class XMLSerializer extends Serializer {
 
     public function startResponse($name, $attrs=null, $errors=null) {
         if(!$attrs)
-            $attrs = $this->newAttrs();
+            $attrs = $errors?
+                $this->newAttrs($errors[0]['code'], $errors[0]['title']):
+                $this->newAttrs();
+
         echo "<$name";
         foreach($attrs as $key => $value)
             echo " $key=\"".self::spec2hexAttr($value)."\"";

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -648,14 +648,14 @@ class API extends CommandTarget implements IController {
             $api = Engine::api(IPlaylist::class);
             $api->importPlaylist($json, $this->session->getUser(), $this->session->isAuth("v"));
 
-            $this->serializer->startResponse("importPlaylistRs", null, $json->getErrors());
+            $this->serializer->startResponse("importPlaylistsRs", null, $json->getErrors());
             $json->iterateSuccess(function($attrs) {
                 $this->serializer->startResponse("show", $attrs);
                 $this->serializer->endResponse("show");
             });
-            $this->serializer->endResponse("importPlaylistRs");
+            $this->serializer->endResponse("importPlaylistsRs");
         } catch (\Exception $e) {
-            $this->serializer->emitError("importPlaylistRs", 200, $e->getMessage());
+            $this->serializer->emitError("importPlaylistsRs", 200, $e->getMessage());
         }
     }
 
@@ -670,14 +670,14 @@ class API extends CommandTarget implements IController {
             $api = Engine::api(IEditor::class);
             $api->importAlbum($json);
 
-            $this->serializer->startResponse("importAlbumRs", null, $json->getErrors());
+            $this->serializer->startResponse("importAlbumsRs", null, $json->getErrors());
             $json->iterateSuccess(function($attrs) {
                 $this->serializer->startResponse("album", $attrs);
                 $this->serializer->endResponse("album");
             });
-            $this->serializer->endResponse("importAlbumRs");
+            $this->serializer->endResponse("importAlbumsRs");
         } catch (\Exception $e) {
-            $this->serializer->emitError("importAlbumRs", 200, $e->getMessage());
+            $this->serializer->emitError("importAlbumsRs", 200, $e->getMessage());
         }
     }
 

--- a/css/kzsustyle.css
+++ b/css/kzsustyle.css
@@ -223,6 +223,10 @@ P.zktitle A {
 }
 .submit {
 	background-color: #980000;
+	border-color: #3b0000;
+}
+.text, .textsp, .urlValue {
+	border-color: #3b0000;
 }
 .albumReview {
 	background-image: URL('../img/kzsu/kzsu_rinfo.gif');

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -584,18 +584,18 @@ table.recentAirplay td, .sub {
     color: #ffffff;
     background-color: #5863da;
     border-width: 1px;
-    border-color: #3b0000;
+    border-color: #3843ba;
 }
 .success {
     color: #006600;
 }
 .text, .urlValue {
     padding: 2px;
-    border: 1px solid #3b0000;
+    border: 1px solid #2833aa;
 }
 .textsp {
     padding: 1px;
-    border: 1px solid #3b0000;
+    border: 1px solid #2833aa;
     width: 120px;
 }
 .zk-hidden {

--- a/engine/IEditor.php
+++ b/engine/IEditor.php
@@ -36,7 +36,7 @@ interface IEditor {
 
     function insertUpdateAlbum(&$album, $tracks, $label);
     function insertUpdateLabel(&$label);
-    function importAlbum($file);
+    function importAlbum($json);
     function enqueueTag($tag, $user);
     function dequeueTag($tag, $user);
     function getNumQueuedTags($user);

--- a/engine/IEditor.php
+++ b/engine/IEditor.php
@@ -36,6 +36,7 @@ interface IEditor {
 
     function insertUpdateAlbum(&$album, $tracks, $label);
     function insertUpdateLabel(&$label);
+    function importAlbum($file);
     function enqueueTag($tag, $user);
     function dequeueTag($tag, $user);
     function getNumQueuedTags($user);

--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -71,5 +71,5 @@ interface IPlaylist {
     function getDeletedPlaylistCount($user);
     function getListsSelNormal($user);
     function getListsSelDeleted($user);
-    function importPlaylist($file, $user, $allAirnames=false);
+    function importPlaylist($json, $user, $allAirnames=false);
 }

--- a/engine/IUser.php
+++ b/engine/IUser.php
@@ -46,6 +46,6 @@ interface IUser {
     function deleteUser($user);
     function getAPIKeys($user);
     function addAPIKey($user, $apikey);
-    function deleteAPIKeys($user, array $apikeys);
+    function deleteAPIKeys($user, array $ids);
     function lookupAPIKey($apikey);
 }

--- a/engine/JsonApi.php
+++ b/engine/JsonApi.php
@@ -68,7 +68,7 @@ class JsonApi {
         if($json && $this->get($json, 'type') == $type)
             $this->data = [ $json ];
         else if($json && is_array($data = $this->get($json, 'data')) &&
-                $this->get($data[0], 'type') == $type) 
+                $this->get($data[0], 'type') == $type)
             $this->data = $data;
         else {
             $this->data = $this->included = null;

--- a/engine/JsonApi.php
+++ b/engine/JsonApi.php
@@ -77,8 +77,8 @@ class JsonApi {
 
         if($this->data) {
             for($i=0; $i<sizeof($this->data); $i++)
-                if(empty($this->get($data = $this->data[$i], 'id')))
-                    $this->set($data, 'id', "request-id-".($i+1));
+                if(empty($this->get($data = &$this->data[$i], 'lid')))
+                    $this->set($data, 'lid', "request-seq-".($i+1));
 
             $this->included = is_array($included = $this->get($json, 'included'))?$included:null;
         }
@@ -92,7 +92,7 @@ class JsonApi {
         return $this->hasFlag(self::FLAG_ARRAY)?$json[$field]:$json->$field;
     }
 
-    private function set($json, $field, $value) {
+    private function set(&$json, $field, $value) {
         if($this->hasFlag(self::FLAG_ARRAY))
             $json[$field] = $value;
         else

--- a/engine/JsonApi.php
+++ b/engine/JsonApi.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Zookeeper Online
+ *
+ * @author Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
+ * @link https://zookeeper.ibinx.com/
+ * @license GPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3, along with this program.  If not, see
+ * http://www.gnu.org/licenses/
+ *
+ */
+
+namespace ZK\Engine;
+
+/**
+ * JsonApi is a parser helper that provides rudimantary conformance
+ * to the JSON:API specification
+ *
+ * Workflow is to instantiate a JsonApi then visit the top-level data
+ * nodes using the `iterateData` method.  As you go, you may add success
+ * or failure using the `addSuccess` and `addError` methods.  Upon
+ * completion, call `iterateSuccess` to visit the success nodes.
+ * `getErrors` returns an array of errors, if any, suitable for the
+ * top-level response.
+ *
+ * Alternatively, you can specify the FLAG_EXCEPTION flag in the ctor,
+ * which will cause an Exception to be thrown immediatley upon an error.
+ */
+class JsonApi {
+    const FLAG_ARRAY = 1;
+    const FLAG_EXCEPTION = 2;
+
+    private $flags;
+    private $data;
+    private $included;
+    private $internalErrorNr = 0;
+    private $errors = [];
+    private $success = [];
+
+    /**
+     * JsonApi ctor
+     *
+     * @param $file input data to process
+     * @param $type data type
+     * @param $flags flag bitmask (optional)
+     * @throws \Exception on error if FLAG_EXCEPTION specified
+     */
+    public function __construct($file, $type, $flags=0) {
+        $this->flags = $flags;
+
+        // decode and validate required fields
+        $json = json_decode($file, $this->hasFlag(self::FLAG_ARRAY));
+        if(!$json)
+            $this->addError(-1, json_last_error_msg(), 100);
+
+        if($json && $this->get($json, 'type') == $type)
+            $this->data = [ $json ];
+        else if($json && is_array($data = $this->get($json, 'data')) &&
+                $this->get($data[0], 'type') == $type) 
+            $this->data = $data;
+        else {
+            $this->data = $this->included = null;
+            $this->addError(-1, "File is not in the expected format.", 100);
+        }
+
+        if($this->data) {
+            for($i=0; $i<sizeof($this->data); $i++)
+                if(empty($this->get($data = $this->data[$i], 'id')))
+                    $this->set($data, 'id', "request-id-".($i+1));
+
+            $this->included = is_array($included = $this->get($json, 'included'))?$included:null;
+        }
+    }
+
+    private function hasFlag($flag) {
+        return $this->flags & $flag;
+    }
+
+    private function get($json, $field) {
+        return $this->hasFlag(self::FLAG_ARRAY)?$json[$field]:$json->$field;
+    }
+
+    private function set($json, $field, $value) {
+        if($this->hasFlag(self::FLAG_ARRAY))
+            $json[$field] = $value;
+        else
+            $json->$field = $value;
+    }
+
+    public function iterateData($fn) {
+        if($this->data) {
+            foreach($this->data as $data)
+                $fn($data);
+        }
+    }
+
+    /**
+     * get the JSON:API 'included' data node with the specified type and id
+     *
+     * @param $type type
+     * @param $id id
+     * @returns included node or null if none found
+     */
+    public function getIncluded($type, $id) {
+        if($this->included) {
+            foreach($this->included as $included)
+                if($this->get($included, 'type') == $type &&
+                        $this->get($included, 'id') == $id)
+                    return $included;
+        }
+
+        return null;
+    }
+
+    public function addError($id, $message, $code = 200) {
+        if($this->hasFlag(self::FLAG_EXCEPTION))
+            throw new \Exception($message);
+
+        if($id == -1)
+            $id = "internal-id-".(++$this->internalErrorNr);
+
+        $this->errors[] = ["id" => $id, "code" => $code, "title" => $message];
+    }
+
+    public function getErrors() { return $this->errors; }
+
+    public function addSuccess($id, $attrs=[]) {
+        if($id == -1)
+            $id = "internal-id-".(++$this->internalErrorNr);
+
+        $attrs['id'] = $id;
+        $this->success[] = $attrs;
+    }
+
+    public function iterateSuccess($fn) {
+        foreach($this->success as $attrs)
+            $fn($attrs);
+    }
+}

--- a/engine/impl/Editor.php
+++ b/engine/impl/Editor.php
@@ -323,7 +323,7 @@ class EditorImpl extends DBO implements IEditor {
                     $message .= $field[0]. " '{$data[$field[0]]}', ";
 
             if($message) {
-                $json->addError($data['id'], "Bad field(s): " . substr($message, 0, -2));
+                $json->addError($data['lid'], "Bad field(s): " . substr($message, 0, -2));
                 return;
             }
 
@@ -339,11 +339,11 @@ class EditorImpl extends DBO implements IEditor {
                 $rel = $data['relationships']['label']['data'];
                 $label = $json->getIncluded($rel['type'], $rel['id']);
                 if(!$label) {
-                    $json->addError($data['id'], "missing included label");
+                    $json->addError($data['lid'], "missing included label");
                     return;
                 }
             } else {
-                $json->addError($data['id'], "missing label");
+                $json->addError($data['lid'], "missing label");
                 return;
             }
 
@@ -376,9 +376,9 @@ class EditorImpl extends DBO implements IEditor {
             }
 
             if($this->insertUpdateAlbum($data, $tracks, $label))
-                $json->addSuccess($data['id'], ["tag" => $data["tag"]]);
+                $json->addSuccess($data["tag"], ["lid" => $data["lid"]]);
             else
-                $json->addError($data['id'], "insert failed");
+                $json->addError($data['lid'], "insert failed");
         });
     }
 

--- a/engine/impl/Editor.php
+++ b/engine/impl/Editor.php
@@ -305,12 +305,17 @@ class EditorImpl extends DBO implements IEditor {
 
     public function importAlbum($file) {
         // decode and validate required fields
-        $json = json_decode($file, true, 4,
+        $json = json_decode($file, true, 6,
                         PHP_VERSION_ID < 70300?0:JSON_THROW_ON_ERROR);
-        if(!$json || empty($json['type']) || $json['type'] != "album" ||
-                    !is_array($json['label']) ||
-                    empty($json['label']['name']) && empty($json['label']['pubkey']) ||
-                    empty($json['artist']) || empty($json['album']))
+        if($json && $json['type'] != "album") {
+            // also allow for encapsulated 'album'
+            $json = $json['data'][0]['type'] == "album"?$json['data'][0]:null;
+        }
+
+        if(!$json || !is_array($json['label']) ||
+                    empty($json['artist']) || empty($json['album']) ||
+                    empty($json['label']['name']) &&
+                        empty($json['label']['pubkey']))
             throw new \Exception("File is not in the expected format.");
 
         // convert field values to codes

--- a/engine/impl/Editor.php
+++ b/engine/impl/Editor.php
@@ -307,9 +307,10 @@ class EditorImpl extends DBO implements IEditor {
         // decode and validate required fields
         $json = json_decode($file, true, 4,
                         PHP_VERSION_ID < 70300?0:JSON_THROW_ON_ERROR);
-        if(!$json || $json['type'] != "album" || !is_array($json['label']) ||
-                    !($json['label']['name'] || $json['label']['pubkey']) ||
-                    !$json['artist'] || !$json['album'])
+        if(!$json || empty($json['type']) || $json['type'] != "album" ||
+                    !is_array($json['label']) ||
+                    empty($json['label']['name']) && empty($json['label']['pubkey']) ||
+                    empty($json['artist']) || empty($json['album']))
             throw new \Exception("File is not in the expected format.");
 
         // convert field values to codes
@@ -329,7 +330,7 @@ class EditorImpl extends DBO implements IEditor {
             throw new \Exception("Bad field(s): " . substr($message, 0, -2));
 
         // try to find label by name if no pubkey specified
-        if(!$json['label']['pubkey']) {
+        if(empty($json['label']['pubkey'])) {
             $label = Engine::api(ILibrary::class)->search(ILibrary::LABEL_NAME, 0, 1, $json['label']['name']);
             if(sizeof($label))
                 $json['label']['pubkey'] = $label['pubkey'];

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -869,7 +869,7 @@ class PlaylistImpl extends DBO implements IPlaylist {
      * @param $allAirnames allow all airnames (true) or restrict to user's airnames (default)
      */
     public function importPlaylist($jsonapi, $user, $allAirnames=false) {
-        $jsonapi->iterateData(function($json) use($jsonapi) {
+        $jsonapi->iterateData(function($json) use($jsonapi, $user, $allAirnames) {
             // validate the show's properties
             $valid = false;
             list($year, $month, $day) = explode("-", $json->date);

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -916,9 +916,9 @@ class PlaylistImpl extends DBO implements IPlaylist {
                     $success = $this->insertTrackEntry($playlist, $entry, $status);
                 }
 
-                $jsonapi->addSuccess($playlist);
+                $jsonapi->addSuccess($playlist, ["lid" => $json->lid]);
             } else
-                $jsonapi->addError($json->id, "Show details are invalid");
+                $jsonapi->addError($json->lid, "Show details are invalid");
         });
     }
 }

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -31,6 +31,7 @@ use ZK\Engine\ILibrary;
 use ZK\Engine\IPlaylist;
 use ZK\Engine\IReview;
 use ZK\Engine\IUser;
+use ZK\Engine\JsonApi;
 use ZK\Engine\PlaylistEntry;
 use ZK\Engine\PlaylistObserver;
 
@@ -1534,8 +1535,15 @@ class Playlists extends MenuItem {
             $file = file_get_contents($userfile);
 
             try {
+                $json = new JsonApi($file, "show", JsonApi::FLAG_EXCEPTION);
+
                 $api = Engine::api(IPlaylist::class);
-                $id = $api->importPlaylist($file, $this->session->getUser());
+                $api->importPlaylist($json, $this->session->getUser());
+
+                $id = 0;
+                $json->iterateSuccess(function($attrs) use(&$id) {
+                    $id = $attrs['id'];
+                });
 
                 // display the editor
                 $_REQUEST["playlist"] = $id;

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1572,27 +1572,27 @@ class Playlists extends MenuItem {
     }
 
     public function updateDJInfo() {
-       $subactions = [
-           [ "u", "", "Update Airname", "updateAirname" ],
-           [ "u", "manageKeys", "Manage API Keys", "manageKeys" ],
-       ];
-       $this->dispatchSubaction($this->action, $this->subaction, $subactions);
+        $subactions = [
+            [ "u", "", "Update Airname", "updateAirname" ],
+            [ "u", "manageKeys", "Manage API Keys", "manageKeys" ],
+        ];
+        $this->dispatchSubaction($this->action, $this->subaction, $subactions);
     }
 
     public function manageKeys() {
-       $api = Engine::api(IUser::class);
-       if($_POST["newKey"]) {
-           $newKey = sha1(uniqid(rand()));
-           $api->addAPIKey($this->session->getUser(), $newKey);
-       } else if($_POST["deleteKey"]) {
-           $selKeys = [];
-           foreach($_POST as $key => $value) {
-               if(substr($key, 0, 2) == "id" && $value == "on")
-                   $selKeys[] = substr($key, 2);
-           }
-           if(sizeof($selKeys))
-               $api->deleteAPIKeys($this->session->getUser(), $selKeys);
-       }
+        $api = Engine::api(IUser::class);
+        if($_POST["newKey"]) {
+            $newKey = sha1(uniqid(rand()));
+            $api->addAPIKey($this->session->getUser(), $newKey);
+        } else if($_POST["deleteKey"]) {
+            $selKeys = [];
+            foreach($_POST as $key => $value) {
+                if(substr($key, 0, 2) == "id" && $value == "on")
+                    $selKeys[] = substr($key, 2);
+            }
+            if(sizeof($selKeys))
+                $api->deleteAPIKeys($this->session->getUser(), $selKeys);
+        }
     ?>
        <div class='user-tip' style='display: block; max-width: 550px;'>
        <p>API Keys allow external applications access to your playlists
@@ -1600,29 +1600,29 @@ class Playlists extends MenuItem {
        if you trust the external application.</p>
        </div>
     <?php
-       $keys = $api->getAPIKeys($this->session->getUser())->asArray();
-       echo "<form action='?' method=post>\n";
-       if(sizeof($keys)) {
+        $keys = $api->getAPIKeys($this->session->getUser())->asArray();
+        echo "<form action='?' method=post>\n";
+        if(sizeof($keys)) {
     ?>
        <p><b>Your API Keys:</b></p>
        <table border=0>
        <tr><th><input name=all id='all' type=checkbox></th><th align=right>API Key</th><th></th></tr>
    <?php
-       foreach($keys as $key) {
-           echo "<tr><td><input name=id{$key['id']} type=checkbox></td>".
-                "<td class='apikey'>{$key['apikey']}</td>".
-                "<td><a href='#' title='Copy Key to Clipboard' class='copy'>&#x1f4cb;</a></td></tr>\n";
-       }
-       echo "</table>\n";
-       echo "<p><input type=submit class=submit name=deleteKey value=' Remove Key '>&nbsp;&nbsp;&nbsp;\n";
-       } else
-           echo "<p><b>You have no API Keys.</b></p><p>\n";
+            foreach($keys as $key) {
+                echo "<tr><td><input name=id{$key['id']} type=checkbox></td>".
+                     "<td class='apikey'>{$key['apikey']}</td>".
+                     "<td><a href='#' title='Copy Key to Clipboard' class='copy'>&#x1f4cb;</a></td></tr>\n";
+            }
+            echo "</table>\n";
+            echo "<p><input type=submit class=submit name=deleteKey value=' Remove Key '>&nbsp;&nbsp;&nbsp;\n";
+        } else
+            echo "<p><b>You have no API Keys.</b></p><p>\n";
 
-       echo "<input type=submit class=submit name=newKey value=' Generate New Key '></p>\n";
-       echo "<input type=hidden name=action value='{$this->action}'>\n";
-       echo "<input type=hidden name=subaction value='{$this->subaction}'>\n";
-       echo "</form>\n";
-       UI::emitJS('js/user.apikey.js');
+        echo "<input type=submit class=submit name=newKey value=' Generate New Key '></p>\n";
+        echo "<input type=hidden name=action value='{$this->action}'>\n";
+        echo "<input type=hidden name=subaction value='{$this->subaction}'>\n";
+        echo "</form>\n";
+        UI::emitJS('js/user.apikey.js');
     }
 
     public function updateAirname() {

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -1581,10 +1581,10 @@ class Playlists extends MenuItem {
 
     public function manageKeys() {
        $api = Engine::api(IUser::class);
-       if($_REQUEST["newKey"]) {
+       if($_POST["newKey"]) {
            $newKey = sha1(uniqid(rand()));
            $api->addAPIKey($this->session->getUser(), $newKey);
-       } else if($_REQUEST["deleteKey"]) {
+       } else if($_POST["deleteKey"]) {
            $selKeys = [];
            foreach($_POST as $key => $value) {
                if(substr($key, 0, 2) == "id" && $value == "on")
@@ -1601,7 +1601,7 @@ class Playlists extends MenuItem {
        </div>
     <?php
        $keys = $api->getAPIKeys($this->session->getUser())->asArray();
-       echo "       <form action='?' method=post>\n";
+       echo "<form action='?' method=post>\n";
        if(sizeof($keys)) {
     ?>
        <p><b>Your API Keys:</b></p>
@@ -1611,14 +1611,14 @@ class Playlists extends MenuItem {
        foreach($keys as $key) {
            echo "<tr><td><input name=id{$key['id']} type=checkbox></td>".
                 "<td class='apikey'>{$key['apikey']}</td>".
-                "<td><a href='#' title='Copy Key to Clipboard' class='copy'>&#x1f4cb;</a></td></tr>";
+                "<td><a href='#' title='Copy Key to Clipboard' class='copy'>&#x1f4cb;</a></td></tr>\n";
        }
-       echo "</table>";
-       echo "<P><INPUT TYPE=submit CLASS=submit NAME=deleteKey VALUE=' Remove Key '>&nbsp;&nbsp;&nbsp;\n";
+       echo "</table>\n";
+       echo "<p><input type=submit class=submit name=deleteKey value=' Remove Key '>&nbsp;&nbsp;&nbsp;\n";
        } else
            echo "<p><b>You have no API Keys.</b></p><p>\n";
 
-       echo "<INPUT TYPE=submit CLASS=submit NAME=newKey VALUE=' Generate New Key '></p>\n";
+       echo "<input type=submit class=submit name=newKey value=' Generate New Key '></p>\n";
        echo "<input type=hidden name=action value='{$this->action}'>\n";
        echo "<input type=hidden name=subaction value='{$this->subaction}'>\n";
        echo "</form>\n";


### PR DESCRIPTION
This PR adds an API to automate insertion of new albums/labels into zookeeper.

The API takes the album/label in JSON:API format.  The JSON file is posted to the `api/v1/importAlbums` endpoint.  Authentication is via API Key (see #255)  

Required fields for album: `artist`, `album`, `category`, `medium`, `format`, `location`, `coll`.  The values for category, medium, format, and location correspond to the _values_ of the constants defined in ILibrary (e.g., `"category": "Blues", "medium": "CD", "length": "Full", "location": "Library"`).

Fields are scrubbed similarly to the library editor UI vis-a-vis capitalization, etc.

Label is specified as an included relationship and is required.  The included object must have properties `pubkey` or `name`, plus optionally `attention`, `address`, `city`, `state`, `foreign`, `phone`, `fax`, `email`, `url`.  See the minimal sample file below.

Music labels may be specified by `pubkey` or by `name`.  In the case of the latter, if there is an existing label of the same name already in zookeeper, it is reused; otherwise, a new label is created and associated with the album.

Tracks are supplied in the album's `data` object array; each array element contains `track`, `url` (optional), and `artist` (if `coll` is true).

You may include multiple album objects within the top-level request data object array.  You may assign each one a local identifier `lid` to identify it in the response, in the event of errors.  Upon success, the resulting album tag is returned in the `id` property.

A minimal [sample JSON file](https://github.com/RocketMan/zookeeper/files/7653917/album.txt) is here.

[Edit: revised API endpoint per new convention]

