### PR TITLE
Added album relationship to playlist

### DIFF
--- a/api/Albums.php
+++ b/api/Albums.php
@@ -375,7 +375,7 @@ class Albums implements RequestHandlerInterface {
         case "relationships":
             throw new NotAllowedException("unspecified relationship");
         default:
-            throw new ResourceNotFoundException("album", $request->relationship());
+            throw new NotAllowedException('You are not allowed to fetch the relationship ' . $request->relationship());
         }
 
         $document = new Document($res);

--- a/api/OffsetPaginationTrait.php
+++ b/api/OffsetPaginationTrait.php
@@ -101,7 +101,7 @@ trait OffsetPaginationTrait {
         return $result;
     }
 
-    protected function fromPlaylistSearch(array $records) {
+    protected function fromPlaylistSearch(array $records, $wantAlbums = false) {
         $result = [];
         $map = [];
         foreach($records as $record) {
@@ -110,7 +110,7 @@ trait OffsetPaginationTrait {
                 $resource = $map[$list];
                 $events = $resource->attributes()->getOptional("events");
             } else {
-                $resource = $map[$list] = Playlists::fromRecord($record);
+                $resource = $map[$list] = Playlists::fromRecord($record, $wantAlbums);
                 $result[] = $resource;
                 $events = [];
             }
@@ -199,7 +199,7 @@ trait OffsetPaginationTrait {
             $result = $this->fromTrackSearch($records);
             break;
         case Playlists::PLAYLIST_SEARCH:
-            $result = $this->fromPlaylistSearch($records);
+            $result = $this->fromPlaylistSearch($records, $request->requestsInclude("albums"));
             break;
         default:
             $result = self::fromArray($records, $links);

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -138,9 +138,9 @@ class Playlists implements RequestHandlerInterface {
                     else
                         $res = new JsonResource("album", $tag);
                     $relations->set($res);
-                    $spin["tag"] = ["type" => "album", "id" => $tag];
-                } else
-                    unset($spin["tag"]);
+                    $spin["zk:relationships"] = ["albums" => ["data" => ["type" => "album", "id" => $tag]]];
+                }
+                unset($spin["tag"]);
                 unset($spin["id"]);
                 $events[] = $spin;
             }));

--- a/api/Reviews.php
+++ b/api/Reviews.php
@@ -166,7 +166,7 @@ class Reviews implements RequestHandlerInterface {
         case "relationships":
             throw new NotAllowedException("unspecified relationship");
         default:
-            throw new ResourceNotFoundException("review", $request->relationship());
+            throw new NotAllowedException('You are not allowed to fetch the relationship ' . $request->relationship());
         }        
 
         $document = new Document($res);

--- a/engine/PlaylistEntry.php
+++ b/engine/PlaylistEntry.php
@@ -174,7 +174,7 @@ class PlaylistEntry {
             $entry->setTrack(self::scrubField($json->track));
             $entry->setAlbum(self::scrubField($json->album));
             $entry->setLabel(self::scrubField($json->label));
-            $entry->setTag($json->tag);
+            $entry->setTag($json->tag->id ?? $json->tag);
             break;
         }
         $entry->setCreated($json->created);
@@ -198,7 +198,8 @@ class PlaylistEntry {
             $entry->setTrack(self::scrubField($array["track"]));
             $entry->setAlbum(self::scrubField($array["album"]));
             $entry->setLabel(self::scrubField($array["label"]));
-            $entry->setTag($array["tag"]);
+            if($array["tag"] && ($tag = $array["tag"]["id"]))
+                $entry->setTag($tag);
             break;
         }
         $entry->setCreated($array["created"]);

--- a/engine/PlaylistEntry.php
+++ b/engine/PlaylistEntry.php
@@ -174,7 +174,13 @@ class PlaylistEntry {
             $entry->setTrack(self::scrubField($json->track));
             $entry->setAlbum(self::scrubField($json->album));
             $entry->setLabel(self::scrubField($json->label));
-            $entry->setTag($json->tag->id ?? $json->tag);
+            if(($a = $json->{"zk:relationships"} ?? null) &&
+                    ($a = $a->albums ?? null) &&
+                    ($a = $a->data ?? null) &&
+                    $a->type ?? null == "album" &&
+                    ($a = $a->id ?? null) ||
+                    ($a = $json->tag ?? null))
+                $entry->setTag($a);
             break;
         }
         $entry->setCreated($json->created);
@@ -198,8 +204,12 @@ class PlaylistEntry {
             $entry->setTrack(self::scrubField($array["track"]));
             $entry->setAlbum(self::scrubField($array["album"]));
             $entry->setLabel(self::scrubField($array["label"]));
-            if($array["tag"] && ($tag = $array["tag"]["id"]))
-                $entry->setTag($tag);
+            if(($a = $array["zk:relationships"] ?? null) &&
+                    ($a = $a["albums"] ?? null) &&
+                    ($a = $a["data"] ?? null) &&
+                    $a["type"] ?? null == "album" &&
+                    ($a = $a["id"] ?? null))
+                $entry->setTag($a);
             break;
         }
         $entry->setCreated($array["created"]);


### PR DESCRIPTION
Each playlist 'spin' event can have a related album.  Historically, this has been indicated by the 'tag' attribute, which contained the Album's id.

However, per the JSON:API spec, foreign keys should not be included as attributes (see JSON:API v1.0 section 5.2.3), but instead as relationships.  The problem is that the relationship in this case is specific to the nested event object, not the enclosing playlist.  The spec forbids us from including 'relationships' or 'links' objects within the complex attributes (again, from section 5.2.3).

To implement this in the canonical way would require normalizing the events into separate, addressable resources.  This would bring a performance cost as well as complexity for the consumers of the API.

As an interim solution, we link the albums to the top-level playlist show resource in the convention way, whilst including within the event a resource identifier attribute in the zk namespace of the form `"zk:relationships":{"albums":{"data":{"type":"album","id":_id_}}}`.  In this way, it is possible to correlate the event to the album, if you have knowlege of the zk-namespace; otherwise, it is ignored, and only the playlist-level relationships are observed.

If a future version of the spec were to support relationships from complex attributes, then this can be revisited.
