### PR TITLE
Remove cookies from _REQUEST superglobal

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,13 +7,13 @@ Options -Indexes
 <IfModule mod_php7.c>
     php_value error_reporting 32759
     php_value default_charset UTF-8
-    php_value request_order GPC
+    php_value request_order GP
 </IfModule>
 # for PHP 8 and later:
 <IfModule mod_php.c>
     php_value error_reporting 32759
     php_value default_charset UTF-8
-    php_value request_order GPC
+    php_value request_order GP
 </IfModule>
 
 <IfModule mod_rewrite.c>

--- a/.user.ini
+++ b/.user.ini
@@ -1,4 +1,4 @@
 ; set php error reporting to E_ALL & ~E_NOTICE (=32759)
 error_reporting=32759
 default_charset='UTF-8'
-request_order='GPC'
+request_order='GP'


### PR DESCRIPTION
The request_order configuration is currently set to GPC, meaning GET POST and cookies are included in the $_REQUEST superglobal variable.

The application exclusively passes request parameters in the query string (GET) or via form POST.  Cookies are not used for request parameters.  The application uses cookies only for session state, in which case they are exclusively accessed via the $_COOKIES global and never $_REQUEST.

This PR removes cookies from the $_REQUEST variable, such that it will contain only request parameters supplied in the query string (GET) or via form POST.
