### PR TITLE
Add album track duration

### DIFF
--- a/api/Albums.php
+++ b/api/Albums.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2024 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -50,7 +50,7 @@ class Albums implements RequestHandlerInterface {
     const FIELDS = [ "artist", "album", "category", "medium", "size",
                      "created", "updated", "location", "bin", "coll" ];
 
-    const TRACK_FIELDS = [ "seq", "artist", "track", "url" ];
+    const TRACK_FIELDS = [ "seq", "artist", "track", "duration", "url" ];
 
     const LINKS_NONE = 0;
     const LINKS_LABEL = 1;

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2024 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -464,7 +464,8 @@ class Validate implements IController {
                             'coll' => false,
                             'tracks' => [
                                 [
-                                    'track' => 'TEST track 1'
+                                    'track' => 'TEST track 1',
+                                    'duration' => '00:01:23'
                                 ],[
                                     'track' => 'TEST track 2'
                                 ]

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -471,6 +471,10 @@ td.label-form {
     vertical-align: bottom;
     line-height: 10px;
 }
+.trackEditor th.duration {
+    text-align: right;
+    padding-right: 4px;
+}
 
 .trackTable td {
     line-height: 18px;

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -805,10 +805,20 @@ th.sec {
 .success {
     color: #006600;
 }
-.text, .urlValue {
+.text {
     padding: 2px;
     border: 1px solid #666;
     border-radius: 3px;
+}
+.text.c2 {
+    width: 330px;
+}
+.text.c3 {
+    width: 220px;
+}
+.text.duration {
+    width: 45px;
+    text-align: right;
 }
 .textsp {
     border: 1px solid #666;

--- a/db/convert_v2_11_7_to_v3_0_0.sql
+++ b/db/convert_v2_11_7_to_v3_0_0.sql
@@ -2,7 +2,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2024 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -54,6 +54,9 @@ UPDATE albumvol SET location='L' WHERE location='C';
 UPDATE albumvol a INNER JOIN currents c ON a.tag = c.tag AND adddate <= CURDATE() AND pulldate > CURDATE() SET location='C';
 
 ALTER TABLE `reviews` ADD COLUMN `exportid` varchar(80) DEFAULT NULL;
+
+ALTER TABLE `tracknames` ADD COLUMN `duration` time DEFAULT NULL;
+ALTER TABLE `colltracknames` ADD COLUMN `duration` time DEFAULT NULL;
 
 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT;
 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS;

--- a/db/zkdbSchema.sql
+++ b/db/zkdbSchema.sql
@@ -2,7 +2,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2024 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -192,6 +192,7 @@ CREATE TABLE IF NOT EXISTS `colltracknames` (
   `artist` varchar(80) DEFAULT NULL,
   `url` varchar(2083) NOT NULL DEFAULT '',
   `seq` smallint(6) DEFAULT NULL,
+  `duration` time DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `tag` (`tag`),
   KEY `track` (`track`),
@@ -412,6 +413,7 @@ CREATE TABLE IF NOT EXISTS `tracknames` (
   `track` varchar(80) DEFAULT NULL,
   `url` varchar(2083) NOT NULL DEFAULT '',
   `seq` smallint(6) DEFAULT NULL,
+  `duration` time DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `tag` (`tag`),
   KEY `track` (`track`),

--- a/docs/Albums.md
+++ b/docs/Albums.md
@@ -27,6 +27,7 @@ An [example album document](Samples.md#album) is available here.
   * seq
   * track
   * artist (for compilations)
+  * duration (hh:mm:ss or null)
   * url
 
 ### Relations

--- a/engine/impl/Library.php
+++ b/engine/impl/Library.php
@@ -260,14 +260,16 @@ class LibraryImpl extends DBO implements ILibrary {
       
             $query = "SELECT a.tag, track, artist, album, seq, ".
                      "category, medium, size, location, bin, ".
-                     "a.pubkey, name, address, city, state, zip, iscoll, t.url ".
+                     "a.pubkey, name, address, city, state, zip, iscoll, ".
+                     "t.url, t.duration ".
                      "FROM tracknames t, albumvol a ".
                      "LEFT JOIN publist p ON a.pubkey = p.pubkey ".
                      "WHERE a.tag = t.tag AND ".
                      "track LIKE ? ".
                      "UNION SELECT a.tag, track, c.artist, a.artist album, seq, ".
                      "category, medium, size, location, bin, ".
-                     "a.pubkey, name, address, city, state, zip, iscoll, c.url ".
+                     "a.pubkey, name, address, city, state, zip, iscoll, ".
+                     "c.url, c.duration ".
                      "FROM colltracknames c LEFT JOIN albumvol a ON a.tag = c.tag ".
                      "LEFT JOIN publist p ON a.pubkey = p.pubkey ".
                      "WHERE track LIKE ? ".

--- a/js/editor.common.js
+++ b/js/editor.common.js
@@ -2,7 +2,7 @@
 // Zookeeper Online
 //
 // @author Jim Mason <jmason@ibinx.com>
-// @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
+// @copyright Copyright (C) 1997-2024 Jim Mason <jmason@ibinx.com>
 // @link https://zookeeper.ibinx.com/
 // @license GPL-3.0
 //
@@ -233,12 +233,14 @@ $().ready(function() {
         }
         for(var j=next; j>focus; j--) {
             $("INPUT[name='track" + j + "' i]").val($("INPUT[name='track" + (j-1) + "' i]").val());
+            $("INPUT[name='trackDuration" + j + "' i]").val($("INPUT[name='trackDuration" + (j-1) + "' i]").val());
             $("INPUT[name='trackUrl" + j + "' i]").val($("INPUT[name='trackUrl" + (j-1) + "' i]").val());
             if(coll) {
                 $("INPUT[name='artist" + j + "' i]").val($("INPUT[name='artist" + (j-1) + "' i]").val());
             }
         }
         $("INPUT[name='track" + focus + "' i]").val("");
+        $("INPUT[name='trackDuration" + focus + "' i]").val("");
         $("INPUT[name='trackUrl" + focus + "' i]").val("");
         if(coll) {
             $("INPUT[name='artist" + focus + "' i]").val("");
@@ -252,12 +254,14 @@ $().ready(function() {
             var last = nextTrack()-1;
             for(var j=focus; j<last; j++) {
                 $("INPUT[name='track" + j + "' i]").val($("INPUT[name='track" + (j+1) + "' i]").val());
+                $("INPUT[name='trackDuration" + j + "' i]").val($("INPUT[name='trackDuration" + (j+1) + "' i]").val());
                 $("INPUT[name='trackUrl" + j + "' i]").val($("INPUT[name='trackUrl" + (j+1) + "' i]").val());
                 if(coll) {
                     $("INPUT[name='artist" + j + "' i]").val($("INPUT[name='artist" + (j+1) + "' i]").val());
                 }
             }
             $("INPUT[name='track" + last + "' i]").val("");
+            $("INPUT[name='trackDuration" + last + "' i]").val("");
             $("INPUT[name='trackUrl" + last + "' i]").val("");
             if(coll) {
                 $("INPUT[name='artist" + last + "' i]").val("");
@@ -451,6 +455,7 @@ $().ready(function() {
                     var input = $("input[name=track" + track.seq + "]");
                     if(input.length) {
                         input.val(track.title.toLowerCase()).zkAlpha();
+                        $("input[name=trackDuration" + track.seq + "]").val(track.time ?? '');
                         $("input[name=trackUrl" + track.seq + "]").val(track.url ?? '');
                         if(track.artist)
                             $("input[name=artist" + track.seq + "]").val(track.artist);
@@ -462,6 +467,11 @@ $().ready(function() {
                             value: track.title.toLowerCase(),
                             'data-zkalpha': 'true'
                         }).zkAlpha()).append($("<input>", {
+                            type: 'hidden',
+                            name: 'trackDuration' + track.seq,
+                            class: 'prefill',
+                            value: track.time ?? ''
+                        })).append($("<input>", {
                             type: 'hidden',
                             name: 'trackUrl' + track.seq,
                             class: 'prefill',

--- a/js/editor.common.js
+++ b/js/editor.common.js
@@ -521,7 +521,7 @@ $().ready(function() {
     $(".clear-prefill").on('click', function(e) {
         e.preventDefault();
         if(confirm("Clear all tracks?")) {
-            $("input[type=text], input[type=url]").val('');
+            $("input.text").val('');
             $("input.prefill").remove();
 
             $(".discogs-prefill-confirm").slideUp();

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -1306,7 +1306,7 @@ class Editor extends MenuItem {
         <table class='trackEditor'>
     <?php
         $artistHdr = $isCollection ? "<TH>Artist</TH>" : "";
-        $cellWidth = "width:" . ($isCollection ? "220px" : "330px");
+        $cellWidth = $isCollection ? "c3" : "c2";
 
         echo "<TR><TH></TH><TH>Track Name</TH>${artistHdr}<TH>Time</TH><TH>URL</TH><TD align=right>Insert/Delete&nbsp;Track:&nbsp;<INPUT TYPE=BUTTON NAME=insert id='insert' CLASS=submit VALUE='+'>&nbsp;<INPUT TYPE=BUTTON NAME=delete id='delete' CLASS=submit VALUE='&minus;'></TD></TR>\n";
 
@@ -1320,19 +1320,19 @@ class Editor extends MenuItem {
 
             echo "<TR>";
             echo "<TD ALIGN='RIGHT' style='width:20px' ><b>$trackNum:</b></TD>";
-            echo "<TD><INPUT NAME='track$trackNum' style='$cellWidth' VALUE=\"$title\" TYPE=text CLASS=text maxlength=" . PlaylistEntry::MAX_FIELD_LENGTH . " data-zkalpha='true' data-track='$trackNum' $focus ></TD>";
+            echo "<TD><INPUT NAME='track$trackNum' VALUE=\"$title\" TYPE=text CLASS='text $cellWidth' maxlength=" . PlaylistEntry::MAX_FIELD_LENGTH . " data-zkalpha='true' data-track='$trackNum' $focus ></TD>";
 
             if($isCollection) {
                 $artist = htmlentities(stripslashes($_POST["artist".$trackNum]));
-                echo "<TD style='$cellWidth'><INPUT NAME=artist$trackNum style='$cellWidth' VALUE=\"$artist\" TYPE=text CLASS=text maxlength=" . PlaylistEntry::MAX_FIELD_LENGTH . " data-zkalpha='true' data-track='$trackNum'></TD>";
+                echo "<TD><INPUT NAME=artist$trackNum VALUE=\"$artist\" TYPE=text CLASS='text $cellWidth' maxlength=" . PlaylistEntry::MAX_FIELD_LENGTH . " data-zkalpha='true' data-track='$trackNum'></TD>";
                 $this->skipVar("artist".$trackNum);
             }
 
             $duration = $_POST["trackDuration$trackNum"];
-            echo "<TD><INPUT NAME='trackDuration$trackNum' class='text duration' VALUE='$duration' style='width: 45px;text-align: right' maxlength='8' pattern='[0-9:]*'></TD>";
+            echo "<TD><INPUT NAME='trackDuration$trackNum' class='text duration' VALUE='$duration' maxlength='8' pattern='[0-9:]*'></TD>";
 
             $url = $_POST["trackUrl$trackNum"];
-            echo "<TD COLSPAN=2><INPUT class='urlValue' style='$cellWidth' value='${url}' NAME='trackUrl$trackNum' TYPE='url' maxlength=" . IEditor::MAX_PLAYABLE_URL_LENGTH . " data-track='$trackNum' /></TD>";
+            echo "<TD COLSPAN=2><INPUT class='text $cellWidth' value='${url}' NAME='trackUrl$trackNum' TYPE='url' maxlength=" . IEditor::MAX_PLAYABLE_URL_LENGTH . " data-track='$trackNum' /></TD>";
 
             echo "</TR>\n";
         }

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -1308,7 +1308,7 @@ class Editor extends MenuItem {
         $artistHdr = $isCollection ? "<TH>Artist</TH>" : "";
         $cellWidth = $isCollection ? "c3" : "c2";
 
-        echo "<TR><TH></TH><TH>Track Name</TH>${artistHdr}<TH>Time</TH><TH>URL</TH><TD align=right>Insert/Delete&nbsp;Track:&nbsp;<INPUT TYPE=BUTTON NAME=insert id='insert' CLASS=submit VALUE='+'>&nbsp;<INPUT TYPE=BUTTON NAME=delete id='delete' CLASS=submit VALUE='&minus;'></TD></TR>\n";
+        echo "<TR><TH></TH><TH>Track Name</TH>${artistHdr}<TH class='duration'>Time</TH><TH>URL</TH><TD align=right>Insert/Delete&nbsp;Track:&nbsp;<INPUT TYPE=BUTTON NAME=insert id='insert' CLASS=submit VALUE='+'>&nbsp;<INPUT TYPE=BUTTON NAME=delete id='delete' CLASS=submit VALUE='&minus;'></TD></TR>\n";
 
         for($i=0; $i<$this->tracksPerPage; $i++) {
             $trackNum = $_REQUEST["nextTrack"] + $i;

--- a/ui/Editor.php
+++ b/ui/Editor.php
@@ -1346,13 +1346,13 @@ class Editor extends MenuItem {
             $tracks = Engine::api(ILibrary::class)->search($isCollection?ILibrary::COLL_KEY:ILibrary::TRACK_KEY, 0, 2000, $_REQUEST["seltag"]);
             foreach($tracks as $row) {
                 $this->emitHidden("track".$row["seq"], $row["track"]);
-                $this->emitHidden("trackDuration".$row["seq"], $row["url"]);
-                $this->emitHidden("trackUrl".$row["seq"], $row["url"]);
                 $_POST["track".$row["seq"]] = $row["track"];
                 $duration = $row["duration"];
                 if($duration)
                     $duration = preg_replace("/^0(0:0?)?/", "", $duration);
+                $this->emitHidden("trackDuration".$row["seq"], $duration);
                 $_POST["trackDuration".$row["seq"]] = $duration;
+                $this->emitHidden("trackUrl".$row["seq"], $row["url"]);
                 $_POST["trackUrl".$row["seq"]] = $row["url"];
                 if($isCollection) {
                     $this->emitHidden("artist" . $row["seq"], $row["artist"]);

--- a/ui/Search.php
+++ b/ui/Search.php
@@ -148,6 +148,9 @@ class Search extends MenuItem {
         $internalLinks = Engine::param('internal_links');
         $enableExternalLinks = Engine::param('external_links_enabled');
         foreach($tracks as &$track) {
+            if($track["duration"])
+                $track["duration"] = preg_replace("/^0(0:0?)?/", "", $track["duration"]);
+
             $url = $track["url"];
 
             // if external links are enabled, suppress internal URLs for

--- a/ui/Search.php
+++ b/ui/Search.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2024 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *

--- a/ui/templates/default/album/tracks.html
+++ b/ui/templates/default/album/tracks.html
@@ -4,7 +4,7 @@
 
 <table class='trackTable'>
   {%~ if album.iscoll %}
-  <tr><th>&nbsp;</th><th></th><th align=left style='min-width:200px'>Artist</th><th align=left>Track Name</th></tr>
+  <tr><th>&nbsp;</th><th></th><th align=left style='min-width:200px'>Artist</th><th align=left>Track Name</th><th></th></tr>
   {%~ for track in tracks %}
   <tr>
     <td>
@@ -15,6 +15,7 @@
     <td>{{ track.seq }}.</td>
     <td>{{ _self.tracklink('byArtist', track.artist) }}</td>
     <td>{{ _self.tracklink('byTrack', track.track) }}</td>
+    <td align=right>{{ track.duration }}</td>
   </tr>
   {%~ endfor %}
   {%~ else %}
@@ -26,24 +27,26 @@
     <td colspan=4>&nbsp;</td>
     {%~ else %}
       {%~ set track = tracks[i] %}
+      {%~ set duration = track.duration ? ' (' ~ track.duration ~ ') ' %}
     <td>
       {%~ if track.url %}
       <div class='playTrack'><a target='_blank' href='{{ track.url }}'></a></div>
       {%~ endif %}
     </td>
     <td>{{ track.seq }}.</td>
-    <td>{{ _self.tracklink('byTrack', track.track) }}</td>
+    <td>{{ _self.tracklink('byTrack', track.track) }}{{ duration }}</td>
     <td>&nbsp;</td>
     {%~ endif %}
     {#~ right side #}
     {%~ set track = tracks[mid + i] %}
+    {%~ set duration = track.duration ? ' (' ~ track.duration ~ ') ' %}
     <td>
       {%~ if track.url %}
       <div class='playTrack'><a target='_blank' href='{{ track.url }}'></a></div>
       {%~ endif %}
     </td>
     <td>{{ track.seq }}.</td>
-    <td>{{ _self.tracklink('byTrack', track.track) }}</td>
+    <td>{{ _self.tracklink('byTrack', track.track) }}{{ duration }}</td>
   </tr>
   {%~ endfor %}
   {%~ endif %}


### PR DESCRIPTION
This PR adds an optional track duration field to each album track.

Existing album tracks have no duration by default.

New albums prefilled from Discogs get the track duration if it is available.

In addition to the library editor, the track duration is exposed via the JSON:API and in the album details page.

Satisfies #432