### PR TITLE
Revise artwork expiration semantics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: bionic
+
 php:
   - 7.4
   - 8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-dist: focal
-
 php:
   - 7.4
   - 8.0
@@ -15,13 +13,13 @@ before_install:
 before_script:
   # Install Apache
   - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fcgid
+  - sudo apt-get install apache2 libapache2-mod-fastcgi
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fcgid alias
+  - sudo a2enmod rewrite actions fastcgi alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
-  - sudo chown -R travis:travis /var/lib/apache2/fcgid
+  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # Fixup rewrites for php-fpm
   - cat build/php-fpm-redirect >> api/.htaccess

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,22 @@ php:
 services:
   - mysql
 
+addons:
+  apt:
+    packages:
+    - apache2
+    - libapache2-mod-fastcgi
+
 before_install:
   - mysql -e 'CREATE DATABASE zookeeper'
 
 before_script:
   # Install Apache
   - sudo apt-get update
-  - sudo apt-get install apache2
+  # sudo apt-get install apache2
   # Install mod_fastcgi which is no longer available in Ubuntu repositories
-  - wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
-  - sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  # wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  # sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - sudo a2enmod rewrite actions fastcgi alias

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: bionic
+
 php:
   - 7.4
   - 8.0
@@ -13,13 +15,13 @@ before_install:
 before_script:
   # Install Apache
   - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fastcgi
+  - sudo apt-get install apache2 libapache2-mod-fcgid
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fastcgi alias
+  - sudo a2enmod rewrite actions fcgid alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
-  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
+  - sudo chown -R travis:travis /var/lib/apache2/fcgid
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # Fixup rewrites for php-fpm
   - cat build/php-fpm-redirect >> api/.htaccess

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ before_script:
   - sudo apt-get update
   - sudo apt-get install apache2
   # Install mod_fastcgi which is no longer available in Ubuntu repositories
-  # wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
-  # sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  - wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  - sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions proxy_fcgi alias
+  - sudo a2enmod rewrite actions fastcgi alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
-  # sudo chown -R travis:travis /var/lib/apache2/fcgid
+  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # Fixup rewrites for php-fpm
   - cat build/php-fpm-redirect >> api/.htaccess

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: bionic
+dist: xenial
 
 php:
   - 7.4
@@ -14,9 +14,9 @@ before_install:
 
 before_script:
   # Install Apache
-  # sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu xenial main universe multiverse restricted'
+  - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu xenial main universe multiverse restricted'
   - sudo apt-get update
-  - sudo apt-get install apache2 libapache-mod-fastcgi
+  - sudo apt-get install apache2 libapache2-mod-fastcgi
   # Install mod_fastcgi which is no longer available in Ubuntu repositories
   # wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
   # sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
   # Install Apache
   - sudo apt-get update
   - sudo apt-get install apache2 libapache2-mod-fastcgi
+  - sudo apt-get -y install libargon2-0
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - sudo a2enmod rewrite actions fastcgi alias

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ before_install:
 
 before_script:
   # Install Apache
-  - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu bionic main universe multiverse restricted'
+  # sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu xenial main universe multiverse restricted'
   - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fastcgi
+  - sudo apt-get install apache2 libapache-mod-fastcgi
   # Install mod_fastcgi which is no longer available in Ubuntu repositories
   # wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
   # sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - sudo a2enmod rewrite actions fcgid alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
-  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
+  - sudo chown -R travis:travis /var/lib/apache2/fcgid
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # Fixup rewrites for php-fpm
   - cat build/php-fpm-redirect >> api/.htaccess

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 before_script:
   # Install Apache
   - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fastcgi
+  - sudo apt-get install apache2 libapache2-mod-fcgid
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - sudo a2enmod rewrite actions fastcgi alias

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-dist: bionic
-
 php:
   - 7.4
   - 8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - sudo apt-get install apache2 libapache2-mod-fcgid
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fastcgi alias
+  - sudo a2enmod rewrite actions fcgid alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
   - sudo chown -R travis:travis /var/lib/apache2/fastcgi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: bionic
