### PR TITLE
Refactor php-fpm rewrite fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_script:
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
   - sudo chown -R travis:travis /var/lib/apache2/fastcgi
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
+  # Fixup rewrites for php-fpm
+  - cat build/php-fpm-redirect >> api/.htaccess
   # Configure Apache vhosts
   - sudo cp -f build/travis-ci-apache /etc/apache2/sites-available/000-default.conf
   - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/000-default.conf

--- a/api/.htaccess
+++ b/api/.htaccess
@@ -4,16 +4,4 @@ RewriteCond %{REQUEST_URI}::$0 ^(/.+)/(v([0-9]+(\.[0-9]+)*)/.*)::\2$
 RewriteRule .* - [E=BASE:%1,E=APIVER:%3,E=PREFIX:%1/v%3/]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule ^ %{ENV:BASE}/index.php [L]
-
-# The following rules are needed for php-fcgi, as apache does an extra rewrite.
-#
-# In absence of these rules, we would end up with REDIRECT_APIVER in the non-
-# php-fcgi case, but with php-fcgi, we get REDIRECT_REDIRECT_APIVER due to
-# the extra rewrite.  By rewriting to APIVER (and PREFIX) here, the extra
-# rewrite of php-fcgi will result in REDIRECT_APIVER as expected.  (In the
-# non php-fcgi case, this rule will result in an unused APIVER/PREFIX.)
-RewriteCond %{ENV:REDIRECT_APIVER} (.+)
-RewriteRule .* - [E=APIVER:%1]
-RewriteCond %{ENV:REDIRECT_PREFIX} (.+)
-RewriteRule .* - [E=PREFIX:%1]
 </IfModule>

--- a/build/php-fpm-redirect
+++ b/build/php-fpm-redirect
@@ -1,0 +1,13 @@
+# Invocation of php-fpm results in an extra rewrite,
+# which prefixes the environment variables with REDIRECT_.
+#
+# These rules rewrite the existing REDIRECT_x to x.  After
+# php-fpm, they will once again be REDIRECT_x as expected,
+# rather than REDIRECT_REDIRECT_x.
+
+<IfModule mod_rewrite.c>
+RewriteCond %{ENV:REDIRECT_APIVER} (.+)
+RewriteRule .* - [E=APIVER:%1]
+RewriteCond %{ENV:REDIRECT_PREFIX} (.+)
+RewriteRule .* - [E=PREFIX:%1]
+</IfModule>


### PR DESCRIPTION
Travis CI uses php-fpm, which requires us to fixup the environment variables.

This PR refactors the fix from the source code to the CI build process.
