### PR TITLE
Revise playlist editor to accept tag in artist on manual page

### DIFF
--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -55,9 +55,8 @@ $().ready(function(){
         $("#nme-entry input").val('');
         setAddButtonState(false);
 
-        if (clearTagInfo) {
+        if (clearTagInfo)
             tagId = 0;
-        }
 
         switch(mode) {
         case 'manual-entry':
@@ -112,8 +111,8 @@ $().ready(function(){
     function getDiskInfo(id, refArtist) {
         $("#track-title").attr('list',''); // webkit hack
         $("#track-titles").empty();
-        clearUserInput(false);
-        tagId = 0;
+        clearUserInput(true);
+
         // chars [ and ] in the QS param name are supposed to be %-encoded.
         // It seems to work ok without and reads better in the server logs,
         // but this may need revisiting if there are problems.

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -481,6 +481,14 @@ $().ready(function(){
             alert('A required field is missing');
             return;
         }
+
+        // don't allow submission of album tag in the artist field
+        if($("#track-artist").val().trim().match(/^\d+$/) && tagId == 0) {
+            alert('If you are entering an album tag, select it from the list.');
+            $("#track-artist").focus();
+            return;
+        }
+
         // check that the timestamp, if any, is valid
         if($("INPUT[data-date].invalid-input").length > 0)
             return;
@@ -583,8 +591,6 @@ $().ready(function(){
                 $("#track-album").val("");
                 $("#track-label").val("");
             }
-            $("#track-artist").attr('list', ''); // webkit hack
-            $("#track-artists").empty();
             $("#track-titles").empty();
             if(artist.length > 3) {
                 // if artist is numeric with correct check digit,

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -31,11 +31,11 @@ $().ready(function(){
     $("#track-artist").focus();
 
     function htmlify(s) {
-        return s?s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\'/g, '&#39;'):"";
+        return s?String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\'/g, '&#39;'):"";
     }
 
     function escQuote(s) {
-        return s.replace(/\'/g, '\\\'');
+        return String(s).replace(/\'/g, '\\\'');
     }
 
     function setAddButtonState(enableIt) {

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -42,22 +42,27 @@ $().ready(function(){
         $("#track-submit").prop("disabled", !enableIt);
     }
 
-    function clearUserInput(clearTagInfo) {
-        var mode = $("#track-type-pick").val();
+    function clearUserInput(clearArtistList) {
         $("#track-time").val('');
         $("#manual-entry input").val('');
         $("#comment-entry textarea").val('');
-        $("#track-artists").empty();
         $("#track-title").attr('list',''); // webkit hack
         $("#track-titles").empty();
         $("#error-msg").text('');
         $("#tag-status").text('');
         $("#nme-entry input").val('');
+
+        if (clearArtistList) {
+            $("#track-artist").attr('list',''); // webkit hack
+            $("#track-artists").empty();
+            $("#track-artist").attr('list','track-artists'); // webkit hack
+        }
+
+        tagId = 0;
+
         setAddButtonState(false);
 
-        if (clearTagInfo)
-            tagId = 0;
-
+        var mode = $("#track-type-pick").val();
         switch(mode) {
         case 'manual-entry':
             $('#track-artist').focus();
@@ -111,7 +116,7 @@ $().ready(function(){
     function getDiskInfo(id, refArtist) {
         $("#track-title").attr('list',''); // webkit hack
         $("#track-titles").empty();
-        clearUserInput(true);
+        clearUserInput(false);
 
         // chars [ and ] in the QS param name are supposed to be %-encoded.
         // It seems to work ok without and reads better in the server logs,
@@ -524,7 +529,6 @@ $().ready(function(){
         });
 
         artist.attr('list', 'track-artists'); // webkit hack
-        artist.focus(); // webkit hack
     }
 
     function searchLibrary(key) {
@@ -576,7 +580,14 @@ $().ready(function(){
         });
     }
 
-    $("#track-artist").on('input', function() {
+    $("#track-artist").focusout(function() {
+        var opt, artist = $(this).val();
+        if(artist.match(/^\d+$/) &&
+               (opt = $("#track-artists option[data-tag='" + escQuote(artist) + "']")).length > 0) {
+            getDiskInfo(opt.data("tag"), opt.data("artist"));
+            $("#track-title").focus();
+        }
+    }).on('input', function() {
         var artist = $(this).val();
         var opt = $("#track-artists option[value='" + escQuote(artist) + "']");
         if(opt.length > 0) {
@@ -588,10 +599,11 @@ $().ready(function(){
                 $("#track-title").val("");
                 $("#track-title").attr('list',''); // webkit hack
                 $("#track-titles").empty();
+                $("#track-title").attr('list','track-titles'); // webkit hack
                 $("#track-album").val("");
                 $("#track-label").val("");
             }
-            $("#track-titles").empty();
+
             if(artist.length > 3) {
                 // if artist is numeric with correct check digit,
                 // treat it as an album tag

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -498,11 +498,14 @@ $().ready(function(){
         return htmlify(name);
     }
 
-    function addArtists(data) {
+    function addArtists(data, replace) {
         var artist = $("#track-artist");
         artist.attr('list', ''); // webkit hack
 
         var results = $("#track-artists");
+        if(replace)
+            results.empty();
+
         data.forEach(function(entry) {
             var attrs = entry.attributes;
             var row = htmlify(attrs.artist) + " - " +
@@ -529,7 +532,7 @@ $().ready(function(){
             url: url,
             success: function(response) {
                 addArtists(response.links.first.meta.total > 0 ?
-                           response.data : []);
+                           response.data : [], true);
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 var json = JSON.parse(jqXHR.responseText);
@@ -550,7 +553,7 @@ $().ready(function(){
             accept: "application/json; charset=utf-8",
             url: url,
             success: function(response) {
-                addArtists([ response.data ]);
+                addArtists([ response.data ], false);
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 if(jqXHR.status == 404) {

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -549,7 +549,7 @@ $().ready(function(){
                 var json = JSON.parse(jqXHR.responseText);
                 var status = (json && json.errors)?
                         json.errors[0].title:('There was a problem retrieving the data: ' + textStatus);
-                alert(status);
+                showUserError(status);
             }
         });
     }
@@ -575,7 +575,7 @@ $().ready(function(){
                 var json = JSON.parse(jqXHR.responseText);
                 var status = (json && json.errors)?
                         json.errors[0].title:('There was a problem retrieving the data: ' + textStatus);
-                alert(status);
+                showUserError(status);
             }
         });
     }

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -489,7 +489,7 @@ $().ready(function(){
 
         // don't allow submission of album tag in the artist field
         if($("#track-artist").val().trim().match(/^\d+$/) && tagId == 0) {
-            alert('If you are entering an album tag, select it from the list.');
+            alert('Album tag is invalid');
             $("#track-artist").focus();
             return;
         }
@@ -581,11 +581,15 @@ $().ready(function(){
     }
 
     $("#track-artist").focusout(function() {
-        var opt, artist = $(this).val();
-        if(artist.match(/^\d+$/) &&
-               (opt = $("#track-artists option[data-tag='" + escQuote(artist) + "']")).length > 0) {
-            getDiskInfo(opt.data("tag"), opt.data("artist"));
-            $("#track-title").focus();
+        $(this).removeClass('invalid-input');
+        var artist = $(this).val();
+        if(artist.match(/^\d+$/)) {
+            var opt = $("#track-artists option[data-tag='" + escQuote(artist) + "']");
+            if(opt.length > 0) {
+                getDiskInfo(opt.data("tag"), opt.data("artist"));
+                $("#track-title").focus();
+            } else
+                $(this).addClass('invalid-input');
         }
     }).on('input', function() {
         var artist = $(this).val();

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -579,7 +579,7 @@ $().ready(function(){
     $("#track-artist").focusout(function() {
         $(this).removeClass('invalid-input');
         var artist = $(this).val();
-        if(artist.match(/^\d+$/)) {
+        if(artist.match(/^\d+$/) && tagId == 0) {
             var opt = $("#track-artists option[data-tag='" + escQuote(artist) + "']");
             if(opt.length > 0) {
                 getDiskInfo(opt.data("tag"), opt.data("artist"));

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -52,7 +52,6 @@ $().ready(function(){
         $("#track-titles").empty();
         $("#error-msg").text('');
         $("#tag-status").text('');
-        $("#tag-artist").text('');
         $("#nme-entry input").val('');
         setAddButtonState(false);
 
@@ -168,8 +167,6 @@ $().ready(function(){
                     }
                 }
             }
-            $("#tag-artist").text(diskInfo.attributes.artist  + ' - ' + diskInfo.attributes.album);
-
         }).fail(function (jqXHR, textStatus, errorThrown) {
             var json = JSON.parse(jqXHR.responseText);
             if (json && json.errors) {

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -44,7 +44,7 @@ $().ready(function(){
 
     function clearUserInput(clearArtistList) {
         $("#track-time").val('');
-        $("#manual-entry input").val('');
+        $("#manual-entry input").removeClass('invalid-input').val('');
         $("#comment-entry textarea").val('');
         $("#track-title").attr('list',''); // webkit hack
         $("#track-titles").empty();

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -114,8 +114,6 @@ $().ready(function(){
     }
 
     function getDiskInfo(id, refArtist) {
-        $("#track-title").attr('list',''); // webkit hack
-        $("#track-titles").empty();
         clearUserInput(false);
 
         // chars [ and ] in the QS param name are supposed to be %-encoded.
@@ -130,19 +128,17 @@ $().ready(function(){
             url: url,
         }).done(function (response) { //TODO: success?
             tagId = id;
-            var options = "<option value=''>Select Track</option>";
-            var options2 = "";
+            var options = "";
             var diskInfo = response.data;
             var trackList = diskInfo.attributes.tracks;
             for (var i=0; i < trackList.length; i++) {
                 var track = trackList[i];
                 var artist = track.artist ? track.artist + ' - ' : '';
-                options += `<option value='${i}' >${i+1}. ${artist} ${track.track}</option>`;
-                options2 += "<option data-track='" + htmlify(track.track) +
+                options += "<option data-track='" + htmlify(track.track) +
                     "' data-artist='" + htmlify(track.artist) +
                     "' value='" + htmlify((i+1) + ". " + artist + track.track) + "'>";
             }
-            $("#track-titles").html(options2);
+            $("#track-titles").html(options);
             $("#track-title").attr('list','track-titles'); // webkit hack
             $("#track-artist").val(diskInfo.attributes.artist);
             $("#track-label").val(diskInfo.relationships != null &&

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -828,30 +828,17 @@ class Playlists extends MenuItem {
 
                 <label>Type:</label>
                 <select id='track-type-pick'>
-                   <option value='tag-entry'>Tag ID</option>
                    <option value='manual-entry'>Manual</option>
                    <option value='comment-entry'>Comment</option>
                    <?php echo $nmeOpts; ?>
                 </select>
             </div>
             <div id='track-entry'>
-                <div id='tag-entry'>
-                    <div>
-                        <label>Tag:</label>
-                        <input id='track-tag' data-focus />
-                        <span class='track-info' id='tag-status'>Enter tag ID followed by Tab or Enter</span>
-                    </div>
-                    <div>
-                        <label>Track:</label>
-                        <select id='track-title-pick'>
-                        </select>
-                    </div>
-                </div>
- 
-                <div id='manual-entry' class='zk-hidden' >
+                <div id='manual-entry'>
                     <div>
                         <label>Artist:</label>
                         <input required id='track-artist' list='track-artists' autocomplete='off' maxlength=<?php echo PlaylistEntry::MAX_FIELD_LENGTH;?> data-focus />
+                        <span class='track-info' id='tag-status'>Enter artist or tag number</span>
                         <datalist id='track-artists'>
                         </datalist>
                     </div>

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -838,7 +838,7 @@ class Playlists extends MenuItem {
                     <div>
                         <label>Artist / Tag:</label>
                         <input required id='track-artist' list='track-artists' autocomplete='off' maxlength=<?php echo PlaylistEntry::MAX_FIELD_LENGTH;?> data-focus />
-                        <span class='track-info' id='tag-status'>Last, first name or tag number</span>
+                        <span class='track-info' id='tag-status'>Artist (last name, first name) or tag number</span>
                         <datalist id='track-artists'>
                         </datalist>
                     </div>

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -836,9 +836,9 @@ class Playlists extends MenuItem {
             <div id='track-entry'>
                 <div id='manual-entry'>
                     <div>
-                        <label>Artist:</label>
+                        <label>Artist / Tag:</label>
                         <input required id='track-artist' list='track-artists' autocomplete='off' maxlength=<?php echo PlaylistEntry::MAX_FIELD_LENGTH;?> data-focus />
-                        <span class='track-info' id='tag-status'>Enter artist or tag number</span>
+                        <span class='track-info' id='tag-status'>Last, first name or tag number</span>
                         <datalist id='track-artists'>
                         </datalist>
                     </div>

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -828,7 +828,7 @@ class Playlists extends MenuItem {
 
                 <label>Type:</label>
                 <select id='track-type-pick'>
-                   <option value='manual-entry'>Manual</option>
+                   <option value='manual-entry'>Music</option>
                    <option value='comment-entry'>Comment</option>
                    <?php echo $nmeOpts; ?>
                 </select>


### PR DESCRIPTION
This PR revises the manual entry page of the playlist editor to accept tag as well as artist in the artist field.

In addition, it removes the tag entry page and makes the manual page the default.

Satisfies #296
