### PR TITLE
Remove php 8.0 as CI build target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.0', '8.2']
+        php-versions: ['7.4', '8.2']
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
PHP 8.0 has been deprecated.  This PR removes it as a CI build target.