+
 php:
   - 7.4
   - 8.0
@@ -13,7 +15,10 @@ before_install:
 before_script:
   # Install Apache
   - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fastcgi
+  - sudo apt-get install apache2
+  # Install mod_fastcgi which is no longer available in Ubuntu repositories
+  - wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  - sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - sudo a2enmod rewrite actions fastcgi alias

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,16 @@ before_install:
 before_script:
   # Install Apache
   - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fcgid
+  - sudo apt-get install apache2
   # Install mod_fastcgi which is no longer available in Ubuntu repositories
-  # wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fcgid/libapache2-mod-fcgid_2.4.7~0910052141-1.2_amd64.deb
-  # sudo dpkg -i libapache2-mod-fcgid_2.4.7~0910052141-1.2_amd64.deb
+  - wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  - sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fcgid alias
+  - sudo a2enmod rewrite actions fastcgi alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
-  - sudo chown -R travis:travis /var/lib/apache2/fcgid
+  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # Fixup rewrites for php-fpm
   - cat build/php-fpm-redirect >> api/.htaccess

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: php
 
-dist: bionic
-
 php:
-  - 7.4
+  - 7.4.22
   - 8.0
 
 services:
@@ -15,10 +13,7 @@ before_install:
 before_script:
   # Install Apache
   - sudo apt-get update
-  - sudo apt-get install apache2
-  # Install mod_fastcgi which is no longer available in Ubuntu repositories
-  - wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
-  - sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  - sudo apt-get install apache2 libapache2-mod-fastcgi
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - sudo a2enmod rewrite actions fastcgi alias

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_script:
   # Install Apache
   - sudo apt-get update
   - sudo apt-get install apache2 libapache2-mod-fastcgi
-  - sudo apt-get -y install libargon2-0
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
   - sudo a2enmod rewrite actions fastcgi alias

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: xenial
+dist: bionic
 
 php:
   - 7.4
@@ -14,18 +14,17 @@ before_install:
 
 before_script:
   # Install Apache
-  - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu xenial main universe multiverse restricted'
   - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fastcgi
+  - sudo apt-get install apache2 libapache2-mod-fcgid
   # Install mod_fastcgi which is no longer available in Ubuntu repositories
-  # wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
-  # sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  # wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fcgid/libapache2-mod-fcgid_2.4.7~0910052141-1.2_amd64.deb
+  # sudo dpkg -i libapache2-mod-fcgid_2.4.7~0910052141-1.2_amd64.deb
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fastcgi alias
+  - sudo a2enmod rewrite actions fcgid alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
-  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
+  - sudo chown -R travis:travis /var/lib/apache2/fcgid
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # Fixup rewrites for php-fpm
   - cat build/php-fpm-redirect >> api/.htaccess

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,14 @@ php:
 services:
   - mysql
 
-addons:
-  apt:
-    packages:
-    - apache2
-    - libapache2-mod-fastcgi
-
 before_install:
   - mysql -e 'CREATE DATABASE zookeeper'
 
 before_script:
   # Install Apache
+  - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu bionic main universe multiverse restricted'
   - sudo apt-get update
-  # sudo apt-get install apache2
+  - sudo apt-get install apache2 libapache2-mod-fastcgi
   # Install mod_fastcgi which is no longer available in Ubuntu repositories
   # wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
   # sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: php
 
+dist: focal
+
 php:
-  - 7.2.15
+  - 7.4
   - 8.0
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-dist: bionic
-
 php:
   - 7.4
   - 8.0
@@ -15,13 +13,13 @@ before_install:
 before_script:
   # Install Apache
   - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fcgid
+  - sudo apt-get install apache2 libapache2-mod-fastcgi
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fcgid alias
+  - sudo a2enmod rewrite actions fastcgi alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
-  - sudo chown -R travis:travis /var/lib/apache2/fcgid
+  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # Fixup rewrites for php-fpm
   - cat build/php-fpm-redirect >> api/.htaccess

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ before_script:
   - sudo apt-get update
   - sudo apt-get install apache2
   # Install mod_fastcgi which is no longer available in Ubuntu repositories
