### PR TITLE
Add print queue functionality to api

### DIFF
--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -479,6 +479,12 @@ class Validate implements IController {
             $this->showSuccess($success8);
         }
 
+        if($this->doTest("enqueue album", $success2)) {
+            $response = $this->client->post($album . "/printq");
+            $success12 = $response->getStatusCode() == 204;
+            $this->showSuccess($success12);
+        }
+
         if($this->doTest("create review", $success2)) {
             $airname = self::TEST_NAME." ".$this->testUser; // make unique
             $response = $this->client->post('api/v1/review', [

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -62,7 +62,7 @@ class Validate implements IController {
         return $runTest;
     }
 
-    private function showSuccess($success, $critical = true) {
+    private function showSuccess($success, $response = null, $critical = true) {
         if($critical)
             $this->success &= $success;
 
@@ -72,6 +72,11 @@ class Validate implements IController {
             echo self::FAIL."FAILED!";
             if(!$critical)
                 echo " (soft failure)";
+            if($response)
+                echo self::NORMAL."  ".
+                    $response->getStatusCode()." ".
+                    $response->getReasonPhrase()." ".
+                    $response->getBody()->getContents();
         }
         echo self::NORMAL."\n";
     }
@@ -165,7 +170,8 @@ class Validate implements IController {
                     RequestOptions::HEADERS => [
                         'Accept' => 'application/json',
                         'X-APIKEY' => $apiKey
-                    ]
+                    ],
+                    RequestOptions::HTTP_ERRORS => false
                 ]);
             }
 
@@ -197,7 +203,7 @@ class Validate implements IController {
                 $pid = basename($list);
             }
 
-            $this->showSuccess($success);
+            $this->showSuccess($success, $response);
         }
 
         if($this->doTest("insert comment", $success)) {
@@ -222,7 +228,7 @@ class Validate implements IController {
                     $success2 = false;
             }
 
-            $this->showSuccess($success2);
+            $this->showSuccess($success2, $response);
         } else
             $success2 = false;
 
@@ -250,7 +256,7 @@ class Validate implements IController {
                 else
                     $success3 = false;
             }
-            $this->showSuccess($success3);
+            $this->showSuccess($success3, $response);
         } else
             $success3 = false;
 
@@ -265,7 +271,7 @@ class Validate implements IController {
             ]);
 
             $success4 = $response->getStatusCode() == 200;
-            $this->showSuccess($success4);
+            $this->showSuccess($success4, $response);
         } else
             $success4 = false;
 
@@ -288,7 +294,7 @@ class Validate implements IController {
             $trackPos = strpos($page, self::TEST_TRACK);
             $success5 = $commentPos !== false && $trackPos !== false &&
                     $commentPos > $trackPos;
-            $this->showSuccess($success5);
+            $this->showSuccess($success5, $response);
         }
 
         if($this->doTest("validate search", $success3)) {
@@ -316,13 +322,13 @@ class Validate implements IController {
                     break;
                 }
             }
-            $this->showSuccess($success6);
+            $this->showSuccess($success6, $response);
         }
 
         if($this->doTest("delete playlist", $success)) {
             $response = $this->client->delete($list);
             $success = $response->getStatusCode() == 204;
-            $this->showSuccess($success);
+            $this->showSuccess($success, $response);
         }
 
         if($this->doTest("purge playlists", $success)) {
@@ -386,7 +392,7 @@ class Validate implements IController {
                 $pubkey = basename($label);
             }
 
-            $this->showSuccess($success);
+            $this->showSuccess($success, $response);
         }
 
         if($this->doTest("create album", $success)) {
@@ -429,7 +435,7 @@ class Validate implements IController {
                 $tag = basename($album);
             }
 
-            $this->showSuccess($success2);
+            $this->showSuccess($success2, $response);
         }
 
         if($this->doTest("validate create", $success2)) {
@@ -454,7 +460,7 @@ class Validate implements IController {
             ]);
 
             $success3 = $response->getStatusCode() == 204;
-            $this->showSuccess($success3);
+            $this->showSuccess($success3, $response);
         }
 
         if($this->doTest("edit label", $success)) {
@@ -471,7 +477,7 @@ class Validate implements IController {
             ]);
 
             $success4 = $response->getStatusCode() == 204;
