### PR TITLE
Field negation cleanup

### DIFF
--- a/api/ApiRequest.php
+++ b/api/ApiRequest.php
@@ -30,6 +30,8 @@ use Enm\JsonApi\Model\Request\Request;
  * Zookeeper custom implementation of Request
  */
 class ApiRequest extends Request {
+    private $fieldNegation = [];
+
     /**
      * hack to access private properties of superclass
      */
@@ -48,16 +50,18 @@ class ApiRequest extends Request {
         if($wantsField) {
             $fields = $this->fields;
             if(key_exists($type, $fields)) {
-                $neg = false;
-                foreach($fields[$type] as $field) {
-                    if(substr($field, 0, 1) == "-") {
-                        if($field === "-" . $name) return false;
-                        $neg = true;
-                        break;
+                if(!key_exists($type, $this->fieldNegation)) {
+                    $this->fieldNegation[$type] = false;
+                    foreach($fields[$type] as $field) {
+                        if(substr($field, 0, 1) == "-") {
+                            $this->fieldNegation[$type] = true;
+                            if($field === "-" . $name) return false;
+                            break;
+                        }
                     }
                 }
 
-                $wantsField = $neg ?
+                $wantsField = $this->fieldNegation[$type] ?
                         !in_array("-" . $name, $fields[$type], true) :
                         in_array($name, $fields[$type], true);
             }

--- a/api/ApiRequest.php
+++ b/api/ApiRequest.php
@@ -83,7 +83,9 @@ class ApiRequest extends Request {
      * superclass), rather than the derived class as desired.
      *
      * If the upstream superclass method ever changes 'new self' to
-     * 'new static' for late static binding, this method can go away.
+     * 'new static' for late static binding, this method can be changed
+     * to delegate subrequest creation to the superclass, then simply
+     * add subclass-specifics (namely, fieldNegation) on the result.
      */
     public function createSubRequest(
         string $relationship,

--- a/api/ApiRequest.php
+++ b/api/ApiRequest.php
@@ -119,7 +119,7 @@ class ApiRequest extends Request {
                 $this->apiPrefix
             );
 
-            $subRequest->headers = $this->headers;
+            $subRequest->headers()->mergeCollection($this->headers());
             $subRequest->fieldNegation = &$this->fieldNegation;
 
             $this->requestCache[$requestKey] = $subRequest;

--- a/api/ApiRequest.php
+++ b/api/ApiRequest.php
@@ -44,15 +44,6 @@ class ApiRequest extends Request {
      * add support for fields negation (e.g., fields[resource]=-notWanted)
      */
     public function requestsField(string $type, string $name): bool {
-        // If caller requests a negated name, he wants to know if the
-        // negation literally appears in the fields list, versus the
-        // normal semantics of wanting to know if the field is requsted.
-        // See ApiServer::cleanUpResource which depends on this behaviour.
-        //
-        // In this case, delegate to the superclass.
-        if(substr($name, 0, 1) == "-")
-            return parent::requestsField($type, $name);
-
         $wantsField = $this->requestsAttributes();
         if($wantsField) {
             $fields = $this->fields;

--- a/api/ApiRequest.php
+++ b/api/ApiRequest.php
@@ -76,16 +76,7 @@ class ApiRequest extends Request {
     }
 
     /**
-     * Fix to run subrequest on derived class
-     *
-     * The superclass method creates subrequests via 'new self', which
-     * instantiates the class where the 'new' appears (that is, the
-     * superclass), rather than the derived class as desired.
-     *
-     * If the upstream superclass method ever changes 'new self' to
-     * 'new static' for late static binding, this method can be changed
-     * to delegate subrequest creation to the superclass, then simply
-     * add subclass-specifics (namely, fieldNegation) on the result.
+     * Fix to use derived class for the subrequest
      */
     public function createSubRequest(
         string $relationship,

--- a/api/ApiServer.php
+++ b/api/ApiServer.php
@@ -63,27 +63,4 @@ class ApiServer extends JsonApiServer {
             }
         }
     }
-
-    /**
-     * Optimise implementation of cleanUpResource.
-     *
-     * ApiRequest::requestsField checks requestsAttributes, so no need
-     * to do it here as well.
-     *
-     * This is an optimisation only and is not required.
-     */
-    protected function cleanUpResource(
-        ResourceInterface $resource,
-        RequestInterface $request
-    ): void {
-        foreach ($resource->attributes()->all() as $key => $value) {
-            if (!$request->requestsField($resource->type(), $key))
-                $resource->attributes()->remove($key);
-        }
-
-        if (!$request->requestsRelationships()) {
-            foreach ($resource->relationships()->all() as $relationship)
-                $resource->relationships()->removeElement($relationship);
-        }
-    }
 }

--- a/api/ApiServer.php
+++ b/api/ApiServer.php
@@ -65,40 +65,25 @@ class ApiServer extends JsonApiServer {
     }
 
     /**
-     * add support for fields negation (e.g., fields[resource]=-notWanted)
+     * Optimise implementation of cleanUpResource.
+     *
+     * ApiRequest::requestsField checks requestsAttributes, so no need
+     * to do it here as well.
+     *
+     * This is an optimisation only and is not required.
      */
     protected function cleanUpResource(
         ResourceInterface $resource,
         RequestInterface $request
     ): void {
-        // If no fields have been requested for a given type, then
-        // `requestsField` will return true for any candidate name.
-        // This means it will tell us there are negations even if none.
-        //
-        // To detect this case, we first test an unlikely field name.
-        // If it succeeds, we know that no fields have been requested.
-        if ($request->requestsAttributes() &&
-                !$request->requestsField($resource->type(), "-#&*(Q@")) {
-            // There is a field filter, so we can trust `requestsField`
-            $negation = false;
-            foreach ($resource->attributes()->all() as $key => $value) {
-                if ($request->requestsField($resource->type(), "-" . $key)) {
-                    $resource->attributes()->remove($key);
-                    $negation = true;
-                }
-            }
-
-            if ($negation) {
-                // There was one or more negation, finish the clean-up
-                if (!$request->requestsRelationships()) {
-                    foreach ($resource->relationships()->all() as $relationship)
-                        $resource->relationships()->removeElement($relationship);
-                }
-                return;
-            }
+        foreach ($resource->attributes()->all() as $key => $value) {
+            if (!$request->requestsField($resource->type(), $key))
+                $resource->attributes()->remove($key);
         }
 
-        // in all other cases, delegate to the superclass
-        parent::cleanUpResource($resource, $request);
+        if (!$request->requestsRelationships()) {
+            foreach ($resource->relationships()->all() as $relationship)
+                $resource->relationships()->removeElement($relationship);
+        }
     }
 }


### PR DESCRIPTION
Support for field negation is spread across two classes -- ApiServer and ApiRequest.  It is in the former due to a bug in the upstream superclass of ApiRequest, which causes subrequests to run on the superclass rather than the derived class, and hence miss the ApiRequest code path.

This PR:
* Fixes subrequests to run on the derived class;
* Deprecates the field negation code in ApiServer;
* Optimises the field negation test to run at most once per resource type.

There should be no functional changes noted.  There should be a slight performance improvement due to optimisation of the field negation test.