-  - wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
-  - sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  # wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  # sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fastcgi alias
+  - sudo a2enmod rewrite actions proxy_fcgi alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
-  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
+  # sudo chown -R travis:travis /var/lib/apache2/fcgid
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # Fixup rewrites for php-fpm
   - cat build/php-fpm-redirect >> api/.htaccess

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,13 @@ before_install:
 before_script:
   # Install Apache
   - sudo apt-get update
-  - sudo apt-get install apache2
-  # Install mod_fastcgi which is no longer available in Ubuntu repositories
-  - wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
-  - sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  - sudo apt-get install apache2 libapache2-mod-fcgid
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fastcgi alias
+  - sudo a2enmod rewrite actions fcgid alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
-  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
+  - sudo chown -R travis:travis /var/lib/apache2/fcgid
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # Fixup rewrites for php-fpm
   - cat build/php-fpm-redirect >> api/.htaccess

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.4
+  - 7.2.15
   - 8.0
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,16 @@ before_install:
 before_script:
   # Install Apache
   - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fcgid
+  - sudo apt-get install apache2
+  # Install mod_fastcgi which is no longer available in Ubuntu repositories
+  - wget http://mirrors.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
+  - sudo dpkg -i libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
   # Enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fcgid alias
+  - sudo a2enmod rewrite actions fastcgi alias
   - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
-  - sudo chown -R travis:travis /var/lib/apache2/fcgid
+  - sudo chown -R travis:travis /var/lib/apache2/fastcgi
   - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
   # Fixup rewrites for php-fpm
   - cat build/php-fpm-redirect >> api/.htaccess

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.2.15
+  - 7.4
   - 8.0
 
 services:

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -7,20 +7,11 @@
     Options FollowSymLinks MultiViews ExecCGI
     AllowOverride All
     Require all granted
+    <IfModule mod_fcgid.c>
+      AddHandler fcgid-script .php
+      FCGIWrapper /usr/lib/cgi-bin/php5-fcgi .php
+    </IfModule>
   </Directory>
-
-  # Wire up Apache to use Travis CI's php-fpm.
-  <IfModule mod_fcgid.c>
-    AddHandler fcgid-script .php
-    AddType application/x-httpd-php .php
-    AddHandler application/x-httpd-php .php
-    Action php7-fcgi /php7-fcgi
-    Alias /php7-fcgi /usr/lib/cgi-bin/php7-fcgi
-
-    <Directory /usr/lib/cgi-bin>
-        Require all granted
-    </Directory>
-  </IfModule>
 
   # [...]
 </VirtualHost>

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -10,19 +10,16 @@
   </Directory>
 
   # Wire up Apache to use Travis CI's php-fpm.
-  <FilesMatch "\.php$">
-    SetHandler "proxy:unix:///var/run/php/php7.4-fpm.sites.mydomain.sock|fcgi://sites/"
-  </FilesMatch>
-#  <IfModule mod_fastcgi.c>
-#    AddHandler php5-fcgi .php
-#    Action php5-fcgi /php5-fcgi
-#    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
-#    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
-#
-#    <Directory /usr/lib/cgi-bin>
-#        Require all granted
-#    </Directory>
-#  </IfModule>
+  <IfModule mod_fastcgi.c>
+    AddHandler php5-fcgi .php
+    Action php5-fcgi /php5-fcgi
+    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+
+    <Directory /usr/lib/cgi-bin>
+        Require all granted
+    </Directory>
+  </IfModule>
 
   # [...]
 </VirtualHost>

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -10,16 +10,9 @@
   </Directory>
 
   # Wire up Apache to use Travis CI's php-fpm.
-  <IfModule mod_fastcgi.c>
-    AddHandler php5-fcgi .php
-    Action php5-fcgi /php5-fcgi
-    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
-    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
-
-    <Directory /usr/lib/cgi-bin>
-        Require all granted
-    </Directory>
-  </IfModule>
+  <FilesMatch \.php$>
+    SetHandler "proxy:fcgi://127.0.0.1:9000"
+  </FilesMatch>
 
   # [...]
 </VirtualHost>

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -10,10 +10,15 @@
   </Directory>
 
   # Wire up Apache to use Travis CI's php-fpm.
