### PR TITLE
PlaylistObserver: support single handler for multiple types

### DIFF
--- a/controllers/PushServer.php
+++ b/controllers/PushServer.php
@@ -137,11 +137,7 @@ class NowAiringServer implements MessageComponentInterface {
                     $spin = $entry->asArray();
                     $spin['artist'] = PlaylistEntry::swapNames($spin['artist']);
                     $event = $spin;
-                })->onComment(function($entry) use(&$event) {
-                    $event = null;
-                })->onLogEvent(function($entry) use(&$event) {
-                    $event = null;
-                })->onSetSeparator(function($entry) use(&$event) {
+                })->on('comment logEvent setSeparator', function($entry) use(&$event) {
                     $event = null;
                 }), 0, OnNowFilter::class);
         }

--- a/engine/PlaylistObserver.php
+++ b/engine/PlaylistObserver.php
@@ -55,6 +55,9 @@ namespace ZK\Engine;
  *    on('comment logEvent', function($entry) {...})...
  *
  * In this case, the function will be installed for all the specified types.
+ *
+ * If the lambda function returns a trueish value, the observer will
+ * stop iteration.
  * 
  */
 class PlaylistObserver {
@@ -72,7 +75,7 @@ class PlaylistObserver {
     /**
      * install lambda function to handle comment entries
      */
-    public function onComment($comment) {
+    public function onComment(\Closure $comment) {
         $this->comment = $comment;
         return $this;
     }
@@ -80,7 +83,7 @@ class PlaylistObserver {
     /**
      * install lambda function to handle log event entries
      */
-    public function onLogEvent($logEvent) {
+    public function onLogEvent(\Closure $logEvent) {
         $this->logEvent = $logEvent;
         return $this;
     }
@@ -88,7 +91,7 @@ class PlaylistObserver {
     /**
      * install lambda function to handle set separator entries
      */
-    public function onSetSeparator($setSeparator) {
+    public function onSetSeparator(\Closure $setSeparator) {
         $this->setSeparator = $setSeparator;
         return $this;
     }
@@ -96,7 +99,7 @@ class PlaylistObserver {
     /**
      * install lambda function to handle spin entries
      */
-    public function onSpin($spin) {
+    public function onSpin(\Closure $spin) {
         $this->spin = $spin;
         return $this;
     }
@@ -104,7 +107,7 @@ class PlaylistObserver {
     /**
      * install lambda function to handle one or more entry types
      */
-    public function on($types, $fn) {
+    public function on(string $types, \Closure $fn) {
         foreach(explode(' ', $types) as $type)
             $this->$type = $fn;
 
@@ -112,42 +115,40 @@ class PlaylistObserver {
     }
     
     private function observeComment($entry) {
-        if($this->comment)
-            $this->comment($entry);
+        return $this->comment ? $this->comment($entry) : null;
     }
 
     private function observeLogEvent($entry) {
-        if($this->logEvent)
-            $this->logEvent($entry);
+        return $this->logEvent ? $this->logEvent($entry) : null;
     }
 
     private function observeSetSeparator($entry) {
-        if($this->setSeparator)
-            $this->setSeparator($entry);
+        return $this->setSeparator ? $this->setSeparator($entry) : null;
     }
 
     private function observeSpin($entry) {
-        if($this->spin)
-            $this->spin($entry);
+        return $this->spin ? $this->spin($entry) : null;
     }
 
     /**
      * observe the specified PlaylistEntry
      */
     public function observe(PlaylistEntry $entry) {
+        $retVal = null;
         switch($entry->getType()) {
         case PlaylistEntry::TYPE_SPIN:
-            $this->observeSpin($entry);
+            $retVal = $this->observeSpin($entry);
             break;
         case PlaylistEntry::TYPE_LOG_EVENT:
-            $this->observeLogEvent($entry);
+            $retVal = $this->observeLogEvent($entry);
             break;
         case PlaylistEntry::TYPE_COMMENT:
-            $this->observeComment($entry);
+            $retVal = $this->observeComment($entry);
             break;
         case PlaylistEntry::TYPE_SET_SEPARATOR:
-            $this->observeSetSeparator($entry);
+            $retVal = $this->observeSetSeparator($entry);
             break;
         }
+        return $retVal;
     }
 }

--- a/engine/PlaylistObserver.php
+++ b/engine/PlaylistObserver.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2019 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2022 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -45,6 +45,16 @@ namespace ZK\Engine;
  *       onSpin
  *
  * One or more onXXX functions may be chained to the PlaylistObserver instance.
+ *
+ * Alternatively, you may use the form:
+ *
+ *    on(types, function)
+ *
+ * where 'types' is a space-separated string of entry types; e.g.,
+ *
+ *    on('comment logEvent', function($entry) {...})...
+ *
+ * In this case, the function will be installed for all the specified types.
  * 
  */
 class PlaylistObserver {
@@ -58,7 +68,7 @@ class PlaylistObserver {
         if(isset($this->$method) && $this->$method instanceof \Closure)
             return call_user_func_array($this->$method, $args);
     }
-    
+
     /**
      * install lambda function to handle comment entries
      */
@@ -82,12 +92,22 @@ class PlaylistObserver {
         $this->setSeparator = $setSeparator;
         return $this;
     }
-    
+
     /**
      * install lambda function to handle spin entries
      */
     public function onSpin($spin) {
         $this->spin = $spin;
+        return $this;
+    }
+
+    /**
+     * install lambda function to handle one or more entry types
+     */
+    public function on($types, $fn) {
+        foreach(explode(' ', $types) as $type)
+            $this->$type = $fn;
+
         return $this;
     }
     

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -509,8 +509,8 @@ class PlaylistImpl extends DBO implements IPlaylist {
         $tracks = $this->getTracks($playlist, $desc);
         if($tracks && $filter)
             $tracks = new $filter($tracks);
-        while($tracks && ($track = $tracks->fetch()))
-            $observer->observe(new PlaylistEntry($track));
+        while($tracks && ($track = $tracks->fetch()) &&
+                !$observer->observe(new PlaylistEntry($track)));
         return $tracks;
     }
 

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -895,22 +895,7 @@ class Playlists extends MenuItem {
                     "break" => false,
                     "id" => $editTrack
                 ];
-                $observer = (new PlaylistObserver())->onComment(function($entry) use(&$time) {
-                    if($time['break']) return;
-                    $time['break'] = $time['id'] === $entry->getId();
-                    $created = $entry->getCreatedTime();
-                    if($created) $time['created'] = $created;
-                })->onLogEvent(function($entry) use(&$time) {
-                    if($time['break']) return;
-                    $time['break'] = $time['id'] === $entry->getId();
-                    $created = $entry->getCreatedTime();
-                    if($created) $time['created'] = $created;
-                })->onSetSeparator(function($entry) use(&$time) {
-                    if($time['break']) return;
-                    $time['break'] = $time['id'] === $entry->getId();
-                    $created = $entry->getCreatedTime();
-                    if($created) $time['created'] = $created;
-                })->onSpin(function($entry) use(&$time) {
+                $observer = (new PlaylistObserver())->on('comment logEvent setSeparator spin', function($entry) use(&$time) {
                     if($time['break']) return;
                     $time['break'] = $time['id'] === $entry->getId();
                     $created = $entry->getCreatedTime();

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -892,14 +892,12 @@ class Playlists extends MenuItem {
                 $window = $api->getTimestampWindow($playlistId);
                 $time = [
                     "created" => null,
-                    "break" => false,
                     "id" => $editTrack
                 ];
                 $observer = (new PlaylistObserver())->on('comment logEvent setSeparator spin', function($entry) use(&$time) {
-                    if($time['break']) return;
-                    $time['break'] = $time['id'] === $entry->getId();
                     $created = $entry->getCreatedTime();
                     if($created) $time['created'] = $created;
+                    return $time['id'] === $entry->getId();
                 });
                 $api->getTracksWithObserver($playlistId, $observer);
                 if($time['created'])


### PR DESCRIPTION
The PlaylistObserver pattern currently requires that a handler be installed for each event type of interest.

This PR extends PlaylistObserver to support use of a single handler for multiple types.

In this way, if the handlers are the same for multiple event types, they can be collapsed into a single handler.

In addition, this PR adds the ability for a handler to terminate iteration.