### PR TITLE
migrate to more RESTian API

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -20,7 +20,7 @@ RewriteRule ^zkrss\.php$ index.php?target=rss [QSA,L]
 RewriteRule ^zk-feed-reader\.xslt$ controllers/RSS.xslt [QSA,L]
 RewriteRule ^zkapi\.php$ index.php?target=api [QSA,L]
 RewriteRule ^ssoLogin\.php$ index.php?target=sso [QSA,L]
-RewriteRule ^api/v([0-9]+(\.[0-9]+)*)/([^/]+)(/([0-9]+))?$ index.php?target=api&method=$3Rq&id=$5&apiver=$1 [QSA,L]
+RewriteRule ^api/v([0-9]+(\.[0-9]+)*)/([^/]+)(/([0-9]+))?(/(.+))?$ index.php?target=api&method=$3Rq&id=$5&relation=$7&apiver=$1 [QSA,L]
 RewriteCond $0 !^\.mdhandler.php/.*$
 RewriteRule ^(.+)\.md$ .mdhandler.php?asset=/$1.md [L]
 RewriteRule ^zk$ - [R=404,L]

--- a/.htaccess
+++ b/.htaccess
@@ -20,7 +20,7 @@ RewriteRule ^zkrss\.php$ index.php?target=rss [QSA,L]
 RewriteRule ^zk-feed-reader\.xslt$ controllers/RSS.xslt [QSA,L]
 RewriteRule ^zkapi\.php$ index.php?target=api [QSA,L]
 RewriteRule ^ssoLogin\.php$ index.php?target=sso [QSA,L]
-RewriteRule ^api/v([0-9]+(\.[0-9]+)*)/(.+)$ index.php?target=api&method=$3Rq&apiver=$1 [QSA,L]
+RewriteRule ^api/v([0-9]+(\.[0-9]+)*)/([^/]+)(/([0-9]+))?$ index.php?target=api&method=$3Rq&id=$5&apiver=$1 [QSA,L]
 RewriteCond $0 !^\.mdhandler.php/.*$
 RewriteRule ^(.+)\.md$ .mdhandler.php?asset=/$1.md [L]
 RewriteRule ^zk$ - [R=404,L]

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
 	"axy/sourcemap": "^0.1.5",
 	"cboden/ratchet": "^0.4.3",
 	"erusev/parsedown": "^1.8.0-beta7",
+	"json-api-php/json-api": "^2.2",
 	"mrclay/jsmin-php": "^2.4.0",
 	"react/datagram": "^1.5",
 	"react/http": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de344bfd1cb29bb31f95ff957e2f7b43",