-  <IfModule mod_fcgid.c>
-    AddType application/x-httpd-php .php
-    AddHandler application/x-httpd-php .php
-    ProxyPassMatch "^/(.*\.php(/.*)?)$" fcgi://127.0.0.1:9000
+  <IfModule mod_fastcgi.c>
+    AddHandler php5-fcgi .php
+    Action php5-fcgi /php5-fcgi
+    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+
+    <Directory /usr/lib/cgi-bin>
+        Require all granted
+    </Directory>
   </IfModule>
 
   # [...]

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -10,9 +10,16 @@
   </Directory>
 
   # Wire up Apache to use Travis CI's php-fpm.
-  <FilesMatch "\.php$">
-    SetHandler "proxy:unix:///var/run/php/php7.2-fpm.sites.mydomain.sock|fcgi://127.0.0.1:9000/"
-  </FilesMatch>
+  <IfModule mod_fastcgi.c>
+    AddHandler php5-fcgi .php
+    Action php5-fcgi /php5-fcgi
+    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+
+    <Directory /usr/lib/cgi-bin>
+        Require all granted
+    </Directory>
+  </IfModule>
 
   # [...]
 </VirtualHost>

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -10,16 +10,9 @@
   </Directory>
 
   # Wire up Apache to use Travis CI's php-fpm.
-  <IfModule mod_fastcgi.c>
-    AddHandler php5-fcgi .php
-    Action php5-fcgi /php5-fcgi
-    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
-    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
-
-    <Directory /usr/lib/cgi-bin>
-        Require all granted
-    </Directory>
-  </IfModule>
+  <FilesMatch "\.php$">
+    SetHandler "proxy:unix:///var/run/php/php7.2-fpm.sites.mydomain.sock|fcgi://127.0.0.1:9000/"
+  </FilesMatch>
 
   # [...]
 </VirtualHost>

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -10,16 +10,19 @@
   </Directory>
 
   # Wire up Apache to use Travis CI's php-fpm.
-  <IfModule mod_fastcgi.c>
-    AddHandler php5-fcgi .php
-    Action php5-fcgi /php5-fcgi
-    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
-    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
-
-    <Directory /usr/lib/cgi-bin>
-        Require all granted
-    </Directory>
-  </IfModule>
+  <FilesMatch "\.php$">
+    SetHandler "proxy:unix:///var/run/php/php7.4-fpm.sites.mydomain.sock|fcgi://sites/"
+  </FilesMatch>
+#  <IfModule mod_fastcgi.c>
+#    AddHandler php5-fcgi .php
+#    Action php5-fcgi /php5-fcgi
+#    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+#    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+#
+#    <Directory /usr/lib/cgi-bin>
+#        Require all granted
+#    </Directory>
+#  </IfModule>
 
   # [...]
 </VirtualHost>

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -7,11 +7,19 @@
     Options FollowSymLinks MultiViews ExecCGI
     AllowOverride All
     Require all granted
-    <IfModule mod_fcgid.c>
-      AddHandler fcgid-script .php
-      FCGIWrapper /usr/lib/cgi-bin/php5-fcgi .php
-    </IfModule>
   </Directory>
+
+  # Wire up Apache to use Travis CI's php-fpm.
+  <IfModule mod_fastcgi.c>
+    AddHandler php5-fcgi .php
+    Action php5-fcgi /php5-fcgi
+    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+
+    <Directory /usr/lib/cgi-bin>
+        Require all granted
+    </Directory>
+  </IfModule>
 
   # [...]
 </VirtualHost>

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -10,9 +10,16 @@
   </Directory>
 
   # Wire up Apache to use Travis CI's php-fpm.