-            $this->showSuccess($success4);
+            $this->showSuccess($success4, $response);
         }
 
         if($this->doTest("validate edit", $success3 && $success4)) {
@@ -482,7 +488,7 @@ class Validate implements IController {
         if($this->doTest("enqueue album", $success2)) {
             $response = $this->client->post($album . "/printq");
             $success12 = $response->getStatusCode() == 204;
-            $this->showSuccess($success12);
+            $this->showSuccess($success12, $response);
         }
 
         if($this->doTest("create review", $success2)) {
@@ -511,7 +517,7 @@ class Validate implements IController {
             $success9 = $response->getStatusCode() == 201;
             if($success9)
                 $review = $response->getHeader('Location')[0];
-            $this->showSuccess($success9);
+            $this->showSuccess($success9, $response);
         }
 
         if($this->doTest("validate review", $success9)) {
@@ -522,19 +528,19 @@ class Validate implements IController {
         if($this->doTest("delete review", $success9)) {
             $response = $this->client->delete($review);
             $success11 = $response->getStatusCode() == 204;
-            $this->showSuccess($success11);
+            $this->showSuccess($success11, $response);
         }
 
         if($this->doTest("delete album", $success2)) {
             $response = $this->client->delete($album);
             $success5 = $response->getStatusCode() == 204;
-            $this->showSuccess($success5);
+            $this->showSuccess($success5, $response);
         }
 
         if($this->doTest("delete label", $success)) {
             $response = $this->client->delete($label);
             $success6 = $response->getStatusCode() == 204;
-            $this->showSuccess($success6);
+            $this->showSuccess($success6, $response);
         }
     }
 

--- a/docs/Albums.md
+++ b/docs/Albums.md
@@ -162,3 +162,20 @@ Delete the album with tag :id by sending a DELETE request to
 `api/v1/album/:id`.  Delete will fail if the album has reviews, or if
 it has ever been in the a-file or has charted.  X-APIKEY
 authentication required; you must belong to the 'm' group.
+
+## Print Queue
+
+Albums may be enqueued for printing via the album's 'printq'
+pseudo-relation.  Issue requests as follows:
+
+* `GET api/v1/album/printq` - retrieve collection of albums in the user's print queue
+* `POST api/v1/album/:id/printq` - add album with tag :id to the print queue
+* `DELETE api/v1/album/:id/printq` - remove album with tag :id from the print queue
+
+All requests require X-APIKEY authentication, and you must belong to
+the 'm' group.
+
+Upon success, POST and DELETE return an HTTP `204 No Content` response.
+
+The POST request will fail if the album is already in the user's
+queue.

--- a/docs/Albums.md
+++ b/docs/Albums.md
@@ -165,12 +165,17 @@ authentication required; you must belong to the 'm' group.
 
 ## Print Queue
 
-Albums may be enqueued for printing via the album's 'printq'
-pseudo-relation.  Issue requests as follows:
+The album printer queue can be accessed and managed via the 'printq'
+pseudo-relation.  Requests are as follows:
 
-* `GET api/v1/album/printq` - retrieve collection of albums in the user's print queue
-* `POST api/v1/album/:id/printq` - add album with tag :id to the print queue
-* `DELETE api/v1/album/:id/printq` - remove album with tag :id from the print queue
+* `GET api/v1/album/printq` - retrieves collection of albums in the user's print queue
+* `POST api/v1/album/:id/printq` - adds album with tag :id to the print queue
+* `DELETE api/v1/album/:id/printq` - removes album with tag :id from the print queue
+
+If you wish, you may also use the endpoint
+`api/v1/album/:id/relationships/printq` for the POST and DELETE
+methods.  The request and response semantics, as well as the server
+action are the same.
 
 All requests require X-APIKEY authentication, and you must belong to
 the 'm' group.


### PR DESCRIPTION
This PR adds print queue functionality to the api/v1/album API.

Supported requests are as follows:

* `GET api/v1/album/printq` - retrieve collection of albums in the user's print queue
* `POST api/v1/album/:id/printq` - add album with tag :id to the print queue
* `DELETE api/v1/album/:id/printq` - remove album with tag :id from the print queue

All requests require `X-APIKEY` authentication, and you must belong to the 'm' group.

Upon success, `POST` and `DELETE` return an HTTP `204 No Content` response.

The `POST` request will fail if the album is already in the user's queue.