### PR TITLE
Coalesce punctuation in searches

### DIFF
--- a/engine/impl/Library.php
+++ b/engine/impl/Library.php
@@ -289,7 +289,7 @@ class LibraryImpl extends DBO implements ILibrary {
             $key = $matches[1];
 
             // Before MySQL 8, RLIKE is not unicode-aware, so do bytewise test
-            $rlike = preg_replace("/['\u{2019}]/u", "('|\u{2019})", $search);
+            $rlike = preg_replace("/['\u{2019}]/u", "('|\u{2019})", preg_quote($search));
             if(substr($rlike, -1) == "%")
                 $rlike = substr($rlike, 0, -1);
 
@@ -333,6 +333,7 @@ class LibraryImpl extends DBO implements ILibrary {
             $pos = (!$count && $stmt->fetch())?$pos + $askCount - 1:0;
         } else {
             // caller has requested total row count instead of data
+
             // strip ORDER BY and/or LIMIT clauses
             $ob = strpos($query, " ORDER BY");
             if($ob)

--- a/js/editor.album.js
+++ b/js/editor.album.js
@@ -134,9 +134,8 @@ $().ready(function() {
     var seltag = $("#seltag").val();
     if(seltag > 0) {
         getAlbums('filter[id]=' + encodeURIComponent(seltag));
-        $("#list").focus();
     } else {
         getAlbums('page[before]=');
-        $("#search").focus();
     }
+    $("#search").focus();
 });


### PR DESCRIPTION
This extends the implementation from #376 to provide for generic coalescing of arbitrary sets of codepoints for searching.

Default collation for utf8mb4 coalesces related characters, such as 'a', 'ä', 'á', and so on, such that any one will match a query where one of the others is present.  However, it does not coalese various punctuation, such as apostrophe (') and right single quotation mark U+2019 (’).

This PR provides an extensible facility to allow coalescing of any arbitrary set of codepoints.  It includes additional codepoints for the single quotation mark collation, and as well adds a set of codepoints for a new double quotation marks collation.

