### PR TITLE
Playlist editor:  Add support for track cueing

### DIFF
--- a/config/config.kzsu.php
+++ b/config/config.kzsu.php
@@ -148,7 +148,7 @@ $config = [
      */
     'nme' => [
         ['name' => 'LID', 'args'  => 0],
-        ['name' => 'PROMO','args' => 1],
+        ['name' => 'Promo','args' => 1],
         ['name' => 'PSA',  'args'  => 1]
      ],
 

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -1026,3 +1026,18 @@ div.toggle-time-entry div {
     height: 17px;
     background-image: url('../img/clock-icon.png');
 }
+
+.play-now {
+    z-index: 9;
+}
+.play-now button {
+    font-size: 10px;
+    border: none;
+    color: #fff;
+    background-color: #2b547e;
+    border-radius: 4px;
+    box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19);
+}
+.play-now button:active {
+    transform: translate(1px, 1px);
+}

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -1038,6 +1038,9 @@ div.toggle-time-entry div {
     border-radius: 4px;
     box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19);
 }
+.play-now button:hover {
+    background-color: #3b648e;
+}
 .play-now button:active {
     transform: translate(1px, 1px);
 }

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -760,7 +760,9 @@ $().ready(function(){
 
                     var rows = $(".playlistTable > tbody > tr");
                     var index = rows.length - respObj.seq + 1;
-                    if(index < rows.length)
+                    if(index == 0)
+                        $(".playlistTable > tbody").prepend(respObj.row);
+                    else if(index < rows.length)
                         rows.eq(index).before(respObj.row);
                     else
                         rows.eq(rows.length - 1).after(respObj.row);

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -792,6 +792,11 @@ $().ready(function(){
                     $(".playlistTable > tbody > tr").eq(index).find(".grab").mousedown(grabStart);
 
                     updatePlayable();
+
+                    if(respObj.runsover) {
+                        $("#extend-show").show();
+                        $("#extend-time").focus();
+                    }
                     break;
                 }
             },

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -439,7 +439,7 @@ $().ready(function(){
             eventType: eventType,
             eventCode: eventCode,
             comment: comment,
-            future: id == 'track-add' ? 1 : 0,
+            cue: id == 'track-add' ? 1 : 0,
             size: $(".playlistTable > tbody > tr").length,
         };
 

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -834,5 +834,8 @@ $().ready(function(){
     $("#future-entry").prop('checked',
                             getPending() != null ||
                             localStorage.getItem('future-entry')*1);
+    $("#track-time").prop('disabled',
+                          $("#track-time").data("live") &&
+                          $("#future-entry").is(":checked"));
     $("*[data-focus]").focus();
 });

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -27,9 +27,6 @@ $().ready(function(){
     const NME_PREFIX=$("#const-prefix").val();
     var tagId = 0;
 
-    $("#track-type-pick").val('manual-entry');
-    $("#track-artist").focus();
-
     function htmlify(s) {
         return s?String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\'/g, '&#39;'):"";
     }
@@ -826,10 +823,11 @@ $().ready(function(){
     }
 
     updatePlayable();
+
     $("#track-type-pick").html($("#track-type-pick option").sort(function(a, b) {
-        return b.value == 'manual-entry' || a.value != 'manual-entry' && 
+        return b.value == 'manual-entry' || a.value != 'manual-entry' &&
             a.text.toLowerCase() > b.text.toLowerCase() ? 1 : -1;
-    }));
+    })).val('manual-entry');
 
     $("*[data-focus]").focus();
 });

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -287,7 +287,7 @@ $().ready(function(){
         // for live shows, restrict end time to 'now'
         if($(this).data("live")) {
             end = new Date();
-            end.setMinutes(end.getMinutes() - end.getTimezoneOffset());
+            end.setMinutes(end.getMinutes() - $("#timezone-offset").val()*1);
         }
 
         if(isNaN(val) || val < start || val > end) {

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -721,7 +721,31 @@ $().ready(function(){
         }
     });
 
+    function getPending() {
+        var highlight = null;
+
+        $(".playlistTable > tbody > tr").each(function() {
+            if($(this).find(".time").contents().filter(function() {
+                return this.nodeType == 3; // text node
+            }).text() === '')
+                highlight = this;
+            else
+                return false;
+        });
+
+        return highlight;
+    }
+
     $("#future-entry").change(function() {
+        if(!this.checked) {
+            // check to see if any entries are pending
+            if(getPending() != null) {
+                alert("You have cued tracks.  Play or delete them.");
+                $(this).prop('checked', true);
+                return;
+            }
+        }
+
         $("#track-time").prop('disabled', this.checked).val('');
         localStorage.setItem('future-entry', this.checked?1:0);
     });
@@ -788,17 +812,7 @@ $().ready(function(){
         if(!$("#track-time").data("live"))
             return;
 
-        var highlight = null;
-        var rows = $(".playlistTable > tbody > tr");
-        rows.each(function() {
-            if($(this).find(".time").contents().filter(function() {
-                return this.nodeType == 3; // text nodes
-            }).text() === '')
-                highlight = this;
-            else
-                return false;
-        });
-
+        var highlight = getPending();
         if(highlight != null) {
             if(playable == null)
                 playable = $("<div>", {class: 'play-now'}).append($("<button>").text("play now"));
@@ -817,6 +831,8 @@ $().ready(function(){
     }
 
     updatePlayable();
-    $("#future-entry").prop('checked', localStorage.getItem('future-entry')*1);
+    $("#future-entry").prop('checked',
+                            getPending() != null ||
+                            localStorage.getItem('future-entry')*1);
     $("*[data-focus]").focus();
 });

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -723,6 +723,7 @@ $().ready(function(){
 
     $("#future-entry").change(function() {
         $("#track-time").prop('disabled', this.checked).val('');
+        localStorage.setItem('future-entry', this.checked?1:0);
     });
 
     function timestampTrack(row) {
@@ -816,5 +817,6 @@ $().ready(function(){
     }
 
     updatePlayable();
+    $("#future-entry").prop('checked', localStorage.getItem('future-entry')*1);
     $("*[data-focus]").focus();
 });

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -325,6 +325,11 @@ $().ready(function(){
         }
     });
 
+    $("#edit-cancel").click(function(){
+        location.href = "?action=" + $("#track-action").val() +
+            "&playlist=" + $("#track-playlist").val();
+    });
+
     // display highlight on track edit
     if($("FORM#edit").length > 0) {
         var id = $("FORM#edit INPUT[name=id]").val();

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -284,11 +284,17 @@ $().ready(function(){
                 val.setTime(val.getTime() + 86400000);
         }
 
+        // for live shows, restrict end time to 'now'
+        if($(this).data("live")) {
+            end = new Date();
+            end.setMinutes(end.getMinutes() - end.getTimezoneOffset());
+        }
+
         if(isNaN(val) || val < start || val > end) {
             $(this).removeClass('prefilled-input');
             $(this).addClass('invalid-input');
             $(this).val("").focus();
-            showUserError('Spin time is outside of show start/end times.');
+            showUserError('Spin time is invalid.');
         } else {
             // if we massaged time for webkit, set canonical value
             if($(this).val() != v)
@@ -501,9 +507,6 @@ $().ready(function(){
             $("#track-artist").focus();
             return;
         }
-
-        if($("#track-time").data("live") && this.id == 'track-add')
-            $("#track-time").removeClass('invalid-input').val('');
 
         // check that the timestamp, if any, is valid
         if($("INPUT[data-date].invalid-input").length > 0)

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -294,7 +294,7 @@ $().ready(function(){
             $(this).removeClass('prefilled-input');
             $(this).addClass('invalid-input');
             $(this).val("").focus();
-            showUserError('Spin time is invalid.');
+            showUserError('Time is invalid');
         } else {
             // if we massaged time for webkit, set canonical value
             if($(this).val() != v)

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -809,7 +809,7 @@ class Playlists extends MenuItem {
         $nmePrefix = self::NME_PREFIX;
         if ($nmeAr) {
             foreach ($nmeAr as $nme)
-                $nmeOpts = $nmeOpts . "<option data-args='" . $nme['args'] . "' value='" . $nmePrefix . strtoupper($nme['name']) . "'>" . $nme['name'] . "</option>";
+                $nmeOpts = $nmeOpts . "<option data-args='" . $nme['args'] . "' value='" . $nmePrefix . $nme['name'] . "'>" . $nme['name'] . "</option>";
         }
 
     ?>

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -809,7 +809,7 @@ class Playlists extends MenuItem {
         $nmePrefix = self::NME_PREFIX;
         if ($nmeAr) {
             foreach ($nmeAr as $nme)
-                $nmeOpts = $nmeOpts . "<option data-args='" . $nme['args'] . "' value='" . $nmePrefix . $nme['name'] . "'>" . $nme['name'] . "</option>";
+                $nmeOpts = $nmeOpts . "<option data-args='" . $nme['args'] . "' value='" . $nmePrefix . strtoupper($nme['name']) . "'>" . $nme['name'] . "</option>";
         }
 
     ?>

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -831,6 +831,7 @@ class Playlists extends MenuItem {
                 <select id='track-type-pick'>
                    <option value='manual-entry'>Music</option>
                    <option value='comment-entry'>Comment</option>
+                   <option value='set-separator'>Mic Break (separator)</option>
                    <?php echo $nmeOpts; ?>
                 </select>
             </div>
@@ -886,15 +887,10 @@ class Playlists extends MenuItem {
                     <span class='track-info".($isLiveShow?"":" zk-hidden")."'>Leave blank for current time</span>
                 </div>\n";
             ?>
-            <div class='<?php if(!$isLiveShow) echo "zk-hidden"; ?>'>
-                <label>Cue Item:</label>
-                <input id='future-entry' type='checkbox' />
-                <span>Select for upcoming airplay</span>
-            </div>
             <div>
                 <label></label>
-                <button DISABLED id='track-submit' >Add Item</button>
-                <button style='margin-left:17px;' id='track-separator'>Add Separator</button>
+                <button disabled id='track-add' class='track-submit'>Add</button>
+                <button disabled style='margin-left:17px;' id='track-play' class='track-submit<?php if(!$isLiveShow) echo " zk-hidden"; ?>'>Add and Play</button>
             </div>
             <div class='toggle-time-entry<?php if (!$isLiveShow) echo " zk-hidden"; ?>'><div><!--&#x1f551;--></div></div>
         </div> <!-- track-editor -->

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -227,7 +227,7 @@ class Playlists extends MenuItem {
         if ($spinTime != '')
             $spinDateTime = new \DateTime("${spinDate} ${spinTime}");
 
-        $isFuture = $_REQUEST["future"] ?? 0;
+        $isCue = $_REQUEST["cue"] ?? 0;
 
         $entry = null;
         $tid = $_REQUEST["tid"] ?? null;
@@ -270,7 +270,7 @@ class Playlists extends MenuItem {
             $retMsg = 'success';
             $id = '';
             $status = '';
-            if ($isLiveShow && !$spinDateTime && !$isFuture) {
+            if ($isLiveShow && !$spinDateTime && !$isCue) {
                 $spinDateTime = new \DateTime("now");
             }
 
@@ -305,7 +305,7 @@ class Playlists extends MenuItem {
                     } else
                         $spin = null;
 
-                    if(!$isFuture)
+                    if($spinDateTime)
                         PushServer::sendAsyncNotification($playlist, $spin);
 
                     // track is in the grace period?

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -816,6 +816,7 @@ class Playlists extends MenuItem {
         <div class='pl-form-entry'>
             <input id='show-date' name='edate' type='hidden' value="<?php echo $playlist['showdate']; ?>" >
             <input id='show-time' type='hidden' value="<?php echo $playlist['showtime']; ?>" >
+            <input id='timezone-offset' type='hidden' value="<?php echo round(date('Z')/-60, 2); /* server TZ equivalent of javascript Date.getTimezoneOffset() */ ?>" >
             <input id='track-playlist' type='hidden' value='<?php echo $playlistId; ?>'>
             <input id='track-action' type='hidden' value='<?php echo $this->action; ?>'>
             <input id='const-prefix' type='hidden' value='<?php echo self::NME_PREFIX; ?>'>

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -304,7 +304,9 @@ class Playlists extends MenuItem {
                         $spin['artist'] = PlaylistEntry::swapNames($spin['artist']);
                     } else
                         $spin = null;
-                    PushServer::sendAsyncNotification($playlist, $spin);
+
+                    if(!$isFuture)
+                        PushServer::sendAsyncNotification($playlist, $spin);
 
                     // track is in the grace period?
                     $window = $playlistApi->getTimestampWindow($playlistId, false);
@@ -882,12 +884,13 @@ class Playlists extends MenuItem {
                     <label>Time:</label>
                     <input id='track-time' class='timepicker' step='1' type='time' data-date='".$window['start']->format('Y-m-d')."' data-start='".$window['start']->format('H:i')."' data-end='".$window['end']->format('H:i')."' data-live='".($isLiveShow?1:0)."' />
                     <span class='track-info".($isLiveShow?"":" zk-hidden")."'>Leave blank for current time</span>
-                    <div class='".($isLiveShow?"":"zk-hidden")."'>
-                        <label></label>
-                        <span><input id='future-entry' type='checkbox' /> Future entry</span>
-                    </div>
                 </div>\n";
             ?>
+            <div class='<?php if(!$isLiveShow) echo "zk-hidden"; ?>'>
+                <label>Cue Item:</label>
+                <input id='future-entry' type='checkbox' />
+                <span>Select for upcoming airplay</span>
+            </div>
             <div>
                 <label></label>
                 <button DISABLED id='track-submit' >Add Item</button>

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -959,11 +959,6 @@ class Playlists extends MenuItem {
       $edate = $startTime->format('Y-m-d');
       $showTimeRange = "$startAMPM - $endAMPM";
       $timepickerClass = "timepicker";
-      if($isLive && !$entry->getCreated()) {
-          // pre-fill empty time in live playlist with 'now'
-          $entry->setCreated($nowTime->format(IPlaylist::TIME_FORMAT_SQL));
-          $timepickerClass .= " prefilled-input";
-      }
       $timepickerTime = $entry->getCreatedTime();
       $sep = $id && $entry->isType(PlaylistEntry::TYPE_SET_SEPARATOR);
       $event = $id && $entry->isType(PlaylistEntry::TYPE_LOG_EVENT);
@@ -985,7 +980,6 @@ class Playlists extends MenuItem {
           break;
       } ?></DIV>
       <FORM ACTION="?" id='edit' METHOD=POST>
-      <input id='track-playlist' type='hidden' value='<?php echo $playlistId; ?>'>
       <TABLE>
     <?php if($sep) { ?>
       <INPUT TYPE=HIDDEN NAME=separator VALUE="true">
@@ -1060,14 +1054,15 @@ class Playlists extends MenuItem {
           <TD>&nbsp;</TD>
           <TD>
     <?php if($id) { ?>
-              <INPUT TYPE=BUTTON NAME=button id='edit-save' VALUE="  Save  ">&nbsp;&nbsp;&nbsp;
+              <INPUT TYPE=BUTTON NAME=button id='edit-save' VALUE="  Save  ">
               <INPUT TYPE=BUTTON NAME=button id='edit-delete' VALUE=" Delete ">
+              <INPUT TYPE=BUTTON NAME=button id='edit-cancel' VALUE=" Cancel ">
               <INPUT TYPE=HIDDEN NAME=id VALUE="<?php echo $id;?>">
     <?php } else { ?>
               <INPUT TYPE=SUBMIT VALUE="  Next &gt;&gt;  ">
     <?php } ?>
-              <INPUT TYPE=HIDDEN NAME=playlist VALUE="<?php echo $playlistId;?>">
-              <INPUT TYPE=HIDDEN NAME=action VALUE="<?php echo $this->action;?>">
+              <INPUT TYPE=HIDDEN id='track-playlist' NAME=playlist VALUE="<?php echo $playlistId;?>">
+              <INPUT TYPE=HIDDEN id='track-action' NAME=action VALUE="<?php echo $this->action;?>">
               <INPUT TYPE=HIDDEN NAME=tag VALUE="<?php echo $album["tag"];?>">
               <INPUT TYPE=HIDDEN NAME=seq VALUE="editForm">
           </TD>


### PR DESCRIPTION
This PR adds support to the playlist editor for pre-entry of spins and non-music entries.

With this PR, a DJ may cue one or more entries to a live playlist for subsequent airplay.

For live playlists, the playlist editor button 'Add Item' has been replaced with two new actions: 'Add' and 'Add and Play'.  The former cues an item for pending airplay, while the latter is functionally identical to the erstwhile 'Add Item'; that is, it adds and plays (timestamps) in one action.

When one or more items are cued for airplay, they appear in the track list without timestamp.  The first one has a button 'play now'.  When the DJ presses 'play now', the item is timestamped, and the 'play now' button moves to the next cued item, if any.

Cued items can be resequenced before airplay by grabbing the drag handle and repositioning them as desired.  The earliest one in sequence gets the 'play now' button.

In addition, playlists which are uploaded without timestamp have the first entry flagged with 'play now' during live airplay.  A DJ can assign timestamps to each entry in turn by pressing 'play now' as it plays.

Screenshots:

1. The refreshed dropdown (note the new entry 'Mic Break'):
![Screenshot from 2022-06-08 11-32-20](https://user-images.githubusercontent.com/6860356/172866074-11ab29a1-2605-40bd-8207-2d046cdc60a1.png)

2. New action buttons 'Add' and 'Add and Play'.  Both are active as there are no cued tracks.  We press 'Add':
![Screenshot from 2022-06-08 11-33-19](https://user-images.githubusercontent.com/6860356/172866192-a6abd5f7-dd13-4911-b8ad-ff2acfed2f91.png)

3. Cueing second track.  Note 'Add and Play' is disabled on account of the cued track:
![Screenshot from 2022-06-08 11-43-59](https://user-images.githubusercontent.com/6860356/172866241-aada486e-b1cf-4dd8-90e6-90d1535f0d28.png)

4. After we press 'Add' in the previous step:
![Screenshot from 2022-06-09 15-08-55](https://user-images.githubusercontent.com/6860356/172867528-79613826-3c62-4a08-b5be-efc9105833e2.png)

