### PR TITLE
Configure availability of external track links

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -141,6 +141,11 @@ $config = [
     ],
 
     /**
+     * enable external playable track links
+     */
+    'external_links_enabled' => false,
+
+    /**
      * playable track URLs which should be suppressed for
      * non-authenticated users
      */

--- a/config/ui_config.php
+++ b/config/ui_config.php
@@ -44,7 +44,7 @@ $menu = [
     [ 'a', 'viewDJ%',      'DJ Zone!',              ZK\UI\Playlists::class ],
     [ 'a', 'viewList%',    'Playlists by Date',     ZK\UI\Playlists::class ],
     [ 'U', 'changePass',   'Change Password',       ZK\UI\ChangePass::class ],
-    [ 'p', 'deepStorage',  'Deep Storage',          ZK\UI\DeepStorage::class ],
+    [ 'e', 'deepStorage',  'Deep Storage',          ZK\UI\DeepStorage::class ],
     [ 'x', 'adminUsers',   'Administer Users',      ZK\UI\UserAdmin::class ],
     [ 'a', 'viewChart',    'Airplay Charts',        ZK\UI\Charts::class ],
 ];

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -205,8 +205,8 @@ class Editor extends MenuItem {
     }
 
     private function getUrlAutofill() {
-        return ($config = Engine::param('discogs'))
-            && ($config['track_url_enabled'] ?? false);
+        return Engine::param('external_links_enabled')
+                && $this->session->isAuth("p");
     }
 
     private function prefillTracks() {

--- a/ui/Search.php
+++ b/ui/Search.php
@@ -95,11 +95,15 @@ class Search extends MenuItem {
         return $link;
     }
 
-    private function emitTrackInfo($trackInfo, $showArtist, $isAuth, $internalLinks) {
+    private function emitTrackInfo($trackInfo, $showArtist, $isAuth, $internalLinks, $enableExternalLinks) {
         $url = $trackInfo["url"];
 
-        // suppress internal URLs for non-authenticated users
-        if($internalLinks && preg_match($internalLinks, $url) && !$isAuth)
+        // if external links are enabled, suppress internal URLs for
+        // non-authenticated users; otherwise, suppress all but internal
+        // URLs for authenticated users
+        if($enableExternalLinks ?
+                $internalLinks && preg_match($internalLinks, $url) && !$isAuth :
+                !$internalLinks || !preg_match($internalLinks, $url) || !$isAuth)
             $url = '';
 
         $playLink = $url == '' ? '' : "<DIV class='playTrack'><A target='_blank' href='$url'></A></DIV>";
@@ -133,6 +137,7 @@ class Search extends MenuItem {
 
         $isAuth = $this->session->isAuth('u');
         $internalLinks = Engine::param('internal_links');
+        $enableExternalLinks = Engine::param('external_links_enabled');
 
         if($key)
             $this->searchText = $key;
@@ -250,7 +255,7 @@ class Search extends MenuItem {
             }
 
             echo "<TR>";
-            echo $this->emitTrackInfo($albums[$i], true, $isAuth, $internalLinks);
+            echo $this->emitTrackInfo($albums[$i], true, $isAuth, $internalLinks, $enableExternalLinks);
             echo "</TR>\n";
         }
 
@@ -271,11 +276,11 @@ class Search extends MenuItem {
                     echo "<TR><TD COLSPAN=4>&nbsp;</TD>";
                 else {
                     echo "<TR>";
-                    $this->emitTrackInfo($tracks[$i], false, $isAuth, $internalLinks); // left side
+                    $this->emitTrackInfo($tracks[$i], false, $isAuth, $internalLinks, $enableExternalLinks); // left side
                     echo "<TD>&nbsp;</TD>"; // replace with a right pad
                 }
 
-                $this->emitTrackInfo($tracks[$i + $mid], false, $isAuth, $internalLinks); // right side
+                $this->emitTrackInfo($tracks[$i + $mid], false, $isAuth, $internalLinks, $enableExternalLinks); // right side
                 echo "</TR>\n";
             }
             if($opened) echo $this->closeList();


### PR DESCRIPTION
Station policy may prohibit links to external content, such as that provided by the playable track URL facility #171.

The PR allows external track links to be enabled or disabled based on a new configuration file setting, `external_links_enabled`.  If this value is absent or false, only internal links are displayed to authenticated users; no external links are displayed to any user.
