### PR TITLE
Playlist Editor:  Replace `Print View` link with export menu

### DIFF
--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -531,11 +531,14 @@ p.zktitle a {
     background-color: #2530A7;
     line-height: 24px;
     margin-bottom: 4px;
+    display: inline-block;
+    width: 710px;
 }
 .playlistBanner > div {
     font-size: 11pt;
     float: right;
     font-size: 10px;
+    max-height: 24px;
 }
 
 .playlistHdr {
@@ -688,6 +691,54 @@ table.recentAirplay td, .sub {
 
 .pl-form-entry label {
     width: 84px;
+}
+
+.dot-menu-dots {
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: bolder;
+    height: 24px;
+    width: 24px;
+    line-height: 24px;
+    text-align: center;
+    vertical-align: middle;
+    background-color: rgba(0,0,0,0.1);
+    border-radius: 50%;
+}
+.dot-menu-dots:hover {
+    cursor: pointer;
+    text-decoration: none;
+    background-color: rgba(0,0,0,0.2);
+}
+.dot-menu:focus div.dot-menu-content {
+    opacity: 1;
+    z-index: 1;
+}
+.dot-menu-content ul {
+    list-style-type: none;
+    margin: 0;
+    white-space: nowrap;
+}
+.dot-menu-content li {
+    margin: 0;
+    padding: 4px;
+}
+.pl-form-entry .dot-menu-content:before {
+    left: auto;
+    right: 3px;
+}
+.pl-form-entry .dot-menu-content:after {
+    left: auto;
+    right: 4px;
+}
+.pl-form-entry .dot-menu-content {
+    margin-top: 5px;
+    margin-left: -86px;
+    box-shadow: 0 2px 8px 0 rgba(0,0,0,0.2);
+    opacity: 0;
+    display: inherit;
+    z-index: -1;
+    transition: all 0.5s ease-out;
 }
 
 .zk-popup {
@@ -1284,10 +1335,12 @@ div.toggle-time-entry div {
     text-align: center;
     border: none;
 }
+.dot-menu,
 .mobileMenu {
     position: relative;
     display: inline-block;
 }
+.dot-menu-content:before,
 .mobileMenuContent:before {
     content: '';
     position: absolute;
@@ -1297,6 +1350,7 @@ div.toggle-time-entry div {
     border-right: 10px solid transparent;
     border-bottom: 10px solid #ccc;
 }
+.dot-menu-content:after,
 .mobileMenuContent:after {
     content: '';
     position: absolute;
@@ -1307,6 +1361,7 @@ div.toggle-time-entry div {
     border-bottom: 9px solid #fff;
     z-index: 1;
 }
+.dot-menu-content,
 .mobileMenuContent {
     background-color: #f8f8f8;
     border: 1px solid #ccc;

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -738,6 +738,15 @@ $().ready(function(){
 
     $(".playlistTable .grab").mousedown(grabStart);
 
+    // from user.apikey.js
+    function copyToClipboard(text) {
+        var temp = $("<input>");
+        $("body").append(temp);
+        temp.val(text).select();
+        document.execCommand("copy");
+        temp.remove();
+    }
+
     // from home.js
     function localTime(date) {
         var hour = date.getHours();
@@ -973,6 +982,11 @@ $().ready(function(){
 
     // stretch track-play if track-add is hidden
     $("#track-add.zk-hidden").prev().outerWidth($("#track-type-pick").outerWidth());
+
+    $("#copy-link").on('click', function() {
+        copyToClipboard($(this).data('link'));
+        alert('Playlist URL copied to the clipboard!');
+    });
 
     $("*[data-focus]").focus();
 });

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -557,7 +557,17 @@ class Playlists extends MenuItem {
             <label></label><span id='error-msg' class='error'></span>
             <div>
             <?php if(!$editTrack) { ?>
-                <a style='padding-right:4px;' href='#' class='nav pull-right' onClick=window.open('?target=export&amp;playlist=<?php echo $playlistId ?>&amp;format=html')>Print View</a>
+                <div class='dot-menu pull-right' tabindex='-1'>
+                  <div class='dot-menu-dots no-text-select'>&#x22ee;</div>
+                  <div class='dot-menu-content'>
+                    <ul>
+                      <li><a href='#' class='nav' data-link='<?php echo Engine::getBaseURL()."?action=viewListById&amp;playlist=$playlistId"; ?>' id='copy-link' title='copy playlist URL to the clipboard'>Link to Playlist</a>
+                      <li><a href='?target=export&amp;playlist=<?php echo $playlistId; ?>&amp;format=csv' class='nav' download='playlist.csv' title='export playlist as CSV'>Export CSV</a>
+                      <li><a href='api/v1/playlist/<?php echo $playlistId; ?>' class='nav' download='playlist.json' title='export playlist as JSON'>Export JSON</a>
+                      <li><a href='?target=export&amp;playlist=<?php echo $playlistId; ?>&amp;format=html' class='nav' target='_blank' title='printable playlist (opens in new window)'>Print View</a>
+                    </ul>
+                  </div>
+                </div>
             <?php } ?>
                 <label>Type:</label>
                 <select id='track-type-pick'>


### PR DESCRIPTION
This PR adds a new menu to the playlist editor that contains the following items:

* Link to Playlist (from deprecated Link to Playlist menu #344)
* Export CSV (from Import/Export)
* Export JSON (from Import/Export)
* Print View
