### PR TITLE
Added php 8.1 CI build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 7.4.22
+  - 7.4
   - 8.0
+  - 8.1
 
 services:
   - mysql


### PR DESCRIPTION
This PR adds php 8.1 as a CI build target.

In addition, it removes the workaround for the 7.4 CI build issue (#287)