-  <FilesMatch \.php$>
-    SetHandler "proxy:fcgi://127.0.0.1:9000"
-  </FilesMatch>
+  <IfModule mod_fcgid.c>
+    AddHandler php5-fcgi .php
+    Action php5-fcgi /php5-fcgi
+    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+
+    <Directory /usr/lib/cgi-bin>
+        Require all granted
+    </Directory>
+  </IfModule>
 
   # [...]
 </VirtualHost>

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -11,16 +11,9 @@
 
   # Wire up Apache to use Travis CI's php-fpm.
   <IfModule mod_fcgid.c>
-    Options +ExecCGI
-    FcgidConnectTimeout 20
     AddType application/x-httpd-php .php
     AddHandler application/x-httpd-php .php
-    Alias /php7-fcgi /usr/lib/cgi-bin/php7-fcgi
     ProxyPassMatch "^/(.*\.php(/.*)?)$" fcgi://127.0.0.1:9000
-
-    <Directory /usr/lib/cgi-bin>
-        Require all granted
-    </Directory>
   </IfModule>
 
   # [...]

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -11,10 +11,11 @@
 
   # Wire up Apache to use Travis CI's php-fpm.
   <IfModule mod_fcgid.c>
-    AddHandler php5-fcgi .php
-    Action php5-fcgi /php5-fcgi
-    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
-    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+    AddHandler fcgid-script .php
+    AddType application/x-httpd-php .php
+    AddHandler application/x-httpd-php .php
+    Action php7-fcgi /php7-fcgi
+    Alias /php7-fcgi /usr/lib/cgi-bin/php7-fcgi
 
     <Directory /usr/lib/cgi-bin>
         Require all granted

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -10,11 +10,13 @@
   </Directory>
 
   # Wire up Apache to use Travis CI's php-fpm.
-  <IfModule mod_fastcgi.c>
-    AddHandler php5-fcgi .php
-    Action php5-fcgi /php5-fcgi
-    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
-    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+  <IfModule mod_fcgid.c>
+    Options +ExecCGI
+    FcgidConnectTimeout 20
+    AddType application/x-httpd-php .php
+    AddHandler application/x-httpd-php .php
+    Alias /php7-fcgi /usr/lib/cgi-bin/php7-fcgi
+    ProxyPassMatch "^/(.*\.php(/.*)?)$" fcgi://127.0.0.1:9000
 
     <Directory /usr/lib/cgi-bin>
         Require all granted

--- a/controllers/PushServer.php
+++ b/controllers/PushServer.php
@@ -354,7 +354,8 @@ class NowAiringServer implements MessageComponentInterface {
         }
 
         $queued = $this->imageQ->count() - $start;
