### PR TITLE
Support multiple tag printers

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -214,8 +214,8 @@ $config = [
          */
         'print_queue' => [
             [
-                'queue' => 'label',
-                'description' => 'Annex',
+                'queue' => 'example-lpr-queue',
+                'description' => 'Example Description',
                 /*
                  * preferred is the IP address of a computer for which
                  * this printer should be offered as the default
@@ -229,8 +229,8 @@ $config = [
                  */
             ],
             [
-                'queue' => 'label-2',
-                'description' => 'MD Office',
+                'queue' => 'example-lpr-queue-2',
+                'description' => 'Example Description 2',
             ]
         ],
         /**

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -54,6 +54,9 @@ $config = [
      * This value enables guest account authentication and tag printing
      * only on the specified subnet.
      *
+     * Value may be specified in CIDR subnet notation (e.g., 2.2.2.0/24)
+     * or as an address fragment (e.g., 2.2.2).
+     *
      * Set this value to 0 to enable guest accounts and tag printing for
      * all addresses.
      */
@@ -217,12 +220,15 @@ $config = [
                 'queue' => 'example-lpr-queue',
                 'description' => 'Example Description',
                 /*
-                 * preferred is the IP address of a computer for which
-                 * this printer should be offered as the default
+                 * 'preferred' is the IP address of a computer for which
+                 * this printer should be offered as the default.
+                 *
+                 * It may be a dotted-quad IP address, a CIDR netmask,
+                 * or array of IP addresses and/or netmasks.
                  */
                 'preferred' => '192.168.0.103'
                 /*
-                 * you may optionally specify any of the printer
+                 * You may optionally specify any of the printer
                  * characteristics (use_template, charset, darkness,
                  * text_mode, box_mode); if supplied, they override
                  * the defaults

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -208,8 +208,31 @@ $config = [
         ],
         /**
          * lpr print queue name
+         *
+         * this can be a string (the queue name) or an array if you
+         * have multiple printers
          */
-        'print_queue' => 'label',
+        'print_queue' => [
+            [
+                'queue' => 'label',
+                'description' => 'Annex',
+                /*
+                 * preferred is the IP address of a computer for which
+                 * this printer should be offered as the default
+                 */
+                'preferred' => '192.168.0.103'
+                /*
+                 * you may optionally specify any of the printer
+                 * characteristics (use_template, charset, darkness,
+                 * text_mode, box_mode); if supplied, they override
+                 * the defaults
+                 */
+            ],
+            [
+                'queue' => 'label-2',
+                'description' => 'MD Office',
+            ]
+        ],
         /**
          * lpr charset is one of UTF-8, LATIN-1, or ASCII
          */

--- a/config/config.kzsu.php
+++ b/config/config.kzsu.php
@@ -52,7 +52,7 @@ $config = [
      * Set this value to 0 to enable guest accounts and tag printing for
      * all addresses.
      */
-    'local_subnet' => '171.66.118.',  // IP in subnet 171.66.118.
+    'local_subnet' => '171.66.118.0/25',
 
     /**
      * URLs

--- a/js/editor.common.js
+++ b/js/editor.common.js
@@ -274,9 +274,13 @@ $().ready(function() {
 
     $("#print").click(function() {
         var local = $("#local").val() == 1;
-        if(!local)
+        if(local) {
+            var selected = $("INPUT:checkbox:checked").length > 0;
+            if(!selected)
+                alert("Select at least one tag to proceed");
+        } else
             alert('tags can be printed to the label printer only at the station');
-        return local;
+        return local && selected;
     });
 
     $("#printToPDF").click(function() {

--- a/js/editor.common.js
+++ b/js/editor.common.js
@@ -377,5 +377,56 @@ $().ready(function() {
         return scrollDown();
     });
 
+    var actionButton;
+    $("input[name='print'], input[name='next'][value='  Done!  ']").on('click', function(e) {
+        // if no printer selection, or printer has already been selected,
+        // there is nothing to do
+        var queue = $("#print-queue");
+        if(queue.length == 0 || queue.val().length > 0)
+            return;
+
+        // we only print from track screen if album is new
+        if($(this).attr('name') == 'next' &&
+                $("input[name=new]").val().length == 0)
+            return;
+
+        var printerId = sessionStorage.getItem($("#user-uuid").val());
+        if(!printerId) {
+            actionButton = this;
+            $("#select-printer-dialog").show();
+            $("#select-printer").focus();
+            e.preventDefault();
+            return;
+        }
+
+        queue.val(printerId);
+    });
+
+    $(".zk-popup button").click(function() {
+        if($(this).hasClass("default")) {
+            var printerId =  $("#select-printer").val();
+            sessionStorage.setItem($("#user-uuid").val(), printerId);
+            $("#print-queue").val(printerId);
+            actionButton.click();
+        }
+
+        $(".zk-popup").hide();
+        $("*[data-focus]").focus();
+    });
+
+    var printStatus = $("#print-status");
+    if(printStatus) {
+        var queue = sessionStorage.getItem($("#user-uuid").val());
+        $.ajax({
+            dataType: 'json',
+            type: 'GET',
+            accept: "application/json; charset=utf-8",
+            url: '?action=editor&subaction=status&printqueue=' +
+                        (queue ? encodeURIComponent(queue) : "")
+        }).done(function (response) {
+            printStatus.text(response.text);
+        });
+    }
+
     $("*[data-focus]").focus();
 });

--- a/js/editor.common.js
+++ b/js/editor.common.js
@@ -419,7 +419,7 @@ $().ready(function() {
     });
 
     var printStatus = $("#print-status");
-    if(printStatus) {
+    if(printStatus.length > 0) {
         var queue = sessionStorage.getItem($("#user-uuid").val());
         $.ajax({
             dataType: 'json',

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -30,6 +30,7 @@ use ZK\Engine\Engine;
 use ZK\Engine\IEditor;
 use ZK\Engine\ILibrary;
 use ZK\Engine\PlaylistEntry;
+use ZK\Engine\Session;
 
 use ZK\UI\UICommon as UI;
 
@@ -230,6 +231,14 @@ class Editor extends MenuItem {
         };
     }
 
+    private static function addrInSubnets($addr, $subnets) {
+        foreach(is_array($subnets) ? $subnets : [ $subnets ] as $subnet) {
+            if(Session::addrInSubnet($addr, $subnet))
+                return true;
+        }
+        return false;
+    }
+
     private function emitPrinterSelection() {
         $printers = $this->printConfig['print_queue'] ?? null;
         if(!is_array($printers) || sizeof($printers) < 2)
@@ -238,8 +247,9 @@ class Editor extends MenuItem {
         $clientIP = $_SERVER['REMOTE_ADDR'];
 
         $options = "";
+        $haveSelected = "";
         foreach($printers as $printer) {
-            $selected = ($printer['preferred'] ?? "none") == $clientIP ? " selected" : "";
+            $haveSelected |= $selected = !$haveSelected && self::addrInSubnets($clientIP, $printer['preferred'] ?? "0") ? " selected" : "";
             $options .= "<option value='".htmlentities($printer['queue'], ENT_QUOTES)."'$selected>".htmlentities($printer['description'], ENT_QUOTES, 'UTF-8');
         }
 

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -292,7 +292,7 @@ class Editor extends MenuItem {
                 $title = $this->getPanelTitle($_REQUEST["seq"]);
                 echo "  <FORM ACTION=\"?\" METHOD=POST>\n";
                 echo "    <TABLE CELLPADDING=0 CELLSPACING=0 BORDER=0 WIDTH=\"100%\">\n      <TR><TH ALIGN=LEFT>$title</TH><TH ALIGN=RIGHT CLASS=\"error\">";
-                if(!$this->subaction) {
+                if(!$this->subaction && $this->canPrintLocal()) {
                     echo "<span id='print-status'></span>\n";
                 }
                 echo "</TH></TR>\n      <TR><TD COLSPAN=2 HEIGHT=130 VALIGN=MIDDLE>\n";

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -208,9 +208,13 @@ class Editor extends MenuItem {
         if(!is_array($printers) || sizeof($printers) < 2)
             return;
 
+        $clientIP = $_SERVER['REMOTE_ADDR'];
+
         $options = "";
-        foreach($printers as $printer)
-            $options .= "<option value='".htmlentities($printer['queue'], ENT_QUOTES)."'>".htmlentities($printer['description'], ENT_QUOTES, 'UTF-8');
+        foreach($printers as $printer) {
+            $selected = ($printer['preferred'] ?? "none") == $clientIP ? " selected" : "";
+            $options .= "<option value='".htmlentities($printer['queue'], ENT_QUOTES)."'$selected>".htmlentities($printer['description'], ENT_QUOTES, 'UTF-8');
+        }
 
         // unique but irreversible identifier for the user
         $uuid = md5($this->session->getUser());

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -180,9 +180,12 @@ class Editor extends MenuItem {
         $printers = $this->printConfig['print_queue'] ?? null;
         if(is_array($printers)) {
             $queue = $_REQUEST['printqueue'] ?? "";
-            if(!$probe && (!$queue || sizeof($printers) == 1)) {
-                if(sizeof($printers) > 1)
+            if(!$queue || sizeof($printers) == 1) {
+                if(sizeof($printers) > 1) {
+                    if($probe)
+                        return "";
                     error_log("multiple printers defined but none selected");
+                }
                 $queue = $printers[0]['queue'];
             }
         } else


### PR DESCRIPTION
This PR extends zookeeper to support multiple tag printers.

If multiple printers are configured, the user will be asked to choose a printer upon the first tag print.  The choice will be remembered for subsequent tags during the session, but the printer must be selected again upon the next login.  In this way, the user can select the printer which is most convenient on the day.

Each tag printer can have an associated descriptive name that will be displayed to the user (for example, its location), and as well can have an optional IP address that, if the client request is from this address, the printer will be preselected as the default, requiring only user confirmation (for example, the computer in the room with the printer).
