### PR TITLE
Add optional time parameter to playlist duplication

### DIFF
--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -434,7 +434,11 @@ class Playlists implements RequestHandlerInterface {
 
         if($dup) {
             // duplicate an existing playlist
-            $playlist = $papi->duplicatePlaylist($origin);
+            $fromTime = $show->metaInformation()->getOptional("fromtime");
+            if($fromTime && !preg_match('/^\d{4}(\-\d{4})?$/', $fromTime))
+                throw new \Exception("fromtime invalid");
+
+            $playlist = $papi->duplicatePlaylist($origin, $fromTime);
             if(!$playlist)
                 throw new \Exception("duplication failed");
 

--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -135,7 +135,7 @@ Example with `fromtime`:
 
 Playlist 12345 runs from 0000-0300.  To duplicate only one hour of
 this playlist, from 0100-0200, for rebroadcast on 2022-01-01 from
-1800-2000:
+1800-1900:
 
 ````
 POST /api/v1/playlist HTTP/1.1

--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -98,11 +98,15 @@ name can be specified via the `name` attribute.
 In addition, you may specify an optional meta attribute `fromtime` to
 indicate the portion of the playlist you wish to duplicate.  The value
 may be a range (hhmm-hhmm) or a time (hhmm).  If you specify a time,
-duplicate copies from the specified time to the end of the playlist.
+the API copies from the specified time to the end of the playlist.
+**Important:** `fromtime` specifies the time relative to the original
+playlist that is being copied.
 
 Example:
 
-To duplicate playlist 12345 for rebroadcast on 2022-01-01 from 1800-2000:
+Playlist 12345 runs from 0000-0300.  To duplicate only one hour of
+this playlist, from 0100-0200, for rebroadcast on 2022-01-01 from
+1800-2000:
 
 ````
 POST /api/v1/playlist HTTP/1.1

--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -95,6 +95,11 @@ The name of the duplicated playlist follows the same convention as
 playlists duplicated in the user interface.  If desired, an alternate
 name can be specified via the `name` attribute.
 
+In addition, you may specify an optional meta attribute `fromtime` to
+indicate the portion of the playlist you wish to duplicate.  The value
+may be a range (hhmm-hhmm) or a time (hhmm).  If you specify a time,
+duplicate copies from the specified time to the end of the playlist.
+
 Example:
 
 To duplicate playlist 12345 for rebroadcast on 2022-01-01 from 1800-2000:
@@ -111,6 +116,39 @@ Content-Type: application/vnd.api+json
       "rebroadcast": true,
       "date": "2022-01-01",
       "time": "1800-2000"
+    },
+    "relationships": {
+      "origin": {
+        "data": {
+          "type": "show",
+          "id": "12345"
+        }
+      }
+    }
+  }
+}
+````
+
+Example with range:
+
+To duplicate one hour of playlist 12345 from 0100-0200 for rebroadcast
+on 2022-01-01 at 1800-1900:
+
+````
+POST /api/v1/playlist HTTP/1.1
+X-APIKEY: eb5e0e0b42a84531af5f257ed61505050494788d
+Content-Type: application/vnd.api+json
+
+{
+  "data": {
+    "type": "show",
+    "attributes": {
+      "rebroadcast": true,
+      "date": "2022-01-01",
+      "time": "1800-1900"
+    },
+    "meta": {
+      "fromtime": "0100-0200"
     },
     "relationships": {
       "origin": {

--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -104,9 +104,7 @@ playlist that is being copied.
 
 Example:
 
-Playlist 12345 runs from 0000-0300.  To duplicate only one hour of
-this playlist, from 0100-0200, for rebroadcast on 2022-01-01 from
-1800-2000:
+To duplicate playlist 12345 for rebroadcast on 2022-01-01 from 1800-2000:
 
 ````
 POST /api/v1/playlist HTTP/1.1
@@ -133,10 +131,11 @@ Content-Type: application/vnd.api+json
 }
 ````
 
-Example with range:
+Example with `fromtime`:
 
-To duplicate one hour of playlist 12345 from 0100-0200 for rebroadcast
-on 2022-01-01 at 1800-1900:
+Playlist 12345 runs from 0000-0300.  To duplicate only one hour of
+this playlist, from 0100-0200, for rebroadcast on 2022-01-01 from
+1800-2000:
 
 ````
 POST /api/v1/playlist HTTP/1.1

--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2022 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -84,7 +84,7 @@ interface IPlaylist {
     function insertPlaylist($user, $date, $time, $description, $airname);
     function updatePlaylist($playlist, $date, $time, $description, $airname,
                                $deleteTracksPastEnd=0);
-    function duplicatePlaylist($playlist);
+    function duplicatePlaylist($playlist, $time = null);
     function reparentPlaylist($playlist, $user);
     function getSeq($list, $id);
     function moveTrack($list, $id, $toId, $clearTimestamp=true);

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2022 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -311,7 +311,87 @@ class PlaylistImpl extends DBO implements IPlaylist {
         return $stmt->execute();
     }
 
-    public function duplicatePlaylist($playlist) {
+    protected function slicePlaylist($playlist, $time) {
+        // use a fresh connection so we don't adversely affect
+        // anything else by changing the attributes, etc.
+        $pdo = $this->newPDO();
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);
+        $pdo->beginTransaction();
+
+        try {
+            $query = "SELECT showdate, showtime FROM lists WHERE id = ?";
+            $stmt = $pdo->prepare($query);
+            $stmt->bindValue(1, $playlist);
+            $from = $stmt->executeAndFetch();
+            $date = $from['showdate'];
+            $oldTime = explode('-', $from['showtime']);
+            $newTime = explode('-', $time);
+            if(count($newTime) == 1)
+                $newTime[] = $oldTime[1];
+            $fromStamp = \DateTime::createFromFormat(self::TIME_FORMAT,
+                        $date . " " . $newTime[0]);
+            $toStamp = \DateTime::createFromFormat(self::TIME_FORMAT,
+                        $date . " " . $newTime[1]);
+            // event timestamps include seconds; we adjust toStamp
+            // to capture all events within the last minute
+            $toStamp->modify("+1 minute");
+
+            // if playlist spans midnight, end time is next day
+            if($toStamp < $fromStamp)
+                $toStamp->modify("+1 day");
+
+            $query = "SELECT id FROM tracks WHERE list = ? " .
+                     "AND created < ? ORDER BY seq DESC, id DESC LIMIT 1";
+            $stmt = $pdo->prepare($query);
+            $stmt->bindValue(1, $playlist);
+            $stmt->bindValue(2, $fromStamp->format(self::TIME_FORMAT_SQL));
+            $lowRow = $stmt->executeAndFetch();
+            if($lowRow && ($seq = $this->getSeq($playlist, $lowRow['id']))) {
+                // getSeq() populated seq for the delete and update
+                $query = "DELETE FROM tracks WHERE list = ? AND seq <= ?";
+                $stmt = $pdo->prepare($query);
+                $stmt->bindValue(1, $playlist);
+                $stmt->bindValue(2, $seq);
+                $stmt->execute();
+
+                $query = "UPDATE tracks SET seq = seq - ? WHERE list = ?";
+                $stmt = $pdo->prepare($query);
+                $stmt->bindValue(1, $seq);
+                $stmt->bindValue(2, $playlist);
+                $stmt->execute();
+            }
+
+            $query = "SELECT id FROM tracks WHERE list = ? " .
+                     "AND created >= ? ORDER BY seq, id LIMIT 1";
+            $stmt = $pdo->prepare($query);
+            $stmt->bindValue(1, $playlist);
+            $stmt->bindValue(2, $toStamp->format(self::TIME_FORMAT_SQL));
+            $highRow = $stmt->executeAndFetch();
+            if($highRow && ($seq = $this->getSeq($playlist, $highRow['id']))) {
+                $query = "DELETE FROM tracks WHERE list = ? AND seq >= ?";
+                $stmt = $pdo->prepare($query);
+                $stmt->bindValue(1, $playlist);
+                $stmt->bindValue(2, $seq);
+                $stmt->execute();
+            }
+
+            $query = "UPDATE lists SET showtime = ? WHERE id = ?";
+            $stmt = $pdo->prepare($query);
+            $stmt->bindValue(1, implode('-', $newTime));
+            $stmt->bindValue(2, $playlist);
+            $stmt->execute();
+
+            // if we made it this far, success!
+            $pdo->commit();
+        } catch(\Exception $e) {
+            error_log("slicePlaylist: " . $e->getMessage());
+            $pdo->rollBack();
+            throw $e;
+        }
+    }
+
+    public function duplicatePlaylist($playlist, $time = null) {
         $query = "SELECT dj, showdate, showtime, description, airname " .
                  "FROM lists WHERE id = ?";
         $stmt = $this->prepare($query);
@@ -342,6 +422,15 @@ class PlaylistImpl extends DBO implements IPlaylist {
             $success = $stmt->execute();
 
             if($success) {
+                if($time) {
+                    try {
+                        $this->slicePlaylist($newListId, $time);
+                    } catch(\Exception $e) {
+                        $this->deletePlaylist($newListId, true);
+                        return false;
+                    }
+                }
+
                 // insert comment at beginning of playlist
                 $comment = preg_replace_callback("/%([^%]*)%/",
                     function($matches) use ($from) {
@@ -907,7 +996,16 @@ class PlaylistImpl extends DBO implements IPlaylist {
         return $res;
     }
 
-    public function deletePlaylist($playlist) {
+    public function deletePlaylist($playlist, $permanent = false) {
+        if($permanent) {
+            $query = "DELETE FROM tracks, lists USING lists " .
+                     "LEFT OUTER JOIN tracks ON lists.id = tracks.list " .
+                     "WHERE lists.id = ?";
+            $stmt = $this->prepare($query);
+            $stmt->bindValue(1, $playlist);
+            return $stmt->execute();
+        }
+
         // fetch the airname from the playlists table
         $row = $this->getPlaylist($playlist);
         $airname = $row?$row['airname']:null;

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -423,16 +423,15 @@ class PlaylistImpl extends DBO implements IPlaylist {
             $stmt->bindValue(2, $playlist);
             $success = $stmt->execute();
 
-            if($success) {
-                if($time) {
-                    try {
-                        $this->slicePlaylist($newListId, $time);
-                    } catch(\Exception $e) {
-                        $this->deletePlaylist($newListId, true);
-                        return false;
-                    }
+            if($success && $time) {
+                try {
+                    $this->slicePlaylist($newListId, $time);
+                } catch(\Exception $e) {
+                    $success = false;
                 }
+            }
 
+            if($success) {
                 // insert comment at beginning of playlist
                 $comment = preg_replace_callback("/%([^%]*)%/",
                     function($matches) use ($from) {
@@ -453,6 +452,9 @@ class PlaylistImpl extends DBO implements IPlaylist {
                         $this->moveTrack($newListId, $entry->getId(), $first['id']);
                 }
             }
+
+            if(!$success)
+                $this->deletePlaylist($newListId, true);
         }
 
         return $success?$newListId:false;


### PR DESCRIPTION
This PR adds an optional `fromtime` parameter to the playlist duplication/rebroadcast API.  The value may be a range (hhmm-hhmm) or a time (hhmm).  If you specify a time, the API copies from the specified time to the end of the playlist.

Example:

Playlist 12345 runs from 0000-0300.  To duplicate only one hour of this playlist 0100-0200 for rebroadcast on 2022-01-01 at 1800-1900:

 ````
 POST /api/v1/playlist HTTP/1.1
 X-APIKEY: eb5e0e0b42a84531af5f257ed61505050494788d
 Content-Type: application/vnd.api+json

 {
   "data": {
     "type": "show",
     "attributes": {
       "rebroadcast": true,
       "date": "2022-01-01",
       "time": "1800-1900"
     },
     "meta": {
       "fromtime": "0100-0200"
     },
     "relationships": {
       "origin": {
         "data": {
           "type": "show",
           "id": "12345"
         }
       }
     }
   }
 }
 ````

More details are available in docs/Playlists.md
