### PR TITLE
Allow time entry during live playlist creation

### DIFF
--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -40,6 +40,15 @@ $().ready(function(){
 
     function setAddButtonState(enableIt) {
         $("#track-submit").prop("disabled", !enableIt);
+
+        var time = $("#track-time");
+        if(enableIt && time.data("live") && time.val().length == 0) {
+            // calculate timestamp relative to server timezone
+            var now = new Date();
+            now.setMinutes(now.getMinutes() - $("#timezone-offset").val()*1);
+            var nowTime = now.toISOString().match(/(\d{2}:?){3}/)[0];
+            time.val(nowTime);
+        }
     }
 
     function clearUserInput(clearArtistList) {
@@ -632,15 +641,6 @@ $().ready(function(){
             if(artist)
                 $("#track-artist").val(artist);
             $("#track-title").val(opt.data("track"));
-        }
-
-        var time = $("#track-time");
-        if(time.data("live") && time.val().length == 0) {
-            // calculate now relative to server timezone
-            var now = new Date();
-            now.setMinutes(now.getMinutes() - $("#timezone-offset").val()*1);
-            var nowTime = now.toISOString().match(/(\d{2}:?){3}/)[0];
-            time.val(nowTime);
         }
     });
 

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -636,8 +636,11 @@ $().ready(function(){
 
         var time = $("#track-time");
         if(time.data("live") && time.val().length == 0) {
-            var now = new Date().toTimeString().split(' ')[0];
-            time.val(now);
+            // calculate now relative to server timezone
+            var now = new Date();
+            now.setMinutes(now.getMinutes() - $("#timezone-offset").val()*1);
+            var nowTime = now.toISOString().match(/(\d{2}:?){3}/)[0];
+            time.val(nowTime);
         }
     });
 

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -633,6 +633,12 @@ $().ready(function(){
                 $("#track-artist").val(artist);
             $("#track-title").val(opt.data("track"));
         }
+
+        var time = $("#track-time");
+        if(time.data("live") && time.val().length == 0) {
+            var now = new Date().toTimeString().split(' ')[0];
+            time.val(now);
+        }
     });
 
     $("#track-album, #track-label").on('change', function() {

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -259,7 +259,7 @@ class Playlists extends MenuItem {
             $retMsg = 'success';
             $id = '';
             $status = '';
-            if ($isLiveShow) {
+            if ($isLiveShow && !$spinDateTime) {
                 $spinDateTime = new \DateTime("now");
             }
 
@@ -865,13 +865,13 @@ class Playlists extends MenuItem {
                     </div>
                 </div>
             </div> <!-- track-entry -->
-            <?php if (!$isLiveShow) {
+            <?php
                 $window = Engine::api(IPlaylist::class)->getTimestampWindow($playlistId);
                 echo "<div>
                     <label>Time:</label>
-                    <input id='track-time' class='timepicker' step='1' type='time' data-date='".$window['start']->format('Y-m-d')."' data-start='".$window['start']->format('H:i')."' data-end='".$window['end']->format('H:i')."' />
-                </div>";
-            }?>
+                    <input id='track-time' class='timepicker' step='1' type='time' data-date='".$window['start']->format('Y-m-d')."' data-start='".$window['start']->format('H:i')."' data-end='".$window['end']->format('H:i')."' data-live='".($isLiveShow?1:0)."' />
+                </div>\n";
+            ?>
             <div>
                 <label></label>
                 <button DISABLED id='track-submit' >Add Item</button>

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -803,7 +803,7 @@ class Playlists extends MenuItem {
         <div class='pl-form-entry'>
             <input id='show-date' name='edate' type='hidden' value="<?php echo $playlist['showdate']; ?>" >
             <input id='show-time' type='hidden' value="<?php echo $playlist['showtime']; ?>" >
-            <input id='timezone-offset' type=hidden value="<?php echo round(date('Z')/-60, 2); /* server TZ equivalent of javascript now.getTimezoneOffset() */ ?>" >
+            <input id='timezone-offset' type='hidden' value="<?php echo round(date('Z')/-60, 2); /* server TZ equivalent of javascript Date.getTimezoneOffset() */ ?>" >
             <input id='track-playlist' type='hidden' value='<?php echo $playlistId; ?>'>
             <input id='track-action' type='hidden' value='<?php echo $this->action; ?>'>
             <input id='const-prefix' type='hidden' value='<?php echo self::NME_PREFIX; ?>'>

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -803,6 +803,7 @@ class Playlists extends MenuItem {
         <div class='pl-form-entry'>
             <input id='show-date' name='edate' type='hidden' value="<?php echo $playlist['showdate']; ?>" >
             <input id='show-time' type='hidden' value="<?php echo $playlist['showtime']; ?>" >
+            <input id='timezone-offset' type=hidden value="<?php echo round(date('Z')/-60, 2); /* server TZ equivalent of javascript now.getTimezoneOffset() */ ?>" >
             <input id='track-playlist' type='hidden' value='<?php echo $playlistId; ?>'>
             <input id='track-action' type='hidden' value='<?php echo $this->action; ?>'>
             <input id='const-prefix' type='hidden' value='<?php echo self::NME_PREFIX; ?>'>


### PR DESCRIPTION
This PR enables the Time entry field during live playlist creation.

For live playlists:
* the Time field will autopopulate with the current time (to the second) when the Track is entered, provided the DJ has not already entered a time value;
* the DJ may override the Time value as desired, provided the supplied time value is within the show start-end range, inclusive grace periods;
* upon Add Item, if the Time field is empty, the server will automatically timestamp the track with the current time.

For non-live playlists, there are no changes.

@romain2k @eric-gilbertson
