### PR TITLE
Add playlist rebroadcast flag

### DIFF
--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -112,7 +112,7 @@ class Playlists implements RequestHandlerInterface {
         $attrs->set("airname", $rec["airname"]);
 
         $origin = $rec["origin"] ?? null;
-        $attrs->set("rebroadcast", $origin || preg_match("/rebroadcast/i", $rec["description"]) ? true : false);
+        $attrs->set("rebroadcast", $origin || preg_match("/rebroadcast/i", $rec["description"]));
         if($origin) {
             if($flags & self::LINKS_ORIGIN) {
                 $row = Engine::api(IPlaylist::class)->getPlaylist($origin, 1);

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -407,7 +407,7 @@ class Playlists implements RequestHandlerInterface {
             $description .= $suffix;
 
             $name = $attrs->getOptional("name", $description);
-            $papi->updatePlaylist($playlist, $date, $time, mb_substr($name, 0, IPlaylist::MAX_DESCRIPTION_LENGTH), $aid ?? $list["airname"], true);
+            $papi->updatePlaylist($playlist, $date, $time, mb_substr($name, 0, IPlaylist::MAX_DESCRIPTION_LENGTH), $aid = $aid ?? $list["airname"], true);
         } else {
             // create a new playlist
             $name = $attrs->getRequired("name");

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -60,8 +60,6 @@ class Playlists implements RequestHandlerInterface {
     const LINKS_ORIGIN = 8;
     const LINKS_ALL = ~0;
 
-    private const DUPLICATE_SUFFIX = " (rebroadcast from %M j, Y%)";
-
     private static $paginateOps = [
         "date" => "paginate",
         "id" => "paginate",
@@ -114,7 +112,7 @@ class Playlists implements RequestHandlerInterface {
         $attrs->set("airname", $rec["airname"]);
 
         $origin = $rec["origin"] ?? null;
-        $attrs->set("rebroadcast", $origin || preg_match("/rebroadcast/i", $rec["description"]));
+        $attrs->set("rebroadcast", $origin || preg_match(IPlaylist::DUPLICATE_REGEX, $rec["description"]));
         if($origin) {
             if($flags & self::LINKS_ORIGIN) {
                 $row = Engine::api(IPlaylist::class)->getPlaylist($origin, 1);
@@ -400,7 +398,7 @@ class Playlists implements RequestHandlerInterface {
                     return \DateTime::createFromFormat(
                         IPlaylist::TIME_FORMAT,
                         $list["showdate"] . " 0000")->format($matches[1]);
-                }, self::DUPLICATE_SUFFIX);
+                }, IPlaylist::DUPLICATE_SUFFIX);
             $description = $list["description"];
             if(mb_strlen($description) + mb_strlen($suffix) > IPlaylist::MAX_DESCRIPTION_LENGTH)
                 $description = mb_substr($description, 0, IPlaylist::MAX_DESCRIPTION_LENGTH - mb_strlen($suffix) - 3) . "...";

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -112,7 +112,7 @@ class Playlists implements RequestHandlerInterface {
         $attrs->set("airname", $rec["airname"]);
 
         $origin = $rec["origin"];
-        $attrs->set("isRebroadcast", $origin ? true : false);
+        $attrs->set("rebroadcast", $origin ? true : false);
         if($origin) {
             if($flags & self::LINKS_ORIGIN) {
                 $row = Engine::api(IPlaylist::class)->getPlaylist($origin, 1);

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -111,7 +111,7 @@ class Playlists implements RequestHandlerInterface {
         $attrs->set("time", $rec["showtime"]);
         $attrs->set("airname", $rec["airname"]);
 
-        $origin = $rec["origin"];
+        $origin = $rec["origin"] ?? null;
         $attrs->set("rebroadcast", $origin ? true : false);
         if($origin) {
             if($flags & self::LINKS_ORIGIN) {

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -112,7 +112,7 @@ class Playlists implements RequestHandlerInterface {
         $attrs->set("airname", $rec["airname"]);
 
         $origin = $rec["origin"] ?? null;
-        $attrs->set("rebroadcast", $origin ? true : false);
+        $attrs->set("rebroadcast", $origin || preg_match("/rebroadcast/i", $rec["description"]) ? true : false);
         if($origin) {
             if($flags & self::LINKS_ORIGIN) {
                 $row = Engine::api(IPlaylist::class)->getPlaylist($origin, 1);

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -405,7 +405,7 @@ class Playlists implements RequestHandlerInterface {
             $description .= $suffix;
 
             $name = $attrs->getOptional("name", $description);
-            $papi->updatePlaylist($playlist, $date, $time, mb_substr($name, 0, IPlaylist::MAX_DESCRIPTION_LENGTH), $aid = $aid ?? $list["airname"], true);
+            $papi->updatePlaylist($playlist, $date, $time, mb_substr($name, 0, IPlaylist::MAX_DESCRIPTION_LENGTH), $aid ??= $list["airname"], true);
         } else {
             // create a new playlist
             $name = $attrs->getRequired("name");

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -442,7 +442,7 @@ class Playlists implements RequestHandlerInterface {
                     ["showdate" => $date, "showtime" => $time]))
                 PushServer::sendAsyncNotification();
 
-            if($events)
+            if($events || $dup)
                 PushServer::lazyLoadImages($playlist);
 
             return new CreatedResponse(Engine::getBaseUrl()."playlist/$playlist");

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -309,7 +309,7 @@ class Playlists implements RequestHandlerInterface {
             if($origin) {
                 $row = $api->getPlaylist($origin, 1);
                 $row['list'] = $origin;
-                $rel = self::fromRecord($row, self::LINKS_NONE);
+                $rel = self::fromRecord($row, self::LINKS_ALL);
                 $relations->set($rel);
             }
             break;

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -333,7 +333,7 @@ class Validate implements IController {
             $page = $response->getBody()->getContents();
             $json = json_decode($page);
             $successd1 = $json->data->attributes->rebroadcast === true &&
-                preg_match('/rebroadcast/i', $json->data->attributes->name) &&
+                preg_match(IPlaylist::DUPLICATE_REGEX, $json->data->attributes->name) &&
                 sizeof($json->data->attributes->events) == 3 &&
                 $json->data->relationships->origin->data->id == $pid;
             $this->showSuccess($successd1, $response);

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -333,9 +333,10 @@ class Validate implements IController {
             $page = $response->getBody()->getContents();
             $json = json_decode($page);
             $successd1 = $json->data->attributes->rebroadcast === true &&
+                $json->data->relationships->origin->data->id == $pid &&
                 preg_match(IPlaylist::DUPLICATE_REGEX, $json->data->attributes->name) &&
-                sizeof($json->data->attributes->events) == 3 &&
-                $json->data->relationships->origin->data->id == $pid;
+                $json->data->attributes->airname == $airname &&
+                sizeof($json->data->attributes->events) == 3;
             $this->showSuccess($successd1, $response);
         }
 

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -297,6 +297,37 @@ class Validate implements IController {
             $this->showSuccess($success5, $response);
         }
 
+        if($this->doTest("duplicate playlist", $success4)) {
+            $response = $this->client->post('api/v1/playlist', [
+                RequestOptions::JSON => [
+                    'data' => [
+                        'type' => 'show',
+                        'attributes' => [
+                            'rebroadcast' => true,
+                            'date' => '2020-06-01',
+                            'time' => '1800-2000',
+                        ],
+                        'relationships' => [
+                            'origin' => [
+                                'data' => [
+                                    'type' => 'show',
+                                    'id' => $pid
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]);
+
+            $successd = $response->getStatusCode() == 201;
+            if($successd) {
+                $dlist = $response->getHeader('Location')[0];
+                $dpid = basename($dlist);
+            }
+
+            $this->showSuccess($successd, $response);
+        }
+
         if($this->doTest("validate search", $success3)) {
             $response = $this->client->get('api/v1/search', [
                 RequestOptions::QUERY => [
@@ -323,6 +354,12 @@ class Validate implements IController {
                 }
             }
             $this->showSuccess($success6, $response);
+        }
+
+        if($this->doTest("delete duplicate", $successd)) {
+            $response = $this->client->delete($dlist);
+            $successd = $response->getStatusCode() == 204;
+            $this->showSuccess($successd, $response);
         }
 
         if($this->doTest("delete playlist", $success)) {

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -335,7 +335,7 @@ class Validate implements IController {
             $successd1 = $json->data->attributes->rebroadcast === true &&
                 preg_match('/rebroadcast/i', $json->data->attributes->name) &&
                 sizeof($json->data->attributes->events) == 3 &&
-                $json->data->relationships->origin->data->id = $pid;
+                $json->data->relationships->origin->data->id == $pid;
             $this->showSuccess($successd1, $response);
         }
 

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -334,6 +334,7 @@ class Validate implements IController {
             $json = json_decode($page);
             $successd1 = $json->data->attributes->rebroadcast == true &&
                 preg_match('/rebroadcast/i', $json->data->attributes->name) &&
+                sizeof($json->data->attributes->events) == 3 &&
                 $json->data->relationships->origin->data->id = $pid;
             $this->showSuccess($successd1, $response);
         }

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -332,7 +332,7 @@ class Validate implements IController {
             $response = $this->client->get($dlist);
             $page = $response->getBody()->getContents();
             $json = json_decode($page);
-            $successd1 = $json->data->attributes->rebroadcast == true &&
+            $successd1 = $json->data->attributes->rebroadcast === true &&
                 preg_match('/rebroadcast/i', $json->data->attributes->name) &&
                 sizeof($json->data->attributes->events) == 3 &&
                 $json->data->relationships->origin->data->id = $pid;

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -181,7 +181,7 @@ class Validate implements IController {
 
     public function validatePlaylists() {
         $success = false;
-        if($this->doTest("create playlist", true)) {
+        if($this->doTest("create playlist", isset($this->apiKeyId))) {
             $airname = self::TEST_NAME." ".$this->testUser; // make unique
             $response = $this->client->post('api/v1/playlist', [
                 RequestOptions::JSON => [

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -328,6 +328,16 @@ class Validate implements IController {
             $this->showSuccess($successd, $response);
         }
 
+        if($this->doTest("validate duplicate", $successd)) {
+            $response = $this->client->get($dlist);
+            $page = $response->getBody()->getContents();
+            $json = json_decode($page);
+            $successd1 = $json->data->attributes->rebroadcast == true &&
+                preg_match('/rebroadcast/i', $json->data->attributes->name) &&
+                $json->data->relationships->origin->data->id = $pid;
+            $this->showSuccess($successd1, $response);
+        }
+
         if($this->doTest("validate search", $success3)) {
             $response = $this->client->get('api/v1/search', [
                 RequestOptions::QUERY => [

--- a/db/convert_v2_11_2_to_v2_11_3.sql
+++ b/db/convert_v2_11_2_to_v2_11_3.sql
@@ -46,6 +46,13 @@ DELETE FROM albummap, artwork USING albummap
 ALTER TABLE `artistmap` CHANGE `artwork` `image_id` int(11);
 ALTER TABLE `albummap` CHANGE `artwork` `image_id` int(11);
 
+CREATE TABLE `lists_rebroadcast` (
+  `id` int(11) NOT NULL,
+  `origin` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `origin` (`origin`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
+
 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT;
 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS;
 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION;

--- a/db/convert_v2_11_2_to_v2_11_3.sql
+++ b/db/convert_v2_11_2_to_v2_11_3.sql
@@ -46,12 +46,7 @@ DELETE FROM albummap, artwork USING albummap
 ALTER TABLE `artistmap` CHANGE `artwork` `image_id` int(11);
 ALTER TABLE `albummap` CHANGE `artwork` `image_id` int(11);
 
-CREATE TABLE `lists_rebroadcast` (
-  `id` int(11) NOT NULL,
-  `origin` int(11) NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `origin` (`origin`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `lists` ADD COLUMN `origin` int(11) DEFAULT NULL;
 
 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT;
 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS;

--- a/db/zkdbSchema.sql
+++ b/db/zkdbSchema.sql
@@ -234,6 +234,7 @@ CREATE TABLE IF NOT EXISTS `lists` (
   `showtime` varchar(20) DEFAULT NULL,
   `description` varchar(80) DEFAULT NULL,
   `airname` int(11) DEFAULT NULL,
+  `origin` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `dj` (`dj`),
   KEY `showdate` (`showdate`),
@@ -254,19 +255,6 @@ CREATE TABLE IF NOT EXISTS `lists_del` (
   PRIMARY KEY (`listid`),
   KEY `deleted` (`deleted`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
-
--- --------------------------------------------------------
-
---
--- Table structure for table `lists_rebroadcast`
---
-
-CREATE TABLE `lists_rebroadcast` (
-  `id` int(11) NOT NULL,
-  `origin` int(11) NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `origin` (`origin`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 

--- a/db/zkdbSchema.sql
+++ b/db/zkdbSchema.sql
@@ -258,6 +258,19 @@ CREATE TABLE IF NOT EXISTS `lists_del` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `lists_rebroadcast`
+--
+
+CREATE TABLE `lists_rebroadcast` (
+  `id` int(11) NOT NULL,
+  `origin` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `origin` (`origin`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `plays`
 --
 

--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -71,17 +71,20 @@ other users: You will own the list in these cases (i.e., can update or
 delete them), but they will display publicly under the other user's
 airname.
 
-### Duplicate
+### <a name="duplicate"></a>Duplicate
 
-You may duplicate an existing playlist.  Duplicate is identical to
-insert above, except that you must:
-* include an attribute `rebroadcast` with value `true`;
-* include a relationship `origin` whose data `id` specifies the
-identifier of the playlist you wish to duplicate.
+Duplicate is identical to Insert, except that in the request body,
+you must also:
+* include an attribute `rebroadcast` with value `true`; and
+* include a relationship `origin` to specify the id of the playlist
+you wish to duplicate.
+
+The date and time of rebroadcast must be specified in attributes `date`
+and `time`, respectively.  All other attributes are optional.
 
 Example:
 
-To duplicate playlist 12345 for rebroadcast on 2022-01-01 at 1800:
+To duplicate playlist 12345 for rebroadcast on 2022-01-01 from 1800-2000:
 
 ````
 POST /api/vi/playlist HTTP/1.1
@@ -108,12 +111,10 @@ Content-Type: application/vnd.api+json
 }
 ````
 
-In general, you may duplicate only your own playlists.  If you belong
+In general, you may only duplicate your own playlists.  If you belong
 to the 'v' group, you may also duplicate playlists of other users.
 You will own the list in these cases (i.e., can update or delete
 them), but they will display publicly under the other user's airname.
-
-
 
 ### Update
 

--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -71,6 +71,50 @@ other users: You will own the list in these cases (i.e., can update or
 delete them), but they will display publicly under the other user's
 airname.
 
+### Duplicate
+
+You may duplicate an existing playlist.  Duplicate is identical to
+insert above, except that you must:
+* include an attribute `rebroadcast` with value `true`;
+* include a relationship `origin` whose data `id` specifies the
+identifier of the playlist you wish to duplicate.
+
+Example:
+
+To duplicate playlist 12345 for rebroadcast on 2022-01-01 at 1800:
+
+````
+POST /api/vi/playlist HTTP/1.1
+X-APIKEY: eb5e0e0b42a84531af5f257ed61505050494788d
+Content-Type: application/vnd.api+json
+
+{
+  "data": {
+    "type": "show",
+    "attributes": {
+      "rebroadcast": true,
+      "date": "2022-01-01",
+      "time": "1800-2000"
+    }
+  },
+  "relationships": {
+    "origin": {
+      "data": {
+        "type": "show",
+        "id": "12345"
+      }
+    }
+  }
+}
+````
+
+In general, you may duplicate only your own playlists.  If you belong
+to the 'v' group, you may also duplicate playlists of other users.
+You will own the list in these cases (i.e., can update or delete
+them), but they will display publicly under the other user's airname.
+
+
+
 ### Update
 
 Update the playlist with id :id by issuing a PATCH request to

--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -76,11 +76,15 @@ airname.
 Duplicate is identical to Insert, except that in the request body,
 you must also:
 * include an attribute `rebroadcast` with value `true`; and
-* include a relationship `origin` to specify the id of the playlist
-you wish to duplicate.
+* include a relationship `origin` to specify the playlist you wish
+to duplicate.
 
 The date and time of rebroadcast must be specified in attributes `date`
 and `time`, respectively.  All other attributes are optional.
+
+The name of the duplicated playlist follows the same convention as
+playlists duplicated in the user interface.  If desired, an alternate
+name can be specified via the `name` attribute.
 
 Example:
 

--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -19,6 +19,7 @@ be found here.
 * date
 * time
 * airname
+* rebroadcast
 * events -- array of zero or more:
   * type (one of `break`, `comment`, `logEvent`, `spin`)
   * created
@@ -35,6 +36,7 @@ of the 'xa:relationships' attribute.)
 
 ### Relations
 
+* origin (to-one)
 * albums (to-many)
 * events (to-many)
 

--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -95,13 +95,13 @@ Content-Type: application/vnd.api+json
       "rebroadcast": true,
       "date": "2022-01-01",
       "time": "1800-2000"
-    }
-  },
-  "relationships": {
-    "origin": {
-      "data": {
-        "type": "show",
-        "id": "12345"
+    },
+    "relationships": {
+      "origin": {
+        "data": {
+          "type": "show",
+          "id": "12345"
+        }
       }
     }
   }

--- a/docs/Samples.md
+++ b/docs/Samples.md
@@ -159,6 +159,7 @@ The following are sample documents for each of the data types.
       "date": "2021-12-23",
       "time": "2100-2200",
       "airname": "DJ Away",
+      "rebroadcast": true,
       "events": [{
         "type": "comment",
         "comment": "Rebroadcast of an episode originally aired on May 20, 2021.",
@@ -284,6 +285,15 @@ The following are sample documents for each of the data types.
       }]
     },
     "relationships": {
+      "origin": {
+        "links": {
+          "related": "/api/v1/playlist/42667/origin"
+        },
+        "data": {
+          "type": "show",
+          "id": "41522"
+        }
+      },
       "albums": {
         "links": {
           "related": "/api/v1/playlist/42667/albums"

--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -28,6 +28,31 @@ namespace ZK\Engine;
  * Playlist operations
  */
 interface IPlaylist {
+    /**
+     * suffix appended to duplicate playlist name
+     *
+     * date format specifiers may be included inside %...%
+     */
+    const DUPLICATE_SUFFIX = " (rebroadcast from %M j, Y%)";
+
+    /**
+     * regular expression to match the name of a duplicate playlist
+     *
+     * should match (some substring of) DUPLICATE_SUFFIX
+     */
+    const DUPLICATE_REGEX = "/\Wrebroadcast\W/i";
+
+    /**
+     * comment inserted at beginning of duplicate playlist
+     *
+     * date format specifiers may be included inside %...%
+     */
+    const DUPLICATE_COMMENT =
+        "Rebroadcast of an episode originally aired on %F j, Y%.";
+
+    /**
+     * internal datetime formats (do not change)
+     */
     const TIME_FORMAT = "Y-m-d Hi"; // eg, 2019-01-01 1234
     const TIME_FORMAT_SQL = "Y-m-d H:i:s"; // 2019-01-01 12:34:56
 

--- a/engine/impl/Library.php
+++ b/engine/impl/Library.php
@@ -56,7 +56,7 @@ class LibraryImpl extends DBO implements ILibrary {
                   "ORDER BY name" ],
          [ "playlists", "playlistrec", "tracks", "artist,album,track",
                   "SELECT list, description, a.airname, showdate, " .
-                  "artist, album, track, showtime FROM tracks t " .
+                  "artist, album, track, showtime, origin FROM tracks t " .
                   "LEFT JOIN lists l ON t.list = l.id " .
                   "LEFT JOIN airnames a ON l.airname = a.id " .
                   "WHERE l.airname IS NOT NULL AND " .

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -31,8 +31,6 @@ namespace ZK\Engine;
 class PlaylistImpl extends DBO implements IPlaylist {
     const GRACE_START = "-15 minutes";
     const GRACE_END = "+30 minutes";
-    const DUPLICATE_COMMENT =
-        "Rebroadcast of an episode originally aired on %F j, Y%.";
 
     public function getShowdates($year, $month) {
         $yearMonth = sprintf("%04d-%02d", $year, $month) . "-%";

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -2263,12 +2263,12 @@ class Playlists extends MenuItem {
         $count = 0;
         $href = '?action=viewListById&playlist';
         while($records && ($row = $records->fetch())) {
-            $timeRange = self::timeToAMPM($row['showtime']);
-            $title = htmlentities($row['description']);
-            $djs = htmlentities($row['airname']);
+            $timeRange = self::timeToAMPM($row[2]);
+            $title = htmlentities($row[3]);
+            $djs = htmlentities($row[5]);
             $tbody .= "<TR>" .
                  "<TD ALIGN='RIGHT' CLASS='sub time range'>$timeRange&nbsp;</TD>" .
-                 "<TD><A CLASS='nav' HREF='$href=${row['id']}'>$title</A>&nbsp;&nbsp;($djs)</TD>" .
+                 "<TD><A CLASS='nav' HREF='$href=$row[0]'>$title</A>&nbsp;&nbsp;($djs)</TD>" .
                  "</TR>\n";
             $count = $count + 1;
         }

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -2263,12 +2263,12 @@ class Playlists extends MenuItem {
         $count = 0;
         $href = '?action=viewListById&playlist';
         while($records && ($row = $records->fetch())) {
-            $timeRange = self::timeToAMPM($row[2]);
-            $title = htmlentities($row[3]);
-            $djs = htmlentities($row[5]);
+            $timeRange = self::timeToAMPM($row['showtime']);
+            $title = htmlentities($row['description']);
+            $djs = htmlentities($row['airname']);
             $tbody .= "<TR>" .
                  "<TD ALIGN='RIGHT' CLASS='sub time range'>$timeRange&nbsp;</TD>" .
-                 "<TD><A CLASS='nav' HREF='$href=$row[0]'>$title</A>&nbsp;&nbsp;($djs)</TD>" .
+                 "<TD><A CLASS='nav' HREF='$href=${row['id']}'>$title</A>&nbsp;&nbsp;($djs)</TD>" .
                  "</TR>\n";
             $count = $count + 1;
         }

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -43,7 +43,6 @@ use VStelmakh\UrlHighlight\UrlHighlight;
 
 class Playlists extends MenuItem {
     private const NME_PREFIX = "nme-";
-    private const DUPLICATE_SUFFIX = " (rebroadcast from %M j, Y%)";
 
     //NOTE: update ui_config.php when changing the actions.
     private static $actions = [
@@ -684,7 +683,7 @@ class Playlists extends MenuItem {
                         return \DateTime::createFromFormat(
                             IPlaylist::TIME_FORMAT,
                             $date . " 0000")->format($matches[1]);
-                    }, self::DUPLICATE_SUFFIX);
+                    }, IPlaylist::DUPLICATE_SUFFIX);
                 if(mb_strlen($description) + mb_strlen($suffix) > IPlaylist::MAX_DESCRIPTION_LENGTH)
                     $description = mb_substr($description, 0, IPlaylist::MAX_DESCRIPTION_LENGTH - mb_strlen($suffix) - 3) . "...";
                 $description .= $suffix;


### PR DESCRIPTION
This PR adds a new boolean attribute 'rebroadcast' to the playlist API response.  The value is set automatically based on whether the playlist was the result of a duplication.

In addition, a duplicated list will have an 'origin' relation to the original playlist.  Note this will be true only for lists duplicated after this PR lands.

For backward compatibility, any playlist which contains 'rebroadcast' in its name will also be flagged true.  In this case, the 'origin' relation will not be included.

The PR also includes a new facility to duplicate a playlist via the API.  See docs/Playlists.md for details.

Satisfies #293