### PR TITLE
Update SSO and validation to use Guzzle http client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_script:
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - echo "php_admin_value[error_reporting]=E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - sudo a2enmod rewrite actions fastcgi alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,5 @@ before_script:
   - mysql -u root zookeeper < db/categories.sql
   - mysql -u root zookeeper < db/chartemail.sql
   - mysql -u root zookeeper < db/bootstrapUser.sql
-  # Set some $_SERVER vars used in Main.php
-  - export HTTP_ACCEPT="application/json"
-  - export HTTP_USER_AGENT="Travis CI"
 
 script: php zk validate url=http://127.0.0.1/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_script:
   - sudo apt-get install apache2 libapache2-mod-fastcgi
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+  - echo "php_admin_value[error_reporting]=E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - sudo a2enmod rewrite actions fastcgi alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -472,7 +472,14 @@ class Playlists implements RequestHandlerInterface {
 
         try {
             $album = $event->relationships()->get("album")->related()->first("album");
-            $entry->setTag($album->id());
+            $albumrec = Engine::api(ILibrary::class)->search(ILibrary::ALBUM_KEY, 0, 1, $album->id());
+            if(sizeof($albumrec)) {
+                // don't allow modification of album info if tag is set
+                $entry->setTag($album->id());
+                $entry->setArtist(PlaylistEntry::swapNames($albumrec[0]["artist"]));
+                $entry->setAlbum($albumrec[0]["album"]);
+                $entry->setLabel($albumrec[0]["name"]);
+            }
         } catch(\Exception $e) {}
 
         $autoTimestamp = false;

--- a/build/zookeeper.ini
+++ b/build/zookeeper.ini
@@ -1,1 +1,2 @@
 date.timezone="Europe/London"
+error_reporting=E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED

--- a/build/zookeeper.ini
+++ b/build/zookeeper.ini
@@ -1,2 +1,1 @@
 date.timezone="Europe/London"
-error_reporting=E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
 	"cboden/ratchet": "^0.4.3",
 	"enm/json-api-server": "^3.1",
 	"erusev/parsedown": "^1.8.0-beta7",
+	"guzzlehttp/guzzle": "^7.4",
 	"mrclay/jsmin-php": "^2.4.0",
 	"react/datagram": "^1.5",
 	"react/http": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e254ae27bafe2a001fd1d59f3968d66",
