### PR TITLE
Improve usability of weekly charts

### DIFF
--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -537,7 +537,7 @@ p.zktitle a {
     width: 100%;
 }
 
-.home-onnow, th {
+.home-onnow, .chart-year-pick, th {
     font-size: 11pt;
     font-weight: bold;
     color: #000000;

--- a/ui/Charts.php
+++ b/ui/Charts.php
@@ -161,6 +161,8 @@ class Charts extends MenuItem {
             $urls = Engine::param('urls');
             if($isOldestYear && array_key_exists('old_charts', $urls))
                 echo "  <P><A HREF=\"".$urls['old_charts']."\">Older airplay charts</A> are available here.</P>\n";
+
+            $this->title = "Weekly charts for $year";
             return;
         }
     

--- a/ui/Charts.php
+++ b/ui/Charts.php
@@ -74,7 +74,7 @@ class Charts extends MenuItem {
             echo "      </TABLE>\n    </TD>\n";
         }
         echo "  </TR>\n</TABLE>\n";
-        UI::setFocus();
+        $this->title = "Airplay Top 30";
     }
     
     public function emitChartYearNav($currentYear, $header=0) {
@@ -289,7 +289,8 @@ class Charts extends MenuItem {
                     echo "    <TR><TD><A HREF=\"".$urls['old_charts']."\">Old airplay charts</A> are available here.</TD></TR>\n";
                 echo "  </TABLE>\n";
             }
-            UI::setFocus();
+
+            $this->title = "Amalgamated charts";
             return;
         }
 

--- a/ui/Charts.php
+++ b/ui/Charts.php
@@ -78,21 +78,32 @@ class Charts extends MenuItem {
     }
     
     public function emitChartYearNav($currentYear, $header=0) {
-        echo "  <TABLE>\n    <TR><TH>View charts for:</TH>";
-        echo "<TD>&nbsp;&nbsp;</TD>";
+?>
+  <div class="chart-year-pick">
+  <form action="?" method="POST" autocomplete="off">
+  <input type="hidden" name="action" value="viewChart">
+  <input type="hidden" name="subaction" value="weekly">
+  Weekly charts for
+  <select name="year">
+<?php
         $years = Engine::api(IChart::class)->getChartYears();
         while($years && ($year = $years->fetch())) {
-            
+            echo "    <option value=\"{$year[0]}\"";
             if($year[0] == $currentYear)
-                echo "<TH>$currentYear</TH>";
-            else
-                echo "<TH><A CLASS=\"nav\" HREF=\"?action=viewChart&amp;subaction=weekly&amp;year=" . $year[0] . "\">" . $year[0] . "</A></TH>";
-            echo "<TD>&nbsp;&nbsp;&nbsp;</TD>";
+                echo " selected";
+            echo ">{$year[0]}</option>\n";
         }
-        $urls = Engine::param('urls');
-        if(array_key_exists('old_charts', $urls))
-            echo "    <TD><A HREF=\"".$urls['old_charts']."\">Old airplay charts</A> are available here.</TD>";
-        echo "    </TR>\n  </TABLE>\n";
+        ?>
+  </select>
+  </form>
+  </div>
+  <script type="text/javascript"><!--
+  $("div.chart-year-pick select").change(function() {
+    $("div.chart-year-pick form").submit();
+  }).focus();
+  // -->
+  </script>
+<?php
     }
     
     public function chartWeekly() {
@@ -126,7 +137,7 @@ class Charts extends MenuItem {
       <P>Note that the 'Main' section of our weekly charts now lists all of
          our current new releases which received airplay during the charting
          week.</P-->
-    <?php 
+<?php
             $this->emitChartYearNav($year, 1);
             echo "  <TABLE WIDTH=\"100%\">\n";
             echo "    <TR><TD>\n      <UL>\n";
@@ -143,9 +154,10 @@ class Charts extends MenuItem {
             }
             echo "      </UL>\n    </TD></TR>\n";
             echo "  </TABLE>\n";
-    
-            $this->emitChartYearNav($year, 0);
-            UI::setFocus();
+
+            $urls = Engine::param('urls');
+            if(array_key_exists('old_charts', $urls))
+                echo "  <P><A HREF=\"".$urls['old_charts']."\">Older airplay charts</A> are available here.</P>\n";
             return;
         }
     

--- a/ui/Charts.php
+++ b/ui/Charts.php
@@ -86,12 +86,14 @@ class Charts extends MenuItem {
   Weekly charts for
   <select name="year">
 <?php
+        $oldestYear = null;
         $years = Engine::api(IChart::class)->getChartYears();
         while($years && ($year = $years->fetch())) {
             echo "    <option value=\"{$year[0]}\"";
             if($year[0] == $currentYear)
                 echo " selected";
             echo ">{$year[0]}</option>\n";
+            $oldestYear = $year[0];
         }
         ?>
   </select>
@@ -104,6 +106,7 @@ class Charts extends MenuItem {
   // -->
   </script>
 <?php
+        return $oldestYear == $currentYear;
     }
     
     public function chartWeekly() {
@@ -138,7 +141,7 @@ class Charts extends MenuItem {
          our current new releases which received airplay during the charting
          week.</P-->
 <?php
-            $this->emitChartYearNav($year, 1);
+            $isOldestYear = $this->emitChartYearNav($year, 1);
             echo "  <TABLE WIDTH=\"100%\">\n";
             echo "    <TR><TD>\n      <UL>\n";
             $weeks = $chartAPI->getChartDatesByYear($year);
@@ -156,7 +159,7 @@ class Charts extends MenuItem {
             echo "  </TABLE>\n";
 
             $urls = Engine::param('urls');
-            if(array_key_exists('old_charts', $urls))
+            if($isOldestYear && array_key_exists('old_charts', $urls))
                 echo "  <P><A HREF=\"".$urls['old_charts']."\">Older airplay charts</A> are available here.</P>\n";
             return;
         }


### PR DESCRIPTION
Navigation for weekly charts is provided by hyperlinks at the top and bottom of the page.  Each hyperlink corresponds to a year.

As there are now 20+ years of charts, the hyperlink list is quite long and is presenting usability problems.  For some browsers, a scrollbar appears, which is less than ideal, and moreover, Francis reports that Safari simply truncates the list with no scrollbar.

This PR replaces the hyperlink-based year picker with a dropdown.
