### PR TITLE
Automatically set location for currents

### DIFF
--- a/controllers/RunDaily.php
+++ b/controllers/RunDaily.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2022 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -46,6 +46,7 @@ class RunDaily implements IController {
         echo "Starting ".date("Y-m-d H:i:s")."\n";
         
         $this->runCharts();
+        $this->retireCurrents();
         $this->purgeDeletedPlaylists();
         $this->purgeOldSessions();
         $this->purgeArtworkCache();
@@ -100,6 +101,12 @@ class RunDaily implements IController {
             if($addresses['crossroads'])
                 $this->chartMonthly($date, $addresses['crossroads'], 1);
         }
+    }
+
+    private function retireCurrents() {
+        $today = date("Y-m-d");
+        $success = Engine::api(IChart::class)->retireAlbums($today);
+        echo "Retiring currents: ".($success === false ? "FAILED!" : "OK ($success albums)")."\n";
     }
 
     private function purgeDeletedPlaylists() {

--- a/db/convert_v2_11_7_to_v2_12_0.sql
+++ b/db/convert_v2_11_7_to_v2_12_0.sql
@@ -49,8 +49,8 @@ ALTER TABLE `tagqueue` MODIFY `keyed` datetime NOT NULL;
 ALTER TABLE `users` MODIFY `name` varchar(8) NOT NULL;
 
 ALTER TABLE `albumvol` ADD INDEX `location` (`location`);
-UPDATE albumvol a SET location='L' WHERE location='C';
-UPDATE albumvol a INNER JOIN currents c ON a.tag = c.tag AND adddate <= CURDATE() AND pulldate > CURDATE() SET location='C' WHERE location='L';
+UPDATE albumvol SET location='L' WHERE location='C';
+UPDATE albumvol a INNER JOIN currents c ON a.tag = c.tag AND adddate <= CURDATE() AND pulldate > CURDATE() SET location='C';
 
 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT;
 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS;

--- a/db/convert_v2_11_7_to_v2_12_0.sql
+++ b/db/convert_v2_11_7_to_v2_12_0.sql
@@ -49,6 +49,7 @@ ALTER TABLE `tagqueue` MODIFY `keyed` datetime NOT NULL;
 ALTER TABLE `users` MODIFY `name` varchar(8) NOT NULL;
 
 ALTER TABLE `albumvol` ADD INDEX `location` (`location`);
+UPDATE albumvol a SET location='L' WHERE location='C';
 UPDATE albumvol a INNER JOIN currents c ON a.tag = c.tag AND adddate <= CURDATE() AND pulldate > CURDATE() SET location='C' WHERE location='L';
 
 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT;

--- a/db/convert_v2_11_7_to_v2_12_0.sql
+++ b/db/convert_v2_11_7_to_v2_12_0.sql
@@ -48,6 +48,9 @@ ALTER TABLE `tagqueue` MODIFY `tag` int(11) NOT NULL;
 ALTER TABLE `tagqueue` MODIFY `keyed` datetime NOT NULL;
 ALTER TABLE `users` MODIFY `name` varchar(8) NOT NULL;
 
+ALTER TABLE `albumvol` ADD INDEX `location` (`location`);
+UPDATE albumvol a INNER JOIN currents c ON a.tag = c.tag AND adddate <= CURDATE() AND pulldate > CURDATE() SET location='C' WHERE location='L';
+
 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT;
 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS;
 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION;

--- a/db/zkdbSchema.sql
+++ b/db/zkdbSchema.sql
@@ -85,6 +85,7 @@ CREATE TABLE IF NOT EXISTS `albumvol` (
   KEY `album` (`album`),
   KEY `pubkey` (`pubkey`),
   KEY `aat` (`artist`,`album`,`tag`),
+  KEY `location` (`location`),
   FULLTEXT KEY `artist_2` (`artist`,`album`),
   FULLTEXT KEY `artist_3` (`artist`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8mb4 ;

--- a/engine/IChart.php
+++ b/engine/IChart.php
@@ -41,6 +41,7 @@ interface IChart {
     function addAlbum($aid, $tag, $adddate, $pulldate, $cats);
     function updateAlbum($id, $aid, $tag, $adddate, $pulldate, $cats);
     function deleteAlbum($id);
+    function retireAlbums($date);
     function getAlbum($id);
     function getAlbumByTag($tag);
     function getAlbumPlays($tag, $startDate="", $endDate="", $limit="");


### PR DESCRIPTION
This PR makes the following changes:
1. albums with location A-file but which are not are marked Library;
2. current A-file albums are marked location A-file;
3. when a new album is added to the A-file, it is marked location A-file;
4. if an album is prematurely removed from the A-file, it is marked Library;
5. when an album leaves the A-file, it is automatically marked Library.

(1) and (2) are effected through the database conversion script.  (5) is effected through the daily run controller.
