### PR TITLE
Optimise track update

### DIFF
--- a/engine/impl/Editor.php
+++ b/engine/impl/Editor.php
@@ -180,7 +180,7 @@ class EditorImpl extends DBO implements IEditor {
                                      $album["tag"] != $this->getNextTag());
     
         // Tracks
-        if($tracks || $newAlbum) {
+        if($tracks) {
             // We delete from both tracknames and colltracknames
             // because someone could have toggled the 'compilation'
             // checkbox; this ensures no stale track names remain
@@ -194,17 +194,17 @@ class EditorImpl extends DBO implements IEditor {
             $stmt->bindValue(1, $album["tag"]);
             $stmt->execute();
 
-            for($i=1; $tracks && array_key_exists($i, $tracks); $i++) {
-                $trackRow = $tracks[$i];
+            $query = $iscoll ?
+                "INSERT INTO colltracknames (tag, seq, track, url, artist) VALUES (?, ?, ?, ?, ?)" :
+                "INSERT INTO tracknames (tag, seq, track, url) VALUES (?, ?, ?, ?)";
+            $stmt = $this->prepare($query);
+            $stmt->bindValue(1, $album["tag"]);
+
+            foreach($tracks as $seq => $trackRow) {
                 $trackName = mb_substr(trim($trackRow['track']), 0, PlaylistEntry::MAX_FIELD_LENGTH);
                 $trackUrl = trim($trackRow['url'] ?? "");
-                $query = "INSERT INTO tracknames (tag, seq, track, url) VALUES (?, ?, ?, ?)";
-                if ($iscoll)
-                    $query = "INSERT INTO colltracknames (tag, seq, track, url, artist) VALUES (?, ?, ?, ?, ?)";
 
-                $stmt = $this->prepare($query);
-                $stmt->bindValue(1, $album["tag"]);
-                $stmt->bindValue(2, $i);
+                $stmt->bindValue(2, $seq);
                 $stmt->bindValue(3, $trackName);
                 $stmt->bindValue(4, $trackUrl);
                 if ($iscoll)

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -500,6 +500,7 @@ class Editor extends MenuItem {
         for($i=1; isset($_POST["track" . $i]); $i++) {
             $this->skipVar("track" . $i);
             $this->skipVar("artist" . $i);
+            $this->skipVar("trackUrl" . $i);
         }
     }
            
@@ -1043,7 +1044,7 @@ class Editor extends MenuItem {
                 $this->skipVar("artist".$trackNum);
             }
 
-            $url = $_POST["url$trackNum"];
+            $url = $_POST["trackUrl$trackNum"];
             echo "<TD COLSPAN=2><INPUT class='urlValue' style='$cellWidth' value='${url}' NAME='trackUrl$trackNum' TYPE='url' maxlength=" . IEditor::MAX_PLAYABLE_URL_LENGTH . " data-track='$trackNum' /></TD>";
 
             echo "</TR>\n";
@@ -1058,8 +1059,9 @@ class Editor extends MenuItem {
             $tracks = Engine::api(ILibrary::class)->search($isCollection?ILibrary::COLL_KEY:ILibrary::TRACK_KEY, 0, 2000, $_REQUEST["seltag"]);
             foreach($tracks as $row) {
                 $this->emitHidden("track".$row["seq"], $row["track"]);
-                $_POST["url".$row["seq"]] = $row["url"];
+                $this->emitHidden("trackUrl".$row["seq"], $row["url"]);
                 $_POST["track".$row["seq"]] = $row["track"];
+                $_POST["trackUrl".$row["seq"]] = $row["url"];
                 if($isCollection) {
                     $this->emitHidden("artist" . $row["seq"], $row["artist"]);
                     $_POST["artist".$row["seq"]] = $row["artist"];


### PR DESCRIPTION
This PR optimises track insert/update.

In addition, it includes a fix to the Library Editor where if track validation fails, it will correctly reload any already populated track URL fields.