-        echo "loadImages($playlist, $track): $queued queued\n";
+        if($queued)
+            echo "loadImages($playlist, $track): $queued queued\n";
 
         if(!$start && $queued) {
             $this->loop->futureTick(function() {

--- a/controllers/PushServer.php
+++ b/controllers/PushServer.php
@@ -238,7 +238,7 @@ class NowAiringServer implements MessageComponentInterface {
 
                 if($entry['track_tag']) {
                     // is the album already known to us?
-                    $image = $imageApi->getAlbumArt($entry['track_tag']);
+                    $image = $imageApi->getAlbumArt($entry['track_tag'], true);
                     if($image) {
                         // if yes, reuse it...
                         $imageUuid = $image['image_uuid'];
@@ -255,7 +255,7 @@ class NowAiringServer implements MessageComponentInterface {
                 if(!isset($imageUuid) &&
                         strlen(trim($entry['track_artist']))) {
                     // is the artist already known to us?
-                    $image = $imageApi->getArtistArt($entry['track_artist']);
+                    $image = $imageApi->getArtistArt($entry['track_artist'], true);
                     if($image) {
                         // if yes, reuse it...
                         $imageUuid = $image['image_uuid'];
@@ -322,8 +322,8 @@ class NowAiringServer implements MessageComponentInterface {
         $entry->setArtist(PlaylistEntry::swapNames($entry->getArtist()));
 
         if($entry->getTag() &&
-                $imageApi->getAlbumArt($entry->getTag()) ||
-                $imageApi->getArtistArt($entry->getArtist())) {
+                $imageApi->getAlbumArt($entry->getTag(), true) ||
+                $imageApi->getArtistArt($entry->getArtist(), true)) {
             // the album or artist is already known to us
             return;
         }

--- a/controllers/RunDaily.php
+++ b/controllers/RunDaily.php
@@ -114,7 +114,7 @@ class RunDaily implements IController {
 
     private function purgeArtworkCache() {
         $ok = Engine::api(IArtwork::class)->expireEmpty();
-        echo "Purging artwork cache: ".($ok?"OK":"FAILED!")."\n";
+        echo "Purging artwork cache: ".($ok !== false?"OK ($ok expired)":"FAILED!")."\n";
     }
 
     private static function weeklyChartDate($date) {

--- a/engine/IArtwork.php
+++ b/engine/IArtwork.php
@@ -28,8 +28,8 @@ namespace ZK\Engine;
  * Artwork operations
  */
 interface IArtwork {
-    function getAlbumArt($tag);
-    function getArtistArt($artist);
+    function getAlbumArt($tag, $newRef = false);
+    function getArtistArt($artist, $newRef = false);
     function insertAlbumArt($tag, $imageUrl, $infoUrl);
     function insertArtistArt($artist, $imageUrl, $infoUrl);
     function getCachePath($key);

--- a/engine/impl/Artwork.php
+++ b/engine/impl/Artwork.php
@@ -87,24 +87,38 @@ class ArtworkImpl extends DBO implements IArtwork {
         return $file;
     }
 
-    public function getAlbumArt($tag) {
+    public function getAlbumArt($tag, $newRef = false) {
         $query = "SELECT artwork image_id, image_uuid, info_url FROM albummap a " .
             "LEFT JOIN artwork i ON a.artwork = i.id WHERE tag = ?";
         $stmt = $this->prepare($query);
         $stmt->bindValue(1, $tag);
-        return $stmt->executeAndFetch();
+        $result = $stmt->executeAndFetch();
+        if($result && $newRef) {
+            $query = "UPDATE albummap SET cached = NOW() WHERE tag = ?";
+            $stmt = $this->prepare($query);
+            $stmt->bindValue(1, $tag);
+            $stmt->execute();
+        }
+        return $result;
     }
 
-    public function getArtistArt($artist) {
+    public function getArtistArt($artist, $newRef = false) {
         $query = "SELECT artwork image_id, image_uuid, info_url FROM artistmap a " .
             "LEFT JOIN artwork i ON a.artwork = i.id WHERE name = ?";
         $stmt = $this->prepare($query);
         $stmt->bindValue(1, $artist);
-        return $stmt->executeAndFetch();
+        $result = $stmt->executeAndFetch();
+        if($result && $newRef) {
+            $query = "UPDATE artistmap SET cached = NOW() WHERE name = ?";
+            $stmt = $this->prepare($query);
+            $stmt->bindValue(1, $artist);
+            $stmt->execute();
+        }
+        return $result;
     }
 
     public function insertAlbumArt($tag, $imageUrl, $infoUrl) {
-        $image = $this->getAlbumArt($tag);
+        $image = $this->getAlbumArt($tag, true);
         if($image)
             $uuid = $image['image_uuid'];
         else {
@@ -135,7 +149,7 @@ class ArtworkImpl extends DBO implements IArtwork {
     }
 
     public function insertArtistArt($artist, $imageUrl, $infoUrl) {
-        $image = $this->getArtistArt($artist);
+        $image = $this->getArtistArt($artist, true);
         if($image)
             $uuid = $image['image_uuid'];
         else {


### PR DESCRIPTION
Successive playlist references to an existing artwork cache entry do not update its cached timestamp.  As a result, it is possible that entries could be expired which still have references within the lookback window.

This PR changes the cache semantics to update the cached timestamp whenever a new reference is made to an existing entry.  In this way, 'cached' will represent the most recent (newest) reference, thus ensuring that entries are not prematurely expired.


