### PR TITLE
Simplify foreign airname handling

### DIFF
--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -127,8 +127,6 @@ class Playlists implements RequestHandlerInterface {
         $attrs->set("date", $rec["showdate"]);
         $attrs->set("time", $rec["showtime"]);
         $attrs->set("airname", $rec["airname"] ?? "None");
-        if(isset($rec["fairname"]))
-            $attrs->set("fairname", (boolean)$rec["fairname"]);
         if(isset($rec["expires"]))
             $attrs->set("expires", $rec["expires"]);
 

--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -19,7 +19,6 @@ be found here.
 * date
 * time
 * airname
-* fairname (true if airname does not belong to playlist owner, false otherwise)
 * expires (expiration date, present only for deleted playlists)
 * rebroadcast
 * events -- array of zero or more:

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -47,8 +47,7 @@ class PlaylistImpl extends DBO implements IPlaylist {
     public function getPlaylist($playlist, $withAirname=0) {
         if($withAirname)
             $query = "SELECT l.description, l.showdate, l.showtime, " .
-                     "       a.id, a.airname, l.dj, l.origin, " .
-                     "       IF(l.airname IS NULL OR l.dj = a.dj, false, true) fairname " .
+                     "       a.id, a.airname, l.dj, l.origin " .
                      "FROM lists l LEFT JOIN airnames a " .
                      "ON l.airname = a.id " .
                      "WHERE l.id = ?";
@@ -64,8 +63,7 @@ class PlaylistImpl extends DBO implements IPlaylist {
                                $showDate="", $airname="", $user="", $desc=1, $limit=null) {
         if($withAirname)
             $query = "SELECT l.id, l.showdate, l.showtime, l.description, " .
-                     "a.id airid, a.airname, l.origin, " .
-                     "IF(l.airname IS NULL OR l.dj = a.dj, false, true) fairname " .
+                     "a.id airid, a.airname, l.origin " .
                      "FROM lists l " .
                      "LEFT JOIN airnames a ON l.airname = a.id ";
         else
@@ -121,8 +119,7 @@ class PlaylistImpl extends DBO implements IPlaylist {
         [$date, $hour] = explode(' ', $now->format(self::TIME_FORMAT));
 
         $query = "SELECT l.id, l.showdate, l.showtime, l.description, " .
-                 "a.id airid, a.airname, l.dj, " .
-                 "IF(l.airname IS NULL OR l.dj = a.dj, false, true) fairname " .
+                 "a.id airid, a.airname, l.dj " .
                  "FROM lists l LEFT JOIN airnames a " .
                  "ON l.airname = a.id " .
                  "WHERE l.showdate = ? " .
@@ -978,8 +975,8 @@ class PlaylistImpl extends DBO implements IPlaylist {
     }
 
     public function getListsSelNormal($user, $pos = 0, $count = 10000) {
-        $query = "SELECT l.id, showdate, showtime, description, a.airname, origin, ".
-                 "IF(l.airname IS NULL OR l.dj = a.dj, false, true) fairname FROM lists l " .
+        $query = "SELECT l.id, showdate, showtime, description, a.airname, origin ".
+                 "FROM lists l ".
                  "LEFT JOIN lists_del ON l.id = lists_del.listid ".
                  "LEFT JOIN airnames a ON l.airname = a.id ".
                  "WHERE l.dj=? AND deleted IS NULL ".
@@ -994,9 +991,8 @@ class PlaylistImpl extends DBO implements IPlaylist {
 
     public function getListsSelDeleted($user, $pos = 0, $count = 10000) {
         $query = "SELECT l.id, showdate, showtime, description, ".
-                 "ADDDATE(deleted, 30) expires, a.airname, origin, ".
-                 "IF(l.airname IS NULL OR l.dj = a.dj, false, true) fairname ".
-                 "FROM lists l " .
+                 "ADDDATE(deleted, 30) expires, a.airname, origin ".
+                 "FROM lists l ".
                  "LEFT JOIN lists_del ON l.id = lists_del.listid ".
                  "LEFT JOIN airnames a ON lists_del.airname = a.id ".
                  "WHERE l.dj=? AND deleted IS NOT NULL ".

--- a/js/playlists.pick.js
+++ b/js/playlists.pick.js
@@ -102,7 +102,7 @@ $().ready(function(){
         }).on('mouseenter', function() {
             if(this.offsetWidth < this.scrollWidth && !this.title)
                 this.title = list.attributes.airname;
-        }).data('foreign', list.attributes.fairname).append($("<span>").text(list.attributes.airname)));
+        }).append($("<span>").text(list.attributes.airname)));
         tr.append($("<td>", {
             class: 'date'
         }).data('date', list.attributes.date).append($("<span>").html(localDate(list.attributes.date))));
@@ -223,7 +223,7 @@ $().ready(function(){
         row.data('id', list.id);
         row.find('input.description').val(list.attributes.name);
         row.find('input.airname')
-            .prop('disabled', list.attributes.fairname)
+            .prop('disabled', list.attributes.airname && $(".airnames option[value='" + escQuote(list.attributes.airname) + "' i]").length == 0)
             .val(list.attributes.airname);
         row.find('input.date').val(localDate(list.attributes.date));
         row.find('input.time#start').fxtime('val', time ? localTimeIntl(time[0]) : null);
@@ -243,7 +243,6 @@ $().ready(function(){
             attributes: {
                 name: row.find('input.description').val(),
                 airname: airname.val(),
-                fairname: airname.prop('disabled'),
                 date: date.toISOString().split('T')[0],
                 time: start + '-' + end
             }
@@ -574,7 +573,6 @@ $().ready(function(){
             attributes: {
                 name: row.find('.description span').text(),
                 airname: row.find('.airname span').text(),
-                fairname: row.find('.airname').data('foreign'),
                 date: row.find('.date').data('date'),
                 time: row.find('.start').data('start') + '-' + row.find('.end').data('end')
             }
@@ -616,7 +614,6 @@ $().ready(function(){
             attributes: {
                 name: row.find('.description span').text() + suffix,
                 airname: row.find('.airname span').text(),
-                fairname: row.find('.airname').data('foreign'),
                 date: now[0],
                 time: now[1].replace(':','') + '-'
             }
@@ -687,7 +684,6 @@ $().ready(function(){
             response.data.attributes.name += suffix;
             response.data.attributes.date = now[0];
             response.data.attributes.time = now[1].replace(':','') + '-';
-            response.data.attributes.fairname = $(".airnames option[value='" + escQuote(response.data.attributes.airname) + "']").length == 0;
             var edit = makeEditRow(true);
             setEditRow(edit, response.data);
             $(".active-grid tbody").prepend(edit);


### PR DESCRIPTION
The playlist read-only attribute `fairname` was introduced in service of client-side playlist duplication in My Playlists.

This PR simplifies the client-side logic around foreign airname handling in playlist duplication.  As a result of this simplification, `fairname` is no longer needed and has been removed.
