### PR TITLE
Prompt to extend live shows that run over

### DIFF
--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -672,6 +672,9 @@ table.recentAirplay td, .sub {
     width: 80px;
     margin-left: 5px;
 }
+.zk-popup-actionarea button.default {
+    font-weight: bold;
+}
 
 input[type="radio"], 
 input[type="checkbox"] {

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -661,6 +661,7 @@ table.recentAirplay td, .sub {
     padding: 12px 22px;
     width: 300px;
     background-color: #fff;
+    border-radius: 4px 4px 0 0;
     box-shadow: 0 4px 8px 0 rgba(0,0,0,0.8),0 6px 20px 0 rgba(0,0,0,0.2);
 }
 .zk-popup .zk-popup-content .zk-popup-actionarea {

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -643,6 +643,35 @@ table.recentAirplay td, .sub {
     width: 84px;
 }
 
+.zk-popup {
+    display: none;
+    position: fixed;
+    z-index: 1;
+    padding-top: 200px;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.4);
+}
+.zk-popup .zk-popup-content {
+    position: relative;
+    margin: auto;
+    padding: 12px 22px;
+    width: 300px;
+    background-color: #fff;
+    box-shadow: 0 4px 8px 0 rgba(0,0,0,0.8),0 6px 20px 0 rgba(0,0,0,0.2);
+}
+.zk-popup .zk-popup-content .zk-popup-actionarea {
+    padding-top: 22px;
+    text-align: right;
+}
+.zk-popup-actionarea button {
+    width: 80px;
+    margin-left: 5px;
+}
+
 input[type="radio"], 
 input[type="checkbox"] {
     height: 15px;

--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -92,7 +92,7 @@ interface IPlaylist {
     function getTracks($playlist, $desc = 0);
     function getTracksWithObserver($playlist, PlaylistObserver $observer, $desc = 0, $filter = null);
     function getTrackCount($playlist);
-    function getTimestampWindow($playlistId);
+    function getTimestampWindow($playlistId, $allowGrace = true);
     function insertTrack($playlistId, $tag, $artist, $track, $album, $label, $spinTimestamp, &$id, &$status);
     function updateTrack($playlistId, $id, $tag, $artist, $track, $album, $label, $dateTime);
     function insertTrackEntry($playlistId, PlaylistEntry $entry, &$status);

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -556,9 +556,9 @@ class PlaylistImpl extends DBO implements IPlaylist {
         return $result;
     }
 
-    public function getTimestampWindow($playlistId) {
+    public function getTimestampWindow($playlistId, $allowGrace = true) {
         $playlist = $this->getPlaylist($playlistId);
-        return $this->getTimestampWindowInternal($playlist);
+        return $this->getTimestampWindowInternal($playlist, $allowGrace);
     }
 
     // return true if dateTime is within the show time range or null.

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -467,7 +467,13 @@ $().ready(function(){
                     $(".playlistTable > tbody > tr").eq(index).find(".grab").mousedown(grabStart);
                     break;
                 }
+
                 clearUserInput(true);
+
+                if(respObj.runsover) {
+                    $("#extend-show").show();
+                    $("#extend-time").focus();
+                }
             },
             error: function (jqXHR, textStatus, errorThrown) {
                 const msg = jqXHR.responseJSON ? jqXHR.responseJSON.status : errorThrown;
@@ -634,6 +640,75 @@ $().ready(function(){
     });
 
     $(".playlistTable .grab").mousedown(grabStart);
+
+    // from home.js
+    function localTime(date) {
+        var hour = date.getHours();
+        var ampm = hour >= 12?"pm":"am";
+        var m = date.getMinutes();
+        var min = m == 0?'':':' + String(m).padStart(2, '0');
+        if(hour > 12)
+            hour -= 12;
+        else if(hour == 0)
+            hour = 12;
+        return hour + min + ampm;
+    }
+
+    $(".zk-popup button#extend").click(function() {
+        var start, end, showTime = $("#show-time").val();
+        [ start, end ] = showTime.split('-');
+
+        var edate = new Date("2022-01-01T" +
+                           end.substring(0, 2) + ":" +
+                           end.substring(2, 4) + ":00Z");
+        edate.setMinutes(edate.getMinutes() + edate.getTimezoneOffset());
+
+        var extend = $("#extend-time").val();
+        edate = new Date(edate.getTime() + extend * 60 * 1000);
+
+        end = String(edate.getHours()).padStart(2, '0') +
+              String(edate.getMinutes()).padStart(2, '0');
+
+        showTime = start + "-" + end;
+
+        var playlistId = $("#track-playlist").val();
+        var postData = {
+            data: {
+                type: 'show',
+                id: playlistId,
+                attributes: {
+                    time: showTime
+                }
+            }
+        };
+
+        $.ajax({
+            type: 'PATCH',
+            url: 'api/v1/playlist/' + playlistId,
+            dataType: 'json',
+            contentType: "application/json; charset=utf-8",
+            accept: "application/json; charset=utf-8",
+            data: JSON.stringify(postData),
+            success: function(response) {
+                $("#show-time").val(showTime);
+
+                var banner = $(".playlistBanner > DIV");
+                var prefix = banner.html().split('-')[0];
+                banner.html(prefix + " - " + localTime(edate) + "&nbsp;");
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                var json = JSON.parse(jqXHR.responseText);
+                var status = (json && json.errors)?
+                        json.errors[0].title:('There was a problem extending the show time: ' + textStatus);
+                showUserError(status);
+            }
+        });
+    });
+
+    $(".zk-popup button").click(function() {
+        $(".zk-popup").hide();
+        $("*[data-focus]").focus();
+    });
 
     $("*[data-focus]").focus();
 });

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -655,21 +655,19 @@ $().ready(function(){
     }
 
     $(".zk-popup button#extend").click(function() {
-        var start, end, showTime = $("#show-time").val();
-        [ start, end ] = showTime.split('-');
+        var showTime = $("#show-time").val().split('-');
 
         var edate = new Date("2022-01-01T" +
-                           end.substring(0, 2) + ":" +
-                           end.substring(2, 4) + ":00Z");
+                           showTime[1].substring(0, 2) + ":" +
+                           showTime[1].substring(2, 4) + ":00Z");
         edate.setMinutes(edate.getMinutes() + edate.getTimezoneOffset());
 
         var extend = $("#extend-time").val();
-        edate = new Date(edate.getTime() + extend * 60 * 1000);
+        edate.setMinutes(edate.getMinutes() + extend*1);
 
-        end = String(edate.getHours()).padStart(2, '0') +
-              String(edate.getMinutes()).padStart(2, '0');
-
-        showTime = start + "-" + end;
+        showTime[1] = String(edate.getHours()).padStart(2, '0') +
+                      String(edate.getMinutes()).padStart(2, '0');
+        showTime = showTime.join('-');
 
         var playlistId = $("#track-playlist").val();
         var postData = {

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -305,6 +305,11 @@ class Playlists extends MenuItem {
                     } else
                         $spin = null;
                     PushServer::sendAsyncNotification($playlist, $spin);
+
+                    // track is in the grace period?
+                    $window = $playlistApi->getTimestampWindow($playlistId, false);
+                    if($spinDateTime >= $window['end'])
+                        $retVal['runsover'] = true;
                 } else if(!$isLiveShow)
                     $this->lazyLoadImages($playlistId, $entry->getId());
             }
@@ -834,6 +839,7 @@ class Playlists extends MenuItem {
     ?>
         <div class='pl-form-entry'>
             <input id='show-date' name='edate' type='hidden' value="<?php echo $playlist['showdate']; ?>" >
+            <input id='show-time' type='hidden' value="<?php echo $playlist['showtime']; ?>" >
             <input id='track-playlist' type='hidden' value='<?php echo $playlistId; ?>'>
             <input id='track-action' type='hidden' value='<?php echo $this->action; ?>'>
             <input id='const-prefix' type='hidden' value='<?php echo self::NME_PREFIX; ?>'>
@@ -910,6 +916,23 @@ class Playlists extends MenuItem {
             </div>
         </div> <!-- track-editor -->
         <hr>
+        <div id="extend-show" class="zk-popup">
+            <div class="zk-popup-content">
+                <h4>Your show's end time has been reached.</h4>
+                <p>Extend by:
+                <select id="extend-time">
+                    <option value="5">5 minutes</option>
+                    <option value="10">10 minutes</option>
+                    <option value="15">15 minutes</option>
+                    <option value="30">30 minutes</option>
+                    <option value="60">1 hour</option>
+                </select></p>
+                <div class="zk-popup-actionarea">
+                    <button type="button">Cancel</button>
+                    <button type="button" id="extend">Extend</button>
+                </div>
+            </div>
+        </div> <!-- extend-show -->
     <?php
     }
     private function emitTrackField($tag, $seltrack, $id) {

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -918,7 +918,7 @@ class Playlists extends MenuItem {
         <hr>
         <div id="extend-show" class="zk-popup">
             <div class="zk-popup-content">
-                <h4>Your show's end time has been reached.</h4>
+                <h4>You have reached the end time of your show.</h4>
                 <p>Extend by:
                 <select id="extend-time">
                     <option value="5">5 minutes</option>
@@ -929,7 +929,7 @@ class Playlists extends MenuItem {
                 </select></p>
                 <div class="zk-popup-actionarea">
                     <button type="button">Cancel</button>
-                    <button type="button" id="extend">Extend</button>
+                    <button type="button" class="default" id="extend">Extend</button>
                 </div>
             </div>
         </div> <!-- extend-show -->


### PR DESCRIPTION
Zookeeper allows a grace period of 30 minutes after the designated show time for entry of tracks.  Push notification, however, stops at the show end.

I was originally thinking to extend the show end time automatically, or have push delay its indication of end of show to handle these cases; however, doing so would create several new potential failure modes.

Instead, this PR prompts a DJ who is continuing to enter tracks in the grace period (that is to say, after his show end time but within the following 30 minutes), whether he wants to extend his show end time.  It offers 5, 10, 15, 30 minutes, and 1 hour extension options.  If he so elects, then the show end time is adjusted and push notifications continue to work as expected.

Screenshot:  (Modal displays after entry of a track in the grace period.)
![Screenshot from 2022-05-20 17-06-59](https://user-images.githubusercontent.com/6860356/169568506-14f1204f-bade-43d4-87c0-598f19d486de.png)

