### PR TITLE
Playlist add event:  Validate required fields are non-empty

### DIFF
--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2022 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -666,6 +666,23 @@ class Playlists implements RequestHandlerInterface {
                 $entry->setLabel($albumrec[0]["name"]);
             }
         } catch(\Exception $e) {}
+
+        // validate required fields
+        $invalid = false;
+        switch($entry->getType()) {
+        case PlaylistEntry::TYPE_COMMENT:
+            $invalid = empty($entry->getComment());
+            break;
+        case PlaylistEntry::TYPE_LOG_EVENT:
+            $invalid = empty($entry->getLogEventType()) || empty($entry->getLogEventCode());
+            break;
+        case PlaylistEntry::TYPE_SPIN:
+            $invalid = empty($entry->getArtist()) || empty($entry->getTrack());
+            break;
+        }
+
+        if($invalid)
+            throw new \InvalidArgumentException("missing required field");
 
         $autoTimestamp = false;
         $created = $entry->getCreated();

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -220,12 +220,13 @@ class Validate implements IController {
             ]);
 
             $success2 = $response->getStatusCode() == 200;
-            if($success2) {
-                $json = json_decode($response->getBody()->getContents());
+            if($success2) { $b1 = $response->getBody()->getContents();
+                $json = json_decode($b1);
                 if($json !== null && $json->data)
                     $cid = $json->data->id;
                 else
                     $success2 = false;
+                    echo "body: $b1 ";
             }
 
             $this->showSuccess($success2, $response);
@@ -300,6 +301,7 @@ class Validate implements IController {
             $this->showSuccess($success5, $response);
         }
 
+        $successd = false;
         if($this->doTest("duplicate playlist", $success4)) {
             $response = $this->client->post('api/v1/playlist', [
                 RequestOptions::JSON => [

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2022 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -220,13 +220,12 @@ class Validate implements IController {
             ]);
 
             $success2 = $response->getStatusCode() == 200;
-            if($success2) { $b1 = $response->getBody()->getContents();
-                $json = json_decode($b1);
+            if($success2) {
+                $json = json_decode($response->getBody()->getContents());
                 if($json !== null && $json->data)
                     $cid = $json->data->id;
                 else
                     $success2 = false;
-                    echo "body: $b1 ";
             }
 
             $this->showSuccess($success2, $response);

--- a/engine/PlaylistEntry.php
+++ b/engine/PlaylistEntry.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2022 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -295,11 +295,13 @@ class PlaylistEntry {
         $this->entry['artist'] = IPlaylist::SPECIAL_TRACK . IPlaylist::COMMENT_FLAG;
         if(mb_strlen($comment) < 80) {
             $this->entry['track'] = $comment;
+            $this->entry['album'] = $this->entry['label'] = '';
         } else {
             $this->entry['track'] = mb_substr($comment, 0, 80);
             $rest = mb_substr($comment, 80);
             if(mb_strlen($rest) < 80) {
                 $this->entry['album'] = $rest;
+                $this->entry['label'] = '';
             } else {
                 $this->entry['album'] = mb_substr($rest, 0, 80);
                 $this->entry['label'] = mb_substr($rest, 80);


### PR DESCRIPTION
This PR adds validation to the playlist add event API to ensure all required attributes are non-empty.

In addition, it fixes variable initialisation in the PlaylistEntry and Validation classes.