### PR TITLE
Updated for PHP 8.2 dynamic property deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://zookeeper.ibinx.com/master/
 
 ### Requirements 
 
-* PHP 7.2.5 or later with MySQL PDO driver
+* PHP 7.4 or later with MySQL PDO driver
 * MySQL/MariaDB
 
 It is recommended to use PHP 8.2 or later, as older versions have

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	]
     },
     "require": {
-	"php": ">=7.2.5",
+	"php": ">=7.4",
 	"ext-curl": "*",
 	"ext-pdo": "*",
 	"ext-pdo_mysql": "*",

--- a/engine/TemplateFactory.php
+++ b/engine/TemplateFactory.php
@@ -52,15 +52,21 @@ class LazyLoadParams {
     ];
 
     public $request; // explicit, as we assign by reference later
+    private $params = [];
 
     public function __isset($name) {
-        return in_array($name, self::TEMPLATE_SAFE_PARAMS);
+        return key_exists($name, $this->params) ||
+            in_array($name, self::TEMPLATE_SAFE_PARAMS);
     }
 
     public function __get($name) {
-        $this->$name = in_array($name, self::TEMPLATE_SAFE_PARAMS) ?
-                    Engine::param($name) : null;
-        return $this->$name;
+        return $this->params[$name] ??=
+            in_array($name, self::TEMPLATE_SAFE_PARAMS) ?
+                Engine::param($name) : null;
+    }
+
+    public function __set($name, $value) {
+        $this->params[$name] = $value;
     }
 }
 


### PR DESCRIPTION
This PR updates the helper class `LazyLoadParams` to avoid dynamic properties, as they have been marked deprecated in PHP 8.2 and will raise an exception as of PHP 9.0.  See https://wiki.php.net/rfc/deprecate_dynamic_properties

In addition, the minimum required version of PHP has been bumped to 7.4 to account for the use of the null coalescing assignment operator.
