### PR TITLE
Refactor playlist restore to the JSON:API

### DIFF
--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -99,7 +99,7 @@ Example:
 To duplicate playlist 12345 for rebroadcast on 2022-01-01 from 1800-2000:
 
 ````
-POST /api/vi/playlist HTTP/1.1
+POST /api/v1/playlist HTTP/1.1
 X-APIKEY: eb5e0e0b42a84531af5f257ed61505050494788d
 Content-Type: application/vnd.api+json
 
@@ -144,6 +144,24 @@ may be added, updated, or deleted via the [Events Relationship](#events) (see be
 Delete playlist with :id by issuing a DELETE request to
 `api/v1/playlist/:id`.  X-APIKEY authentication required.
 Delete will fail if you do not own the playlist.
+
+### Restore
+
+DELETE soft-deletes a playlist for 30 days prior to its being deleted
+permanently.  During this period, a deleted playlist with id :id can
+be restored by sending a PATCH request to `api/v1/playlist/:id`.
+
+The request body must include a single request object with at minimum
+`type` and `id` members, per [section
+9.2](https://jsonapi.org/format/#crud-updating) of the JSON:API
+specification.
+
+It is NOT necessary to specify attributes in the request body.
+However, as with any PATCH request, you may provide one or more
+attributes to modify the playlist at the same time as the restore.
+
+X-APIKEY is authentication required.  Restore will fail if you do not
+own the playlist.
 
 <a name="events"></a>
 ## Events Relationship

--- a/js/playlists.pick.js
+++ b/js/playlists.pick.js
@@ -320,12 +320,17 @@ $().ready(function(){
     function prestore(id) {
         showUserError('');
 
-        $.ajax({
-            type: 'POST',
-            url: '?action=editListRestore',
+        var postData = {
             data: {
-                playlist: id
+                type: 'show',
+                id: id
             }
+        };
+
+        $.ajax({
+            type: 'PATCH',
+            url: 'api/v1/playlist/' + id,
+            data: JSON.stringify(postData)
         }).done(function(response) {
             loadLists(maxresults, 0, 0);
             loadLists(maxresults, 0, 1);

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -51,7 +51,6 @@ class Playlists extends MenuItem {
         [ "viewListDaysByDate", "handlePlaylistDaysByDate" ],
         [ "viewListsByDate", "handlePlaylistsByDate" ],
         [ "editList", "emitListManager" ],
-        [ "editListRestore", "listManagerRestore" ],
         [ "editListGetHint", "listManagerGetHint" ],
         [ "editListEditor", "emitEditor" ],
         [ "importExport", "emitImportExportList" ],
@@ -386,14 +385,6 @@ class Playlists extends MenuItem {
 
     public function viewDJReviews() {
         $this->newEntity(Search::class)->doSearch();
-    }
-
-    public function listManagerRestore() {
-        $playlistId = $_POST["playlist"] ?? null;
-        if($playlistId && $this->isOwner($playlistId)) {
-            Engine::api(IPlaylist::class)->restorePlaylist($playlistId);
-            PushServer::sendAsyncNotification();
-        }
     }
 
     public function listManagerGetHint() {


### PR DESCRIPTION
This PR extends the JSON:API to support restoration of soft-deleted playlists.

See docs/Playlists.md for details.