+    "content-hash": "867d87afef1655ecccaed6704ca104a5",
     "packages": [
         {
             "name": "axy/backtrace",
@@ -504,6 +504,214 @@
             "time": "2020-11-24T22:02:12+00:00"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "ee0a041b1760e6a53d2a39c8c34115adc2af2c79"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ee0a041b1760e6a53d2a39c8c34115adc2af2c79",
+                "reference": "ee0a041b1760e6a53d2a39c8c34115adc2af2c79",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.5",
+                "guzzlehttp/psr7": "^1.8.3 || ^2.1",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-12-06T18:43:05+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
+                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/1.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-22T20:56:57+00:00"
+        },
+        {
             "name": "guzzlehttp/psr7",
             "version": "2.1.0",
             "source": {
@@ -674,6 +882,58 @@
                 "source": "https://github.com/mrclay/jsmin-php/tree/master"
             },
             "time": "2018-12-06T15:03:38+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
         },
         {
             "name": "psr/http-factory",

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -215,13 +215,13 @@ class Validate implements IController {
 
             $success2 = $response->getStatusCode() == 200;
             if($success2) {
-                $json = json_decode($r = $response->getBody()->getContents());
+                $json = json_decode($response->getBody()->getContents());
                 if($json !== null && $json->data)
                     $cid = $json->data->id;
                 else
                     $success2 = false;
             }
-echo "DEBUG: code=".$response->getStatusCode()." s2=".($success2?"1":"0")." body=".$r.".\n";
+
             $this->showSuccess($success2);
         } else
             $success2 = false;

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -221,7 +221,7 @@ class Validate implements IController {
                 else
                     $success2 = false;
             }
-echo $response->getBody()->getContents();
+echo "DEBUG: code=".$response->getStatusCode()." s2=".($success2?"1":"0")." body=".$response->getBody()->getContents().".\n";
             $this->showSuccess($success2);
         } else
             $success2 = false;

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -173,6 +173,7 @@ class Validate implements IController {
             $success = false;
 
         if($this->doTest("create playlist", $success)) {
+            $airname = self::TEST_NAME." ".$this->testUser; // make unique
             $response = $client->post('api/v1/playlist', [
                 RequestOptions::JSON => [
                     'data' => [

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -221,7 +221,7 @@ class Validate implements IController {
                 else
                     $success2 = false;
             }
-
+echo $response->getBody()->getContents();
             $this->showSuccess($success2);
         } else
             $success2 = false;
@@ -330,7 +330,7 @@ class Validate implements IController {
             $this->showSuccess($success);
         }
 
-        if($this->doTest("release api key")) {
+        if($this->doTest("release api key", $success)) {
             $success = Engine::api(IUser::class)->deleteAPIKeys($this->testUser, [ $apiKeyId ]);
             $this->showSuccess($success);
         }

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -158,7 +158,8 @@ class Validate implements IController {
             if($success)
                 $apiKeyId = Engine::api(IUser::class)->lastInsertId();
             $this->showSuccess($success);
-        }
+        } else
+            $success = false;
 
         $client = new Client([
             'base_uri' => $_REQUEST["url"],
@@ -167,14 +168,6 @@ class Validate implements IController {
                 'X-APIKEY' => $apiKey
             ]
         ]);
-
-        if($this->doTest("create airname")) {
-            $djapi = Engine::api(IDJ::class);
-            $airname = self::TEST_NAME." ".$this->testUser; // make unique
-            $success = $djapi->insertAirname($airname, $this->testUser);
-            $this->showSuccess($success);
-        } else
-            $success = false;
 
         if($this->doTest("create playlist", $success)) {
             $response = $client->post('api/v1/playlist', [

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -155,6 +155,8 @@ class Validate implements IController {
         if($this->doTest("create api key")) {
             $apiKey = sha1(uniqid(rand()));
             $success = Engine::api(IUser::class)->addAPIKey($this->testUser, $apiKey);
+            if($success)
+                $apiKeyId = Engine::api(IUser::class)->lastInsertId();
             $this->showSuccess($success);
         }
 
@@ -329,7 +331,7 @@ class Validate implements IController {
         }
 
         if($this->doTest("release api key")) {
-            $success = Engine::api(IUser::class)->deleteAPIKeys($this->testUser, [ $apiKey ]);
+            $success = Engine::api(IUser::class)->deleteAPIKeys($this->testUser, [ $apiKeyId ]);
             $this->showSuccess($success);
         }
     }

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -215,13 +215,13 @@ class Validate implements IController {
 
             $success2 = $response->getStatusCode() == 200;
             if($success2) {
-                $json = json_decode($response->getBody()->getContents());
+                $json = json_decode($r = $response->getBody()->getContents());
                 if($json !== null && $json->data)
                     $cid = $json->data->id;
                 else
                     $success2 = false;
             }
-echo "DEBUG: code=".$response->getStatusCode()." s2=".($success2?"1":"0")." body=".$json.".\n";
+echo "DEBUG: code=".$response->getStatusCode()." s2=".($success2?"1":"0")." body=".$r.".\n";
             $this->showSuccess($success2);
         } else
             $success2 = false;

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -221,7 +221,7 @@ class Validate implements IController {
                 else
                     $success2 = false;
             }
-echo "DEBUG: code=".$response->getStatusCode()." s2=".($success2?"1":"0")." body=".$response->getBody()->getContents().".\n";
+echo "DEBUG: code=".$response->getStatusCode()." s2=".($success2?"1":"0")." body=".$json.".\n";
             $this->showSuccess($success2);
         } else
             $success2 = false;

--- a/engine/PlaylistEntry.php
+++ b/engine/PlaylistEntry.php
@@ -216,7 +216,10 @@ class PlaylistEntry {
             }
             break;
         }
-        $entry->setCreated($array["created"]);
+
+        if(isset($array["created"]))
+            $entry->setCreated($array["created"]);
+
         return $entry;
     }
 

--- a/engine/PlaylistEntry.php
+++ b/engine/PlaylistEntry.php
@@ -235,7 +235,7 @@ class PlaylistEntry {
             break;
         }
 
-        if(isset($array["created"]))
+//        if(isset($array["created"]))
             $entry->setCreated($array["created"]);
 
         return $entry;

--- a/engine/PlaylistEntry.php
+++ b/engine/PlaylistEntry.php
@@ -235,7 +235,7 @@ class PlaylistEntry {
             break;
         }
 
-//        if(isset($array["created"]))
+        if(isset($array["created"]))
             $entry->setCreated($array["created"]);
 
         return $entry;

--- a/engine/PlaylistEntry.php
+++ b/engine/PlaylistEntry.php
@@ -180,8 +180,16 @@ class PlaylistEntry {
                     ($a = $a->data ?? null) &&
                     ($a->type ?? null == "album") &&
                     ($a = $a->id ?? null) ||
-                    ($a = $json->tag ?? null))
-                $entry->setTag($a);
+                    ($a = $json->tag ?? null)) {
+                $albumrec = Engine::api(ILibrary::class)->search(ILibrary::ALBUM_KEY, 0, 1, $a);
+                if(sizeof($albumrec)) {
+                    // don't allow modification of album info if tag is set
+                    $entry->setTag($a);
+                    $entry->setArtist(self::swapNames($albumrec[0]["artist"]));
+                    $entry->setAlbum($albumrec[0]["album"]);
+                    $entry->setLabel($albumrec[0]["name"]);
+                }
+            }
             break;
         }
         $entry->setCreated($json->created);
@@ -202,17 +210,27 @@ class PlaylistEntry {
             break;
         case "spin":
         case "track":
-            $entry->setArtist(self::scrubField($array["artist"]));
             $entry->setTrack(self::scrubField($array["track"]));
-            $entry->setAlbum(self::scrubField($array["album"]));
-            $entry->setLabel(self::scrubField($array["label"]));
             if(isset($array["xa:relationships"])) {
                 // using the 'xa' extension
                 // see https://github.com/RocketMan/zookeeper/pull/263
                 try {
                     $album = $array["xa:relationships"]->get("album")->related()->first("album");
-                    $entry->setTag($album->id());
+                    $albumrec = Engine::api(ILibrary::class)->search(ILibrary::ALBUM_KEY, 0, 1, $album->id());
+                    if(sizeof($albumrec)) {
+                        // don't allow modification of album info if tag is set
+                        $entry->setTag($album->id());
+                        $entry->setArtist(self::swapNames($albumrec[0]["artist"]));
+                        $entry->setAlbum($albumrec[0]["album"]);
+                        $entry->setLabel($albumrec[0]["name"]);
+                    }
                 } catch(\Exception $e) {}
+            }
+
+            if(!$entry->getTag()) {
+                $entry->setArtist(self::scrubField($array["artist"]));
+                $entry->setAlbum(self::scrubField($array["album"]));
+                $entry->setLabel(self::scrubField($array["label"]));
             }
             break;
         }

--- a/engine/impl/User.php
+++ b/engine/impl/User.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2022 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -272,6 +272,12 @@ class UserImpl extends DBO implements IUser {
 
         // remove any airnames
         Engine::api(IDJ::class)->getAirnames($user);
+
+        // remove any api keys
+        $query = "DELETE FROM apikeys WHERE user=?";
+        $stmt = $this->prepare($query);
+        $stmt->bindValue(1, $user);
+        $stmt->execute();
 
         $query = "DELETE FROM users WHERE name = ?";
         $stmt = $this->prepare($query);

--- a/engine/impl/User.php
+++ b/engine/impl/User.php
@@ -274,7 +274,7 @@ class UserImpl extends DBO implements IUser {
         Engine::api(IDJ::class)->getAirnames($user);
 
         // remove any api keys
-        $query = "DELETE FROM apikeys WHERE user=?";
+        $query = "DELETE FROM apikeys WHERE user = ?";
         $stmt = $this->prepare($query);
         $stmt->bindValue(1, $user);
         $stmt->execute();


### PR DESCRIPTION
This PR replaces the legacy curl wrapper with Guzzle.

In addition, it updates all playlist validation tests to use Guzzle to exercise the APIs via the web server.