+    "content-hash": "0e71b2615492780a8d7a56f75184763e",
     "packages": [
         {
             "name": "axy/backtrace",
@@ -431,6 +431,60 @@
                 "source": "https://github.com/guzzle/psr7/tree/1.8.2"
             },
             "time": "2021-04-26T09:17:50+00:00"
+        },
+        {
+            "name": "json-api-php/json-api",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/json-api-php/json-api.git",
+                "reference": "fcecfd38ee5ea58885cfb70e6033eb3983c4fc10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/json-api-php/json-api/zipball/fcecfd38ee5ea58885cfb70e6033eb3983c4fc10",
+                "reference": "fcecfd38ee5ea58885cfb70e6033eb3983c4fc10",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.13",
+                "phpunit/phpunit": "^7.0||^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JsonApiPhp\\JsonApi\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexey Karapetov",
+                    "email": "karapetov@gmail.com"
+                }
+            ],
+            "description": "An attempt to express JSON API specs (jsonapi.org) in object-oriented way as a set of PHP 7 classes",
+            "support": {
+                "issues": "https://github.com/json-api-php/json-api/issues",
+                "source": "https://github.com/json-api-php/json-api/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/f3ath",
+                    "type": "custom"
+                }
+            ],
+            "time": "2020-10-13T00:41:38+00:00"
         },
         {
             "name": "mrclay/jsmin-php",
@@ -2169,5 +2223,5 @@
         "php": ">=7.2.5"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -721,19 +721,20 @@ class API extends CommandTarget implements IController {
                     (new PlaylistObserver())->onComment(function($entry) use(&$events) {
                         $events[] = ["type" => "comment",
                                      "comment" => $entry->getComment(),
-                                     "created" => $entry->getCreated()];
+                                     "created" => $entry->getCreatedTime()];
                     })->onLogEvent(function($entry) use(&$events) {
                         $events[] = ["type" => "logEvent",
                                      "event" => $entry->getLogEventType(),
                                      "code" => $entry->getLogEventCode(),
-                                     "created" => $entry->getCreated()];
+                                     "created" => $entry->getCreatedTime()];
                     })->onSetSeparator(function($entry) use(&$events) {
                         $events[] = ["type" => "break",
-                                     "created" => $entry->getCreated()];
+                                     "created" => $entry->getCreatedTime()];
                     })->onSpin(function($entry) use(&$events) {
                         $spin = $entry->asArray();
                         $spin["type"] = "track";
                         $spin["artist"] = UI::swapNames($spin["artist"]);
+                        $spin["created"] = $entry->getCreatedTime();
                         unset($spin["id"]);
                         $events[] = $spin;
                     }), 0, $filter);

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -704,6 +704,7 @@ class API extends CommandTarget implements IController {
         $rel["label"] = [];
         $rel["label"]["links"] = ["related" => "{$this->base}/album/{$key}/label"];
         $rel["label"]["data"] = ["type" => "label", "id" => $albums[0]["pubkey"]];
+        $rel["label"]["meta"] = ["name" => $label];
         if(in_array("label", $include)) {
             $l = $labels[0];
             $l["type"] = "label";
@@ -742,7 +743,6 @@ class API extends CommandTarget implements IController {
         $attrs["id"] = $key;
         $attrs["artist"] =  $artist;
         $attrs["album"] = $albums[0]["album"];
-        $attrs["label"] = ["name" => $label, "pubkey" => $albums[0]["pubkey"]];
         $attrs["category"] = ILibrary::GENRES[$albums[0]["category"]];
         $attrs["medium"] = ILibrary::MEDIA[$albums[0]["medium"]];
         $attrs["format"] = ILibrary::LENGTHS[$albums[0]["size"]];

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -692,7 +692,11 @@ class API extends CommandTarget implements IController {
             $l["type"] = "label";
             $l["links"] = ["self" => "{$base}/label/{$l['id']}"];
             unset($l["pubkey"]);
-            for($i=0; $i<sizeof($l); $i++)
+            if(!$this->session->isAuth("u"))
+                unset($l["attention"], $l["address"], $l["phone"],
+                        $l["fax"], $l["email"], $l["mailcount"],
+                        $l["maillist"], $l["international"]);
+            for($i=0; $i<sizeof($labels[0]); $i++)
                 unset($l[$i]);
             $inc[] = $l;
         }
@@ -709,7 +713,7 @@ class API extends CommandTarget implements IController {
                     $review["date"] = $review["created"];
                     $review["links"] = ["self" => "{$base}/review/{$review['id']}"];
                     unset($review["created"], $review["user"], $review["private"]);
-                    for($i=0; $i<sizeof($review); $i++)
+                    for($i=0; $i<sizeof($review)+5; $i++)
                         unset($review[$i]);
                     $inc[] = $review;
                 }
@@ -843,6 +847,10 @@ class API extends CommandTarget implements IController {
     public function getLabel($byId = 1) {
         $fields = API::LABEL_FIELDS;
         self::array_remove($fields, "pubkey");
+        if(!$this->session->isAuth("u"))
+            self::array_remove($fields, "attention", "address",
+                    "phone", "fax", "email", "mailcount",
+                    "maillist", "international");
         array_unshift($fields, "type", "id");
 
         if($byId)

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -690,6 +690,7 @@ class API extends CommandTarget implements IController {
         if(in_array("label", $include)) {
             $l = $labels[0];
             $l["type"] = "label";
+            $l["id"] = $l["pubkey"];
             $l["links"] = ["self" => "{$base}/label/{$l['id']}"];
             unset($l["pubkey"]);
             if(!$this->session->isAuth("u"))

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -745,6 +745,7 @@ class API extends CommandTarget implements IController {
             $rshow[] = new ResourceObject('show', $id?$id:$row["id"],
                 new Attribute("name", $row["description"]),
                 new Attribute("date", $row["showdate"]),
+                new Attribute("time", $row["showtime"]),
                 new Attribute("airname", $row["airname"]),
                 ...$tracks);
         }

--- a/controllers/API.php
+++ b/controllers/API.php
@@ -959,8 +959,7 @@ class API extends CommandTarget implements IController {
                 if($valid) {
                     $djapi = Engine::api(IDJ::class);
                     $user = $this->session->getUser();
-                    $airname = $djapi->getAirname($data->airname,
-                            $this->session->isAuth("v")?"":$user);
+                    $airname = $djapi->getAirname($data->airname);
                     if(!$airname) {
                         // airname does not exist; try to create it
                         $success = $djapi->insertAirname(mb_substr($data->airname, 0, IDJ::MAX_AIRNAME_LENGTH), $user);

--- a/controllers/CommandTarget.php
+++ b/controllers/CommandTarget.php
@@ -35,11 +35,12 @@ abstract class CommandTarget {
     }
 
     public function dispatchAction($action, &$actions) {
-        $processed = 0;
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        $processed = false;
         foreach($actions as $item) {
-            if($item[0] == $action) {
+            if($item[0] == $action && ($item[2] ?? $method) == $method) {
                 $this->{$item[1]}();
-                $processed = 1;
+                $processed = true;
             }
         }
 

--- a/controllers/ExportPlaylist.php
+++ b/controllers/ExportPlaylist.php
@@ -88,8 +88,7 @@ class ExportPlaylist extends CommandTarget implements IController {
 
     public function emitJSON() {
         header("Location: ".UI::getBaseUrl().
-               "api/v1/getPlaylists?operation=byID&key=".
-               $_REQUEST["playlist"]."&json=1&includeTracks=1");
+               "api/v1/playlist/{$_REQUEST["playlist"]}");
     }
 
     public function emitXML() {

--- a/engine/IEditor.php
+++ b/engine/IEditor.php
@@ -36,7 +36,8 @@ interface IEditor {
 
     function insertUpdateAlbum(&$album, $tracks, $label);
     function insertUpdateLabel(&$label);
-    function importAlbum($json);
+    function importAlbum($json, $update = false);
+    function deleteAlbum($tag);
     function enqueueTag($tag, $user);
     function dequeueTag($tag, $user);
     function getNumQueuedTags($user);

--- a/engine/IReview.php
+++ b/engine/IReview.php
@@ -45,7 +45,7 @@ interface IReview {
     const MAX_REVIEW_LENGTH = 64000;
 
     function getRecentReviews($user = "", $weeks = 0, $limit = 0, $loggedIn = 0);
-    function getReviews($tag, $byName=1, $user = "", $loggedIn = 0);
+    function getReviews($tag, $byName=1, $user = "", $loggedIn = 0, $byId = 0);
     function insertReview($tag, $private, $airname, $review, $user);
     function updateReview($tag, $private, $airname, $review, $user);
     function deleteReview($tag, $user);

--- a/engine/PlaylistEntry.php
+++ b/engine/PlaylistEntry.php
@@ -264,6 +264,20 @@ class PlaylistEntry {
     }
 
     /**
+     * return the time component of the 'created' datetime string
+     *
+     * @return time component on success; original datetime value otherwise
+     */
+    public function getCreatedTime() {
+        $datetime = $this->getCreated();
+
+        // yyyy-mm-dd hh:mm:ss
+        if($datetime && strlen($datetime) == 19)
+            $datetime = substr($datetime, 11, 8);
+        return $datetime;
+    }
+
+    /**
      * get the value of the PlaylistEntry as an associative array
      *
      * CAUTION: the values returned by this method are undefined

--- a/engine/impl/Editor.php
+++ b/engine/impl/Editor.php
@@ -312,15 +312,16 @@ class EditorImpl extends DBO implements IEditor {
 
         $json->iterateData(function($data) use($json, $update, $maps) {
             $message = "";
-            if(empty($data['artist']) || empty($data['album']))
+            $album = $data['attributes'];
+            if(empty($album['artist']) || empty($album['album']))
                 $message .= "artist or album missing, ";
 
             // convert field values to codes
             foreach($maps as $field)
-                if(key_exists($data[$field[0]], $field[1]))
-                    $data[$field[0]] = $field[1][$data[$field[0]]];
+                if(key_exists($album[$field[0]], $field[1]))
+                    $album[$field[0]] = $field[1][$album[$field[0]]];
                 else
-                    $message .= $field[0]. " '{$data[$field[0]]}', ";
+                    $message .= $field[0]. " '{$album[$field[0]]}', ";
 
             if($message) {
                 $json->addError($data['lid'], "Bad field(s): " . substr($message, 0, -2));
@@ -353,15 +354,15 @@ class EditorImpl extends DBO implements IEditor {
                 }
             }
 
-            $data['pubkey'] = $label['pubkey'];
+            $album['pubkey'] = $label['pubkey'];
 
             // reindex tracks
-            $tracks = array_combine(range(1, sizeof($data['data'])),
-                        array_values($data['data']));
+            $tracks = array_combine(range(1, sizeof($album['tracks'])),
+                        array_values($album['tracks']));
 
             // normalize artist, album, and track names
             foreach(["artist", "album"] as $field)
-                $data[$field] = self::zkAlpha($data[$field]);
+                $album[$field] = self::zkAlpha($album[$field]);
 
             foreach($tracks as &$track) {
                 $track["track"] = self::zkAlpha($track["track"], true);
@@ -376,12 +377,12 @@ class EditorImpl extends DBO implements IEditor {
             }
 
             if(!$update)
-                unset($data["tag"]);
-            else if(empty($data["tag"]))
-                $data["tag"] = $data["id"];
+                unset($album["tag"]);
+            else if(empty($album["tag"]))
+                $album["tag"] = $album["id"];
 
-            if($this->insertUpdateAlbum($data, $tracks, $label))
-                $json->addSuccess($data["tag"], ["lid" => $data["lid"]]);
+            if($this->insertUpdateAlbum($album, $tracks, $label))
+                $json->addSuccess($album["tag"], ["lid" => $data["lid"]]);
             else
                 $json->addError($data['lid'], "insert failed");
         });

--- a/engine/impl/Editor.php
+++ b/engine/impl/Editor.php
@@ -377,6 +377,8 @@ class EditorImpl extends DBO implements IEditor {
 
             if(!$update)
                 unset($data["tag"]);
+            else if(empty($data["tag"]))
+                $data["tag"] = $data["id"];
 
             if($this->insertUpdateAlbum($data, $tracks, $label))
                 $json->addSuccess($data["tag"], ["lid" => $data["lid"]]);

--- a/engine/impl/Review.php
+++ b/engine/impl/Review.php
@@ -95,17 +95,17 @@ class ReviewImpl extends DBO implements IReview {
         return $stmt->iterate(\PDO::FETCH_BOTH);
     }
     
-    public function getReviews($tag, $byName=1, $user = "", $loggedIn = 0) {
+    public function getReviews($tag, $byName=1, $user = "", $loggedIn = 0, $byId = 0) {
         settype($tag, "integer");
         if($byName)
             $query = "SELECT r.id, r.created, r.review, " .
-                     "r.private, r.user, a.airname " .
+                     "r.private, r.user, a.airname, r.tag " .
                      "FROM reviews r " .
                      "LEFT JOIN airnames a ON a.id = r.airname ";
         else
             $query = "SELECT id, created, review, " .
-                     "private, user, airname FROM reviews ";
-        $query .= "WHERE tag=? ";
+                     "private, user, airname, tag FROM reviews r ";
+        $query .= $byId?"WHERE r.id=? ":"WHERE tag=? ";
         if($user)
             $query .= "AND user=? ";
         if(!$loggedIn)

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -128,7 +128,7 @@ $().ready(function(){
             accept: "application/json; charset=utf-8",
             url: url,
         }).done(function (response) { //TODO: success?
-            if (response.code == INVALID_TAG) {
+            if (response.errors && response.errors[0].code == INVALID_TAG) {
                 showUserError(id + ' is not a valid tag.');
                 return;
             }
@@ -139,7 +139,7 @@ $().ready(function(){
             var options = "<option value=''>Select Track</option>";
             var options2 = "";
             var diskInfo = response.data[0];
-            trackList = diskInfo.data;
+            trackList = diskInfo.attributes.tracks;
             for (var i=0; i < trackList.length; i++) {
                 var track = trackList[i];
                 var artist = track.artist ? track.artist + ' - ' : '';
@@ -151,9 +151,9 @@ $().ready(function(){
             $("#track-title-pick").find('option').remove().end().append(options);
             $("#track-titles").html(options2);
             $("#track-title").attr('list','track-titles'); // webkit hack
-            $("#track-artist").val(diskInfo.artist);
+            $("#track-artist").val(diskInfo.attributes.artist);
             $("#track-label").val(diskInfo.relationships.label.meta.name);
-            $("#track-album").val(diskInfo.album);
+            $("#track-album").val(diskInfo.attributes.album);
             $("#track-title").val("");
             $("#track-submit").attr("disabled");
             $("#track-submit").prop("disabled", true);
@@ -175,7 +175,7 @@ $().ready(function(){
                     }
                 }
             }
-            $("#tag-artist").text(diskInfo.artist  + ' - ' + diskInfo.album);
+            $("#tag-artist").text(diskInfo.attributes.artist  + ' - ' + diskInfo.attributes.album);
 
         }).fail(function (jqXHR, textStatus, errorThrown) {
             showUserError('Ajax error: ' + textStatus);

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -152,7 +152,7 @@ $().ready(function(){
             $("#track-titles").html(options2);
             $("#track-title").attr('list','track-titles'); // webkit hack
             $("#track-artist").val(diskInfo.artist);
-            $("#track-label").val(diskInfo.label.name);
+            $("#track-label").val(diskInfo.relationships.label.meta.name);
             $("#track-album").val(diskInfo.album);
             $("#track-title").val("");
             $("#track-submit").attr("disabled");

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -121,14 +121,14 @@ $().ready(function(){
         $("#track-titles").empty();
         clearUserInput(false);
         tagId = ""
-        var url = "api/v1/getTracks?key=" + id;
+        var url = "api/v1/album/" + id;
         $.ajax({
             dataType : 'json',
             type: 'GET',
             accept: "application/json; charset=utf-8",
             url: url,
-        }).done(function (diskInfo) { //TODO: success?
-            if (diskInfo.code == INVALID_TAG) {
+        }).done(function (response) { //TODO: success?
+            if (response.code == INVALID_TAG) {
                 showUserError(id + ' is not a valid tag.');
                 return;
             }
@@ -138,6 +138,7 @@ $().ready(function(){
                 $("#track-tag").val(id);
             var options = "<option value=''>Select Track</option>";
             var options2 = "";
+            var diskInfo = response.data[0];
             trackList = diskInfo.data;
             for (var i=0; i < trackList.length; i++) {
                 var track = trackList[i];
@@ -151,7 +152,7 @@ $().ready(function(){
             $("#track-titles").html(options2);
             $("#track-title").attr('list','track-titles'); // webkit hack
             $("#track-artist").val(diskInfo.artist);
-            $("#track-label").val(diskInfo.label);
+            $("#track-label").val(diskInfo.label.name);
             $("#track-album").val(diskInfo.album);
             $("#track-title").val("");
             $("#track-submit").attr("disabled");


### PR DESCRIPTION
This is a revision of the album and playlist APIs to make them more restian.  Specifically:

* Retrieve album details with GET to **api/v1/album/_id_**, where _id_ is the tag number (e.g, `api/v1/album/1001` retrieves album with tag 1001)
* You can request related information be included in the response by adding an 'include' query string parameter with comma separated values (e.g., `api/v1/album/1001?include=label,reviews`)
* You can also request related information by suffixing the path info of the resource (e.g., `api/v1/album/1001/reviews` returns all reviews associated with album tag 1001)
* Update an album or albums with PUT to **api/v1/album**.  Album details are in request body in same format returned by GET (see #256).  X-APIKEY authentication required, must belong to 'm' group.
* Insert a new album or albums with POST to **api/v1/album**.  Album details are in request body as above.   X-APIKEY authentication required, must belong to 'm' group.
* Delete an album with a DELETE to **api/v1/album/_id_**, where _id_ is the tag to delete.  Delete will fail if album has reviews, or if it has ever been in the a-file or charted.   X-APIKEY authentication required, must belong to 'm' group.
* Retrieve a playlist with GET to **api/v1/playlist/_id_**, where _id_ is the playlist ID
* Insert a new playlist or playlists with POST to **api/v1/playlist**.  Playlist is in the request body in the same format returned by GET.  X-APIKEY authentication required.  If you belong to 'v' group, you may insert playlists on behalf of other users:  You will own the list in these cases (i.e., can edit or delete them), but they will display publicly under the other user's airname.
* Delete a playlist with a DELETE to **api/v1/playlist/_id_**, where _id_ is the playlist ID to delete.  X-APIKEY authentication required.  You can delete only your own playlists.
* Request a label with GET to **api/v1/label/_id_**, where _id_ is the label pubkey.  Non-public label information is suppressed unless you authenticate.
* Request a music review with GET to **api/v1/review/_id_**, where _id_ is the review id
* Insert one or more music reviews with a POST to **api/v1/review**  Review is in the request body in the same format returned by GET.  X-APIKEY authentication is required.  You can insert reviews only for yourself.
* Update a music review or reviews with PUT to **api/v1/review**.  Review is in the request body in the same format returned by GET.  X-APIKEY authentication is required.  You can update reviews only for yourself.
* Delete a music review with a DELETE to **api/v1/review/_id_**, where _id_ is the review ID to delete.  X-APIKEY authentication is required.  You can delete only your own reviews.

In addition,
* The 'zkapi.php?method=getTracksRq&key=_tag_' API has been deprecated in favour of 'api/v1/album/_tag_'.  The response has been reogranized for consistency with JSON:API.  Internal uses have been adapted.
* The 'zkapi.php?method=getPlaylistsRq' API has been deprecated.  Use `api/v1/playlist` instead.  Supply the fliter using query string parameters as usual.  The response has been reorganized for consistency with JSON:API.  Internal uses have been adapted.



