### PR TITLE
Enhance page title

### DIFF
--- a/ui/Charts.php
+++ b/ui/Charts.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2022 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -160,6 +160,8 @@ class Charts extends MenuItem {
             $displayDate = date("j F Y", mktime(0,0,0,$month,$day,$year));
             echo "<P CLASS=\"header\">$station chart for the week ending $displayDate</P>\n";
         }
+
+        $this->title = "Chart for $displayDate";
     
     // weekly = hip hop, reggae/world, jazz, heavy shit, dance, classical/exp
     //     no limits

--- a/ui/Charts.php
+++ b/ui/Charts.php
@@ -285,22 +285,26 @@ class Charts extends MenuItem {
             if($dend - $earliestYear < 10)
                 $name .= " (based on available data)";
             echo "<P CLASS=\"header\">$station Top 100 for the decennium $name</P>\n";
+            $this->title = "Chart for $name";
             $monthly = 0;
         } else if($cyear) {
             $startDate = $chartAPI->getMonthlyChartStart(1, $cyear);
             $endDate = $chartAPI->getMonthlyChartEnd(12, $cyear);
             echo "<P CLASS=\"header\">$station Top 100 for the year $cyear</P>\n";
+            $this->title = "Chart for $cyear";
             $monthly = 0;
         } else if($monthly) {
             $startDate = $chartAPI->getMonthlyChartStart($month, $year);
             $endDate = $chartAPI->getMonthlyChartEnd($month, $year);
             $displayDate = date("F Y", mktime(0,0,0,$month,1,$year));
             echo "<P CLASS=\"header\">$station chart for month of $displayDate</P>\n";
+            $this->title = "Chart for $displayDate";
         } else {
             $startDate = "";
             $endDate = "$year-$month-$day";
             $displayDate = date("j F Y", mktime(0,0,0,$month,$day,$year));
             echo "<P CLASS=\"header\">$station chart for the week ending $displayDate</P>\n";
+            $this->title = "Chart for $displayDate";
         }
     
     // weekly = hip hop, reggae/world, jazz, heavy shit, dance, classical/exp

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -185,7 +185,7 @@ class Editor extends MenuItem {
         for($i=0; $i<2; $i++) {
             if($i == 1) {
                 // Emit header
-                $title = $this->getTitle($_REQUEST["seq"]);
+                $title = $this->getPanelTitle($_REQUEST["seq"]);
                 echo "  <FORM ACTION=\"?\" METHOD=POST>\n";
                 echo "    <TABLE CELLPADDING=0 CELLSPACING=0 BORDER=0 WIDTH=\"100%\">\n      <TR><TH ALIGN=LEFT>$title</TH><TH ALIGN=RIGHT CLASS=\"error\">";
                 if(!$this->subaction) {
@@ -233,7 +233,7 @@ class Editor extends MenuItem {
         for($i=0; $i<2; $i++) {
             if($i == 1) {
                 // Emit header
-                $title = $this->getTitle($_REQUEST["seq"]);
+                $title = $this->getPanelTitle($_REQUEST["seq"]);
                 echo "  <FORM ACTION=\"?\" METHOD=POST>\n";
                 echo "    <TABLE CELLPADDING=0 CELLSPACING=0 BORDER=0 WIDTH=\"100%\">\n      <TR><TH ALIGN=LEFT>$title</TH></TR>\n      <TR><TD HEIGHT=130 VALIGN=MIDDLE>\n";
     
@@ -711,7 +711,7 @@ class Editor extends MenuItem {
          return $tracks;
     }
     
-    public function getTitle($seq) {
+    private function getPanelTitle($seq) {
         $albumLabel = htmlentities(stripslashes(($_REQUEST["coll"]?"":$_REQUEST["artist"] . " / ") . $_REQUEST["album"]));
         switch($seq) {
         case "search":

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -711,7 +711,7 @@ class Editor extends MenuItem {
          return $tracks;
     }
     
-    private function getTitle($seq) {
+    public function getTitle($seq) {
         $albumLabel = htmlentities(stripslashes(($_REQUEST["coll"]?"":$_REQUEST["artist"] . " / ") . $_REQUEST["album"]));
         switch($seq) {
         case "search":

--- a/ui/MenuItem.php
+++ b/ui/MenuItem.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2020 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2022 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -27,6 +27,17 @@ namespace ZK\UI;
 use ZK\Controllers\CommandTarget;
 
 abstract class MenuItem extends CommandTarget {
+    protected $title;
+
+    public function getTitle() { return $this->title; }
+
+    public function newEntity($entityClass) {
+        $obj = parent::newEntity($entityClass);
+        if($obj)
+            $obj->title = &$this->title;
+        return $obj;
+    }
+
     public function dispatchSubaction($action, $subaction, &$subactions, $extra=0) {
         // Emit the secondary navbar
         if($extra)

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2021 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2022 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -2004,6 +2004,8 @@ class Playlists extends MenuItem {
         $djId = $playlist['id'];
         $djName = $playlist['airname'];
         $showDateTime = self::makeShowDateAndTime($playlist);
+
+        $this->title = "$showName with $djName " . self::timestampToDate($playlist['showdate']);
 
         if(!$editMode && $this->session->isAuth("v"))
             $showDateTime .= "&nbsp;<A HREF='javascript:document.duplist.submit();' TITLE='Duplicate Playlist'>&#x1f4cb;</A><FORM NAME='duplist' ACTION='?' METHOD='POST'><INPUT TYPE='hidden' NAME='action' VALUE='editListDetails'><INPUT TYPE='hidden' NAME='duplicate' VALUE='1'><INPUT TYPE='hidden' NAME='playlist' VALUE='$playlistId'></FORM>";

--- a/ui/Search.php
+++ b/ui/Search.php
@@ -141,11 +141,15 @@ class Search extends MenuItem {
 
         $artist = strcmp(substr($albums[0]["artist"], 0, 8), "[coll]: ")?
                       $albums[0]["artist"]:"Various Artists";
+
+        $this->title = $artist . " / " . $albums[0]["album"];
         echo "<TABLE WIDTH=\"100%\">\n  <TR><TH ALIGN=LEFT COLSPAN=5 CLASS=\"secdiv\">" .
                   $this->HTMLify($artist, 20) . " / " .
                   $this->HTMLify($albums[0]["album"], 20);
-        if($isAuth)
+        if($isAuth) {
             echo "&nbsp;&nbsp;(Tag #".$albums[0]["tag"].")";
+            $this->title .= " (#" . $albums[0]["tag"] . ")";
+        }
         echo "</TH></TR>\n</TABLE>";
         $extraAttrs = $this->emitDiscogsHook($this->searchText);
         echo "<TABLE CLASS='album-info' $extraAttrs>\n";


### PR DESCRIPTION
This PR enhances the page title for albums, playlists, and charts.

The page title of album pages now includes the artist / album name (and tag number if logged in), playlists include the show name, DJ, and date, and charts include the chart date.

Closes #289