### PR TITLE
Workaround for Travis CI issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.4
+  - 7.4.22
   - 8.0
 
 services:


### PR DESCRIPTION
Travis CI began failing PHP 7.4 builds to an issue on the Travis platform.

This PR works around the issue by hardcoding a specific 7.4 release.

See:
    https://travis-ci.community/t/php-7-4-is-broken-error-while-loading-shared-libraries-libargon2-so-1/12804

The change can be reverted once the Travis platform issue has been resolved.
