### PR TITLE
Revise artwork expiration semantics

### DIFF
--- a/controllers/PushServer.php
+++ b/controllers/PushServer.php
@@ -238,7 +238,7 @@ class NowAiringServer implements MessageComponentInterface {
 
                 if($entry['track_tag']) {
                     // is the album already known to us?
-                    $image = $imageApi->getAlbumArt($entry['track_tag']);
+                    $image = $imageApi->getAlbumArt($entry['track_tag'], true);
                     if($image) {
                         // if yes, reuse it...
                         $imageUuid = $image['image_uuid'];
@@ -255,7 +255,7 @@ class NowAiringServer implements MessageComponentInterface {
                 if(!isset($imageUuid) &&
                         strlen(trim($entry['track_artist']))) {
                     // is the artist already known to us?
-                    $image = $imageApi->getArtistArt($entry['track_artist']);
+                    $image = $imageApi->getArtistArt($entry['track_artist'], true);
                     if($image) {
                         // if yes, reuse it...
                         $imageUuid = $image['image_uuid'];
@@ -322,8 +322,8 @@ class NowAiringServer implements MessageComponentInterface {
         $entry->setArtist(PlaylistEntry::swapNames($entry->getArtist()));
 
         if($entry->getTag() &&
-                $imageApi->getAlbumArt($entry->getTag()) ||
-                $imageApi->getArtistArt($entry->getArtist())) {
+                $imageApi->getAlbumArt($entry->getTag(), true) ||
+                $imageApi->getArtistArt($entry->getArtist(), true)) {
             // the album or artist is already known to us
             return;
         }

--- a/controllers/RunDaily.php
+++ b/controllers/RunDaily.php
@@ -113,8 +113,8 @@ class RunDaily implements IController {
     }
 
     private function purgeArtworkCache() {
-        $ok = Engine::api(IArtwork::class)->expireEmpty();
-        echo "Purging artwork cache: ".($ok?"OK":"FAILED!")."\n";
+        $count = Engine::api(IArtwork::class)->expireEmpty();
+        echo "Purging artwork cache: ".($count !== false?"OK ($count removed)":"FAILED!")."\n";
     }
 
     private static function weeklyChartDate($date) {

--- a/engine/IArtwork.php
+++ b/engine/IArtwork.php
@@ -28,8 +28,8 @@ namespace ZK\Engine;
  * Artwork operations
  */
 interface IArtwork {
-    function getAlbumArt($tag);
-    function getArtistArt($artist);
+    function getAlbumArt($tag, $newRef = false);
+    function getArtistArt($artist, $newRef = false);
     function insertAlbumArt($tag, $imageUrl, $infoUrl);
     function insertArtistArt($artist, $imageUrl, $infoUrl);
     function getCachePath($key);

--- a/engine/impl/Artwork.php
+++ b/engine/impl/Artwork.php
@@ -87,24 +87,38 @@ class ArtworkImpl extends DBO implements IArtwork {
         return $file;
     }
 
-    public function getAlbumArt($tag) {
+    public function getAlbumArt($tag, $newRef = false) {
         $query = "SELECT artwork image_id, image_uuid, info_url FROM albummap a " .
             "LEFT JOIN artwork i ON a.artwork = i.id WHERE tag = ?";
         $stmt = $this->prepare($query);
         $stmt->bindValue(1, $tag);
-        return $stmt->executeAndFetch();
+        $result = $stmt->executeAndFetch();
+        if($result && $newRef) {
+            $query = "UPDATE albummap SET cached = NOW() WHERE tag = ?";
+            $stmt = $this->prepare($query);
+            $stmt->bindValue(1, $tag);
+            $stmt->execute();
+        }
+        return $result;
     }
 
-    public function getArtistArt($artist) {
+    public function getArtistArt($artist, $newRef = false) {
         $query = "SELECT artwork image_id, image_uuid, info_url FROM artistmap a " .
             "LEFT JOIN artwork i ON a.artwork = i.id WHERE name = ?";
         $stmt = $this->prepare($query);
         $stmt->bindValue(1, $artist);
-        return $stmt->executeAndFetch();
+        $result = $stmt->executeAndFetch();
+        if($result && $newRef) {
+            $query = "UPDATE artistmap SET cached = NOW() WHERE name = ?";
+            $stmt = $this->prepare($query);
+            $stmt->bindValue(1, $artist);
+            $stmt->execute();
+        }
+        return $result;
     }
 
     public function insertAlbumArt($tag, $imageUrl, $infoUrl) {
-        $image = $this->getAlbumArt($tag);
+        $image = $this->getAlbumArt($tag, true);
         if($image)
             $uuid = $image['image_uuid'];
         else {
@@ -135,7 +149,7 @@ class ArtworkImpl extends DBO implements IArtwork {
     }
 
     public function insertArtistArt($artist, $imageUrl, $infoUrl) {
-        $image = $this->getArtistArt($artist);
+        $image = $this->getArtistArt($artist, true);
         if($image)
             $uuid = $image['image_uuid'];
         else {


### PR DESCRIPTION
Successive playlist references to an existing artwork cache entry do not update its cached timestamp.  As a result, it is possible that with current expiration semantics, entries could be expired which still have references within the lookback window.

This PR changes the cache semantics to update the cached timestamp whenever a new reference is made to an existing entry.  In this way, the timestamp will represent the most recent (newest) reference, thus ensuring that entries are not prematurely expired while there are still active references.