### PR TITLE
Library Editor: Fix album/label chooser for mobile

### DIFF
--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -1379,7 +1379,7 @@ ul.listbox {
 }
 ul.listbox li {
     margin: 0;
-    padding: 2px;
+    padding: 1px 2px;
     white-space: nowrap;
     overflow-x: hidden;
     text-overflow: ellipsis;

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -1117,14 +1117,17 @@ div.toggle-time-entry div {
     height: 10px;
 }
 
-.playlist-accordion.ui-accordion {
-    height: 520px;
+.no-text-select {
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     -khtml-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
+}
+
+.playlist-accordion.ui-accordion {
+    height: 520px;
 }
 .playlist-accordion.ui-accordion .ui-accordion-header {
     color: #d83d04;

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -331,7 +331,7 @@ td.label-form {
     background-color: #2530a7;
 }
 .editorChooser {
-    width: 220px;
+    width: 218px;
     border-width: 1px;
     overflow: hidden;
     scrollbar-width: none;
@@ -1369,6 +1369,22 @@ ul.pagination li a {
     display: block;
 }
 
+ul.listbox {
+    list-style-type: none;
+    border: 1px solid #ccc;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    cursor: default;
+}
+ul.listbox li {
+    margin: 0;
+    padding: 2px;
+    white-space: nowrap;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+}
+
 .fxtime {
     font-family: monospace;
 }
@@ -1398,6 +1414,7 @@ ul.pagination li a {
 .ui-autocomplete.ui-widget .ui-menu-item {
     cursor: default;
 }
+ul.listbox .state-active,
 .ui-autocomplete .ui-menu-item-wrapper.ui-state-active {
     color: #000;
     background: #ccc;

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -336,7 +336,8 @@ td.label-form {
     overflow: hidden;
     scrollbar-width: none;
 }
-.editorChooser:focus {
+.editorChooser:focus-visible {
+    box-shadow: -2px -18px 0 0 #536779, 2px 18px 0 0 #536779, -2px 18px 0 0 #536779, 2px -18px 0 0 #536779;
     outline: 0;
 }
 

--- a/js/editor.album.js
+++ b/js/editor.album.js
@@ -154,6 +154,12 @@ $().ready(function() {
     $("#coll").click(function(e) {
         onSearch(list, e);
     });
-    $("#bup").click(scrollUp);
-    $("#bdown").click(scrollDown);
+    $("#bup").on('click', function() {
+        $("#list").focus();
+        return scrollUp();
+    });
+    $("#bdown").on('click', function() {
+        $("#list").focus();
+        return scrollDown();
+    });
 });

--- a/js/editor.album.js
+++ b/js/editor.album.js
@@ -49,7 +49,7 @@ function paginateAlbums(op, url) {
             items.forEach(function(obj) {
                 var option = $('<li>');
                 option.text(obj.attributes.artist)
-                    .on('click', function() {
+                    .on('mousedown', function() {
                         setSelectedIndex(list, $(this).index());
                         changeList(list);
                     });

--- a/js/editor.album.js
+++ b/js/editor.album.js
@@ -139,27 +139,4 @@ $().ready(function() {
         getAlbums('page[before]=');
         $("#search").focus();
     }
-
-    var list = $("#list").on('keyup', function(e) {
-        onSearch(list, e);
-    });
-    $("#search").on('keyup', function(e) {
-        onSearch(list, e);
-    }).on('keypress', function(e) {
-        return e.keyCode != 13;
-    }).on('cut paste', function() {
-        // run on next tick, as pasted data is not yet in the field
-        setTimeout(onSearchNow, 0);
-    });
-    $("#coll").click(function(e) {
-        onSearch(list, e);
-    });
-    $("#bup").on('click', function() {
-        $("#list").focus();
-        return scrollUp();
-    });
-    $("#bdown").on('click', function() {
-        $("#list").focus();
-        return scrollDown();
-    });
 });

--- a/js/editor.album.js
+++ b/js/editor.album.js
@@ -71,6 +71,10 @@ function paginateAlbums(op, url) {
                 }
             });
 
+            var delta = $("#list-size").val() - items.length;
+            for(var i=0; i<delta; i++)
+                list.append($("<li>").html("&nbsp;"));
+
             switch(op) {
             case 'prevLine':
             case 'prevPage':

--- a/js/editor.album.js
+++ b/js/editor.album.js
@@ -47,8 +47,12 @@ function paginateAlbums(op, url) {
             links = response.links;
             items = response.data;
             items.forEach(function(obj) {
-                var option = $('<option/>');
-                option.val(obj.id).text(obj.attributes.artist);
+                var option = $('<li>');
+                option.text(obj.attributes.artist)
+                    .on('click', function() {
+                        setSelectedIndex(list, $(this).index());
+                        changeList(list);
+                    });
                 list.append(option);
                 obj.attributes.tag = obj.id;
                 if(obj.relationships != null) {
@@ -70,18 +74,18 @@ function paginateAlbums(op, url) {
             switch(op) {
             case 'prevLine':
             case 'prevPage':
-                list.prop('selectedIndex', 0);
+                setSelectedIndex(list, 0);
                 break;
             case 'nextLine':
             case 'nextPage':
-                list.prop('selectedIndex', items.length - 1);
+                setSelectedIndex(list, items.length - 1);
                 break;
             default:
-                list.prop('selectedIndex', items.length / 2);
+                setSelectedIndex(list, items.length / 2);
                 break;
             }
 
-            changeList();
+            changeList(list);
         },
         error: function (jqXHR, textStatus, errorThrown) {
             var json = JSON.parse(jqXHR.responseText);
@@ -132,14 +136,20 @@ $().ready(function() {
         $("#search").focus();
     }
 
-    $("#search").keyup(function(e) { onSearch(document.forms[0], e); }).
-        keypress(function(e) { return e.keyCode != 13; }).
-        on('cut paste', function() {
-            // run on next tick, as pasted data is not yet in the field
-            setTimeout(onSearchNow, 0);
-        });
-    $("#coll").click(function(e) { onSearch(document.forms[0], e); });
+    var list = $("#list").on('keyup', function(e) {
+        onSearch(list, e);
+    });
+    $("#search").on('keyup', function(e) {
+        onSearch(list, e);
+    }).on('keypress', function(e) {
+        return e.keyCode != 13;
+    }).on('cut paste', function() {
+        // run on next tick, as pasted data is not yet in the field
+        setTimeout(onSearchNow, 0);
+    });
+    $("#coll").click(function(e) {
+        onSearch(list, e);
+    });
     $("#bup").click(scrollUp);
     $("#bdown").click(scrollDown);
-    $("#list").keydown(upDown).change(changeList);
 });

--- a/js/editor.common.js
+++ b/js/editor.common.js
@@ -94,60 +94,60 @@ function upDown(list, e) {
     return true;
 }
 
-function onSearch(list, e) {
-    if(e.type == 'keyup' && (e.keyCode == 33 || e.keyCode == 34 ||
-                             e.keyCode == 38 || e.keyCode == 40 ||
-                             e.keyCode == 9 || e.keyCode == 16)) {
-        switch(e.keyCode) {
-        case 9:
-        case 16:
-            // tab/shift
-            return;
-        case 33:
-            // page up
-            if(getSelectedIndex(list) == 0) {
-                upDown(list, e);
-                return;
-            }
-            setSelectedIndex(list, 0);
-            break;
-        case 38:
-            // line up
-            if(getSelectedIndex(list) == 0) {
-                upDown(list, e);
-                return;
-            }
-            setSelectedIndex(list, getSelectedIndex(list) - 1);
-            break;
-        case 34:
-            // page down
-            if(getSelectedIndex(list) == items.length - 1) {
-                upDown(list, e);
-                return;
-            }
-            setSelectedIndex(list, items.length - 1);
-            break;
-        case 40:
-            // line down
-            if(getSelectedIndex(list) == items.length - 1) {
-                upDown(list, e);
-                return;
-            }
-            setSelectedIndex(list, getSelectedIndex(list) + 1);
-            break;
-        }
-        changeList(list);
-        e.preventDefault();
-        return;
+/**
+ * returns true if key changes input value, undefined otherwise
+ */
+function onKeyDown(list, e) {
+    if(timer) {
+        clearTimeout(timer);
+        timer = null;
     }
 
-    if(timer)
-        clearTimeout(timer);
+    switch(e.keyCode) {
+    case 33:
+        // page up
+        if(getSelectedIndex(list) == 0) {
+            upDown(list, e);
+            return;
+        }
+        setSelectedIndex(list, 0);
+        break;
+    case 38:
+        // line up
+        if(getSelectedIndex(list) == 0) {
+            upDown(list, e);
+            return;
+        }
+        setSelectedIndex(list, getSelectedIndex(list) - 1);
+        break;
+    case 34:
+        // page down
+        if(getSelectedIndex(list) == items.length - 1) {
+            upDown(list, e);
+            return;
+        }
+        setSelectedIndex(list, items.length - 1);
+        break;
+    case 40:
+        // line down
+        if(getSelectedIndex(list) == items.length - 1) {
+            upDown(list, e);
+            return;
+        }
+        setSelectedIndex(list, getSelectedIndex(list) + 1);
+        break;
+    case 9:
+    case 16:
+    case 37:
+    case 39:
+        // arrow left, arrow right, tab, shift
+        return;
+    default:
+        return true;
+    }
 
-    timer = setTimeout(function() {
-        timer = null;
-        onSearchNow();
-    }, 250);
+    changeList(list);
+    e.preventDefault();
 }
 
 $().ready(function() {
@@ -338,6 +338,40 @@ $().ready(function() {
                 }
             }
         }
+    });
+
+    var list = $("#list").on('keydown', function(e) {
+        onKeyDown(list, e);
+    });
+
+    $("#search").on('keydown', function(e) {
+        if(onKeyDown(list, e)) {
+            // input has changed; schedule a search
+            timer = setTimeout(function() {
+                timer = null;
+                onSearchNow();
+            }, 250);
+        }
+    }).on('keypress', function(e) {
+        return e.keyCode != 13;
+    }).on('cut paste', function() {
+        if(!timer) {
+            // run on next tick, as pasted data is not yet in the field
+            setTimeout(onSearchNow, 0);
+        }
+    });
+
+    $("#coll").click(function() {
+        onSearchNow();
+    });
+
+    $("#bup").on('click', function() {
+        list.focus();
+        return scrollUp();
+    });
+    $("#bdown").on('click', function() {
+        list.focus();
+        return scrollDown();
     });
 
     $("*[data-focus]").focus();

--- a/js/editor.common.js
+++ b/js/editor.common.js
@@ -136,13 +136,16 @@ function onKeyDown(list, e) {
         }
         setSelectedIndex(list, getSelectedIndex(list) + 1);
         break;
-    case 9:
-    case 16:
-    case 37:
-    case 39:
-        // arrow left, arrow right, tab, shift
+    case 9:  // tab
+    case 16: // shift
+    case 35: // end
+    case 36: // home
+    case 37: // arrow left
+    case 39: // arrow right
+        // key does not change the input
         return;
     default:
+        // all keys not otherwise handled change the input
         return true;
     }
 

--- a/js/editor.common.js
+++ b/js/editor.common.js
@@ -136,11 +136,13 @@ function onSearch(list, e) {
         return;
     }
 
-    if(timer) {
+    if(timer)
         clearTimeout(timer);
+
+    timer = setTimeout(function() {
         timer = null;
-    }
-    timer = setTimeout(onSearchNow, 250);
+        onSearchNow();
+    }, 250);
 }
 
 $().ready(function() {

--- a/js/editor.common.js
+++ b/js/editor.common.js
@@ -96,8 +96,13 @@ function upDown(list, e) {
 
 function onSearch(list, e) {
     if(e.type == 'keyup' && (e.keyCode == 33 || e.keyCode == 34 ||
-                             e.keyCode == 38 || e.keyCode == 40)) {
+                             e.keyCode == 38 || e.keyCode == 40 ||
+                             e.keyCode == 9 || e.keyCode == 16)) {
         switch(e.keyCode) {
+        case 9:
+        case 16:
+            // tab/shift
+            return;
         case 33:
             // page up
             if(getSelectedIndex(list) == 0) {

--- a/js/editor.common.js
+++ b/js/editor.common.js
@@ -78,17 +78,16 @@ function changeList(list) {
 
 function upDown(list, e) {
     var index = getSelectedIndex(list);
-    var length = list.find('li').length;
     if(e.keyCode == 33 && index == 0) {
         // page up
         scrollUp();
-    } else if(e.keyCode == 34 && index == length-1) {
+    } else if(e.keyCode == 34 && index == items.length - 1) {
         // page down
         scrollDown();
     } else if(e.keyCode == 38 && index == 0) {
         // line up
         lineUp();
-    } else if(e.keyCode == 40 && index == length-1) {
+    } else if(e.keyCode == 40 && index == items.length - 1) {
         // line down
         lineDown();
     }
@@ -98,7 +97,6 @@ function upDown(list, e) {
 function onSearch(list, e) {
     if(e.type == 'keyup' && (e.keyCode == 33 || e.keyCode == 34 ||
                              e.keyCode == 38 || e.keyCode == 40)) {
-        var length = list.find('li').length;
         switch(e.keyCode) {
         case 33:
             // page up
@@ -118,15 +116,15 @@ function onSearch(list, e) {
             break;
         case 34:
             // page down
-            if(getSelectedIndex(list) == length - 1) {
+            if(getSelectedIndex(list) == items.length - 1) {
                 upDown(list, e);
                 return;
             }
-            setSelectedIndex(list, length - 1);
+            setSelectedIndex(list, items.length - 1);
             break;
         case 40:
             // line down
-            if(getSelectedIndex(list) == length - 1) {
+            if(getSelectedIndex(list) == items.length - 1) {
                 upDown(list, e);
                 return;
             }

--- a/js/editor.common.js
+++ b/js/editor.common.js
@@ -35,15 +35,24 @@
  *
  */
 
-var items, links;
+var items, links, timer;
 
 function htmlify(s) {
     return s != null?s.replace(/&/g, '&amp;').replace(/</g, '&lt;'):'';
 }
 
-function changeList() {
-    var list = $("#list");
-    var index = list.prop('selectedIndex');
+function getSelectedIndex(list) {
+    return list.find('.state-active').index();
+}
+
+function setSelectedIndex(list, idx) {
+    list.find('li')
+        .removeClass('state-active')
+        .eq(idx).addClass('state-active');
+}
+
+function changeList(list) {
+    var index = getSelectedIndex(list);
     changeSel(index);
     for(var key in items[0].attributes) {
         var field = $("#"+key);
@@ -67,10 +76,9 @@ function changeList() {
     }
 }
 
-function upDown(e) {
-    var list = $("#list");
-    var index = list.prop('selectedIndex');
-    var length = list.find("option").length;
+function upDown(list, e) {
+    var index = getSelectedIndex(list);
+    var length = list.find('li').length;
     if(e.keyCode == 33 && index == 0) {
         // page up
         scrollUp();
@@ -87,52 +95,54 @@ function upDown(e) {
     return true;
 }
 
-function onSearch(sync, e) {
+function onSearch(list, e) {
     if(e.type == 'keyup' && (e.keyCode == 33 || e.keyCode == 34 ||
                              e.keyCode == 38 || e.keyCode == 40)) {
+        var length = list.find('li').length;
         switch(e.keyCode) {
         case 33:
             // page up
-            if(sync.list.selectedIndex == 0) {
-                upDown(e);
+            if(getSelectedIndex(list) == 0) {
+                upDown(list, e);
                 return;
             }
-            sync.list.selectedIndex = 0;
+            setSelectedIndex(list, 0);
             break;
         case 38:
             // line up
-            if(sync.list.selectedIndex == 0) {
-                upDown(e);
+            if(getSelectedIndex(list) == 0) {
+                upDown(list, e);
                 return;
             }
-            sync.list.selectedIndex--;
+            setSelectedIndex(list, getSelectedIndex(list) - 1);
             break;
         case 34:
             // page down
-            if(sync.list.selectedIndex == sync.list.length-1) {
-                upDown(e);
+            if(getSelectedIndex(list) == length - 1) {
+                upDown(list, e);
                 return;
             }
-            sync.list.selectedIndex = sync.list.length-1;
+            setSelectedIndex(list, length - 1);
             break;
         case 40:
             // line down
-            if(sync.list.selectedIndex == sync.list.length-1) {
-                upDown(e);
+            if(getSelectedIndex(list) == length - 1) {
+                upDown(list, e);
                 return;
             }
-            sync.list.selectedIndex++;
+            setSelectedIndex(list, getSelectedIndex(list) + 1);
             break;
         }
-        changeList();
+        changeList(list);
+        e.preventDefault();
         return;
     }
 
-    if(sync.Timer) {
-        clearTimeout(sync.Timer);
-        sync.Timer = null;
+    if(timer) {
+        clearTimeout(timer);
+        timer = null;
     }
-    sync.Timer = setTimeout('onSearchNow()', 250);
+    timer = setTimeout(onSearchNow, 250);
 }
 
 $().ready(function() {

--- a/js/editor.label.js
+++ b/js/editor.label.js
@@ -54,6 +54,10 @@ function paginateLabels(op, url) {
                 obj.attributes.pubkey = obj.id;
             });
 
+            var delta = $("#list-size").val() - items.length;
+            for(var i=0; i<delta; i++)
+                list.append($("<li>").html("&nbsp;"));
+
             switch(op) {
             case 'prevLine':
             case 'prevPage':

--- a/js/editor.label.js
+++ b/js/editor.label.js
@@ -44,8 +44,12 @@ function paginateLabels(op, url) {
             links = response.links;
             items = response.data;
             items.forEach(function(obj) {
-                var option = $('<option/>');
-                option.val(obj.id).text(obj.attributes.name);
+                var option = $('<li>');
+                option.text(obj.attributes.name)
+                    .on('click', function() {
+                        setSelectedIndex(list, $(this).index());
+                        changeList(list);
+                    });
                 list.append(option);
                 obj.attributes.pubkey = obj.id;
             });
@@ -53,18 +57,18 @@ function paginateLabels(op, url) {
             switch(op) {
             case 'prevLine':
             case 'prevPage':
-                list.prop('selectedIndex', 0);
+                setSelectedIndex(list, 0);
                 break;
             case 'nextLine':
             case 'nextPage':
-                list.prop('selectedIndex', items.length - 1);
+                setSelectedIndex(list, items.length - 1);
                 break;
             default:
-                list.prop('selectedIndex', items.length / 2);
+                setSelectedIndex(list, items.length / 2);
                 break;
             }
 
-            changeList();
+            changeList(list);
         },
         error: function (jqXHR, textStatus, errorThrown) {
             var json = JSON.parse(jqXHR.responseText);
@@ -112,13 +116,17 @@ $().ready(function() {
         $("#search").focus();
     }
 
-    $("#search").keyup(function(e) { onSearch(document.forms[0], e); }).
-        keypress(function(e) { return e.keyCode != 13; }).
-        on('cut paste', function() {
-            // run on next tick, as pasted data is not yet in the field
-            setTimeout(onSearchNow, 0);
-        });
+    var list = $("#list").on('keyup', function(e) {
+        onSearch(list, e);
+    });
+    $("#search").on('keyup', function(e) {
+        onSearch(list, e);
+    }).on('keypress', function(e) {
+        return e.keyCode != 13;
+    }).on('cut paste', function() {
+        // run on next tick, as pasted data is not yet in the field
+        setTimeout(onSearchNow, 0);
+    });
     $("#bup").click(scrollUp);
     $("#bdown").click(scrollDown);
-    $("#list").keydown(upDown).change(changeList);
 });

--- a/js/editor.label.js
+++ b/js/editor.label.js
@@ -131,6 +131,12 @@ $().ready(function() {
         // run on next tick, as pasted data is not yet in the field
         setTimeout(onSearchNow, 0);
     });
-    $("#bup").click(scrollUp);
-    $("#bdown").click(scrollDown);
+    $("#bup").on('click', function() {
+        $("#list").focus();
+        return scrollUp();
+    });
+    $("#bdown").on('click', function() {
+        $("#list").focus();
+        return scrollDown();
+    });
 });

--- a/js/editor.label.js
+++ b/js/editor.label.js
@@ -46,7 +46,7 @@ function paginateLabels(op, url) {
             items.forEach(function(obj) {
                 var option = $('<li>');
                 option.text(obj.attributes.name)
-                    .on('click', function() {
+                    .on('mousedown', function() {
                         setSelectedIndex(list, $(this).index());
                         changeList(list);
                     });

--- a/js/editor.label.js
+++ b/js/editor.label.js
@@ -119,24 +119,4 @@ $().ready(function() {
         getLabels('page[before]=');
         $("#search").focus();
     }
-
-    var list = $("#list").on('keyup', function(e) {
-        onSearch(list, e);
-    });
-    $("#search").on('keyup', function(e) {
-        onSearch(list, e);
-    }).on('keypress', function(e) {
-        return e.keyCode != 13;
-    }).on('cut paste', function() {
-        // run on next tick, as pasted data is not yet in the field
-        setTimeout(onSearchNow, 0);
-    });
-    $("#bup").on('click', function() {
-        $("#list").focus();
-        return scrollUp();
-    });
-    $("#bdown").on('click', function() {
-        $("#list").focus();
-        return scrollDown();
-    });
 });

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -478,7 +478,6 @@ class Editor extends MenuItem {
         $this->skipVar("go");
         $this->skipVar("search");
         $this->skipVar("coll");
-        $this->skipVar("list");
         $this->skipVar("up");
         $this->skipVar("down");
         $this->skipVar("seltag");
@@ -532,7 +531,6 @@ class Editor extends MenuItem {
         $this->skipVar("format");
         $this->skipVar("location");
         $this->skipVar("bin");
-        $this->skipVar("list");
         $this->skipVar("up");
         $this->skipVar("down");
         $this->skipVar("edit");
@@ -562,7 +560,6 @@ class Editor extends MenuItem {
         $this->skipVar("bdown_y");
         $this->skipVar("go");
         $this->skipVar("search");
-        $this->skipVar("list");
         $this->skipVar("up");
         $this->skipVar("down");
         $this->skipVar("lnew");
@@ -599,7 +596,6 @@ class Editor extends MenuItem {
         $this->skipVar("attention");
         $this->skipVar("maillist");
         $this->skipVar("mailcount");
-        $this->skipVar("list");
         $this->skipVar("up");
         $this->skipVar("down");
         $this->skipVar("edit");
@@ -612,7 +608,6 @@ class Editor extends MenuItem {
         $this->trackForm();
         $this->skipVar("nextTrack");
         $this->skipVar("more");
-        $this->skipVar("list");
         $this->skipVar("up");
         $this->skipVar("down");
         $this->skipVar("edit");
@@ -773,12 +768,10 @@ class Editor extends MenuItem {
          echo "<TABLE BORDER=0 CELLPADDING=4 CELLSPACING=0 WIDTH='100%'>";
          echo "<TR><TD COLSPAN=2 ALIGN=LEFT><B>Artist or Tag number:</B><BR><INPUT TYPE=TEXT CLASS=text STYLE='width:214px;' NAME=search id='search' VALUE='$osearch' autocomplete=off><BR>\n";
          echo "<SPAN CLASS='sub'>compilation?</SPAN><INPUT TYPE=CHECKBOX NAME=coll" . ($osearch&&$_REQUEST["coll"]?" CHECKED":"") . " id='coll'></TD><TD></TD></TR>\n";
-         echo "<TR><TD COLSPAN=2 ALIGN=LEFT><INPUT NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><BR><SELECT class='editorChooser' NAME=list id='list' SIZE=$this->limit>\n";
-
+         echo "<TR><TD COLSPAN=2 ALIGN=LEFT><INPUT NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><UL tabindex='0' class='listbox editorChooser' id='list'>\n";
          for($i=0; $i<$this->limit; $i++)
-              echo "  <OPTION VALUE=''>\n";
-
-         echo "</SELECT><BR><INPUT NAME='bdown' id='bdown' VALUE='&or;' TYPE='submit' CLASS='editorDown' ></TD>\n";
+             echo "  <LI>&nbsp;\n";
+         echo "</UL><INPUT NAME='bdown' id='bdown' VALUE='&or;' TYPE='submit' CLASS='editorDown' ></TD>\n";
          echo "</TR></TABLE>\n";
          echo "  <INPUT TYPE=HIDDEN id='list-size' VALUE='$this->limit'>\n";
     ?>
@@ -921,14 +914,14 @@ class Editor extends MenuItem {
     private function emitLabelSel() {
          UI::emitJS('js/editor.label.js');
     
-        echo "<TABLE CELLPADDING=5 CELLSPACING=5 WIDTH='100%'><TR><TD VALIGN=TOP WIDTH=230>\n";
+        echo "<TABLE CELLPADDING=5 CELLSPACING=5 WIDTH='100%'><TR><TD VALIGN=TOP WIDTH=220>\n";
         echo "  <INPUT TYPE=HIDDEN NAME=selpubkey id='selpubkey' VALUE='".$_REQUEST["selpubkey"]."'>\n";
         echo "<TABLE BORDER=0 CELLPADDING=4 CELLSPACING=0 WIDTH='100%'>";
         echo "<TR><TD COLSPAN=2 ALIGN=LEFT><B>Label Name:</B><BR><INPUT TYPE=TEXT CLASS=text STYLE='width:214px;' NAME=search id='search' VALUE='$osearch' autocomplete=off></TD></TR>\n";
-        echo "  <TR><TD COLSPAN=2 ALIGN=LEFT><INPUT NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><BR><SELECT class='editorChooser' NAME=list id='list' SIZE=$this->limit>\n";
+        echo "  <TR><TD COLSPAN=2 ALIGN=LEFT><INPUT NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><UL tabindex='0' class='listbox editorChooser' id='list'>\n";
         for($i=0; $i<$this->limit; $i++)
-            echo "  <OPTION VALUE=''>\n";
-        echo "</SELECT><BR><INPUT NAME='bdown' id='bdown' VALUE='&or;' TYPE='submit' CLASS='editorDown'></TD>\n";
+            echo "  <LI>&nbsp;\n";
+        echo "</UL><INPUT NAME='bdown' id='bdown' VALUE='&or;' TYPE='submit' CLASS='editorDown'></TD>\n";
         echo "</TR></TABLE>\n";
         echo "  <INPUT TYPE=HIDDEN id='list-size' VALUE='$this->limit'>\n";
         echo "  <INPUT TYPE=HIDDEN id='seltag' VALUE='".$_REQUEST["seltag"]."'>\n";

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -768,7 +768,7 @@ class Editor extends MenuItem {
          echo "<TABLE BORDER=0 CELLPADDING=4 CELLSPACING=0 WIDTH='100%'>";
          echo "<TR><TD COLSPAN=2 ALIGN=LEFT><B>Artist or Tag number:</B><BR><INPUT TYPE=TEXT CLASS=text STYLE='width:214px;' NAME=search id='search' VALUE='$osearch' autocomplete=off><BR>\n";
          echo "<SPAN CLASS='sub'>compilation?</SPAN><INPUT TYPE=CHECKBOX NAME=coll" . ($osearch&&$_REQUEST["coll"]?" CHECKED":"") . " id='coll'></TD><TD></TD></TR>\n";
-         echo "<TR><TD COLSPAN=2 ALIGN=LEFT><INPUT NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><UL tabindex='0' class='listbox editorChooser' id='list'>\n";
+         echo "<TR><TD COLSPAN=2 ALIGN=LEFT><INPUT NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><UL tabindex='0' class='listbox editorChooser no-text-select' id='list'>\n";
          for($i=0; $i<$this->limit; $i++)
              echo "  <LI>&nbsp;\n";
          echo "</UL><INPUT NAME='bdown' id='bdown' VALUE='&or;' TYPE='submit' CLASS='editorDown' ></TD>\n";
@@ -918,7 +918,7 @@ class Editor extends MenuItem {
         echo "  <INPUT TYPE=HIDDEN NAME=selpubkey id='selpubkey' VALUE='".$_REQUEST["selpubkey"]."'>\n";
         echo "<TABLE BORDER=0 CELLPADDING=4 CELLSPACING=0 WIDTH='100%'>";
         echo "<TR><TD COLSPAN=2 ALIGN=LEFT><B>Label Name:</B><BR><INPUT TYPE=TEXT CLASS=text STYLE='width:214px;' NAME=search id='search' VALUE='$osearch' autocomplete=off></TD></TR>\n";
-        echo "  <TR><TD COLSPAN=2 ALIGN=LEFT><INPUT NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><UL tabindex='0' class='listbox editorChooser' id='list'>\n";
+        echo "  <TR><TD COLSPAN=2 ALIGN=LEFT><INPUT NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><UL tabindex='0' class='listbox editorChooser no-text-select' id='list'>\n";
         for($i=0; $i<$this->limit; $i++)
             echo "  <LI>&nbsp;\n";
         echo "</UL><INPUT NAME='bdown' id='bdown' VALUE='&or;' TYPE='submit' CLASS='editorDown'></TD>\n";

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -768,10 +768,10 @@ class Editor extends MenuItem {
          echo "<TABLE BORDER=0 CELLPADDING=4 CELLSPACING=0 WIDTH='100%'>";
          echo "<TR><TD COLSPAN=2 ALIGN=LEFT><B>Artist or Tag number:</B><BR><INPUT TYPE=TEXT CLASS=text STYLE='width:214px;' NAME=search id='search' VALUE='$osearch' autocomplete=off><BR>\n";
          echo "<SPAN CLASS='sub'>compilation?</SPAN><INPUT TYPE=CHECKBOX NAME=coll" . ($osearch&&$_REQUEST["coll"]?" CHECKED":"") . " id='coll'></TD><TD></TD></TR>\n";
-         echo "<TR><TD COLSPAN=2 ALIGN=LEFT><INPUT NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><UL tabindex='0' class='listbox editorChooser no-text-select' id='list'>\n";
+         echo "<TR><TD COLSPAN=2 ALIGN=LEFT><INPUT tabindex='-1' NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><UL tabindex='0' class='listbox editorChooser no-text-select' id='list'>\n";
          for($i=0; $i<$this->limit; $i++)
              echo "  <LI>&nbsp;\n";
-         echo "</UL><INPUT NAME='bdown' id='bdown' VALUE='&or;' TYPE='submit' CLASS='editorDown' ></TD>\n";
+         echo "</UL><INPUT tabindex='-1' NAME='bdown' id='bdown' VALUE='&or;' TYPE='submit' CLASS='editorDown' ></TD>\n";
          echo "</TR></TABLE>\n";
          echo "  <INPUT TYPE=HIDDEN id='list-size' VALUE='$this->limit'>\n";
     ?>
@@ -918,10 +918,10 @@ class Editor extends MenuItem {
         echo "  <INPUT TYPE=HIDDEN NAME=selpubkey id='selpubkey' VALUE='".$_REQUEST["selpubkey"]."'>\n";
         echo "<TABLE BORDER=0 CELLPADDING=4 CELLSPACING=0 WIDTH='100%'>";
         echo "<TR><TD COLSPAN=2 ALIGN=LEFT><B>Label Name:</B><BR><INPUT TYPE=TEXT CLASS=text STYLE='width:214px;' NAME=search id='search' VALUE='$osearch' autocomplete=off></TD></TR>\n";
-        echo "  <TR><TD COLSPAN=2 ALIGN=LEFT><INPUT NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><UL tabindex='0' class='listbox editorChooser no-text-select' id='list'>\n";
+        echo "  <TR><TD COLSPAN=2 ALIGN=LEFT><INPUT tabindex='-1' NAME='bup' id='bup' VALUE='&and;' TYPE='submit' CLASS='editorUp'><UL tabindex='0' class='listbox editorChooser no-text-select' id='list'>\n";
         for($i=0; $i<$this->limit; $i++)
             echo "  <LI>&nbsp;\n";
-        echo "</UL><INPUT NAME='bdown' id='bdown' VALUE='&or;' TYPE='submit' CLASS='editorDown'></TD>\n";
+        echo "</UL><INPUT tabindex='-1' NAME='bdown' id='bdown' VALUE='&or;' TYPE='submit' CLASS='editorDown'></TD>\n";
         echo "</TR></TABLE>\n";
         echo "  <INPUT TYPE=HIDDEN id='list-size' VALUE='$this->limit'>\n";
         echo "  <INPUT TYPE=HIDDEN id='seltag' VALUE='".$_REQUEST["seltag"]."'>\n";

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -433,7 +433,7 @@ class Playlists extends MenuItem {
         UI::emitJS("js/jquery.fxtime.js");
         UI::emitJS("js/playlists.pick.js");
         ?>
-  <div class='playlist-accordion' style='display: none'>
+  <div class='playlist-accordion no-text-select' style='display: none'>
     <h3>My Playlists</h3>
     <div class='active-playlist-container'>
       <div class='float-error'></div>


### PR DESCRIPTION
The scrollable album/label chooser uses a multi-line html select, which by design does not display multi-line on mobile devices.

This PR replaces the multi-line select with a custom control that mimics the multi-line select behaviour, including click-select and keyboard drive (arrow up/down, page up/down).

There should be no visual nor functional difference to the user (except that, of course, it should now display on mobile in the same way as desktop).