### PR TITLE
Dispatch cleanup

### DIFF
--- a/config/ui_config.php
+++ b/config/ui_config.php
@@ -43,8 +43,6 @@ $menu = [
     [ 'u', 'updateDJInfo', 'Edit Profile',          ZK\UI\Playlists::class ],
     [ 'a', 'viewDJ%',      'DJ Zone!',              ZK\UI\Playlists::class ],
     [ 'a', 'viewList%',    'Playlists by Date',     ZK\UI\Playlists::class ],
-    [ 'u', 'addTrack',     0,                       ZK\UI\Playlists::class ],
-    [ 'u', 'moveTrack',    0,                       ZK\UI\Playlists::class ],
     [ 'U', 'changePass',   'Change Password',       ZK\UI\ChangePass::class ],
     [ 'p', 'deepStorage',  'Deep Storage',          ZK\UI\DeepStorage::class ],
     [ 'x', 'adminUsers',   'Administer Users',      ZK\UI\UserAdmin::class ],

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -263,7 +263,7 @@ class Validate implements IController {
         if($this->doTest("move track", $success2 && $success3)) {
             $response = $this->client->post('', [
                 RequestOptions::FORM_PARAMS => [
-                    "action" => "moveTrack",
+                    "action" => "editListMoveTrack",
                     "playlist" => $pid,
                     "fromId" => $sid,
                     "toId" => $cid

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -390,7 +390,7 @@ $().ready(function(){
 
         $.ajax({
             type: "POST",
-            url: "?action=moveTrack",
+            url: "?action=editListMoveTrack",
             dataType : "json",
             accept: "application/json; charset=utf-8",
             data: postData,
@@ -493,7 +493,7 @@ $().ready(function(){
 
         $.ajax({
             type: "POST",
-            url: "?action=addTrack&oaction=" + $("#track-action").val(),
+            url: "?action=editListAddTrack&oaction=" + $("#track-action").val(),
             dataType : 'json',
             accept: "application/json; charset=utf-8",
             data: postData,
@@ -860,7 +860,7 @@ $().ready(function(){
             dataType : 'json',
             type: 'POST',
             accept: "application/json; charset=utf-8",
-            url: "?action=addTrack",
+            url: "?action=editListAddTrack",
             data: postData,
             success: function(respObj) {
                 // *1 to coerce to int as switch uses strict comparison

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -53,12 +53,12 @@ class Playlists extends MenuItem {
         [ "editList", "emitListManager" ],
         [ "editListGetHint", "listManagerGetHint" ],
         [ "editListEditor", "emitEditor" ],
+        [ "editListAddTrack", "handleAddTrack" ],
+        [ "editListMoveTrack", "handleMoveTrack" ],
         [ "importExport", "emitImportExportList" ],
         [ "viewDJ", "emitViewDJ" ],
         [ "viewDJReviews", "viewDJReviews" ],
         [ "updateDJInfo", "updateDJInfo" ],
-        [ "addTrack", "handleAddTrack" ],
-        [ "moveTrack", "handleMoveTrack" ],
     ];
 
     private $action;


### PR DESCRIPTION
This PR refactors the top-level actions `addTrack` and `moveTrack` to stemmed actions under `editList`; namely, `editListAddTrack` and `editListMoveTrack`, respectively.

In this way, we lose the overhead of extra routing at the top level and instead delegate it to Playlist.

This is a non-semantic change.
