### PR TITLE
Playlist API v2: Playlist event attribute deprecation

### DIFF
--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -302,7 +302,7 @@ class Validate implements IController {
 
         $successd = false;
         if($this->doTest("duplicate playlist", $success4)) {
-            $response = $this->client->post('api/v1/playlist', [
+            $response = $this->client->post('api/v2/playlist', [
                 RequestOptions::JSON => [
                     'data' => [
                         'type' => 'show',
@@ -340,7 +340,7 @@ class Validate implements IController {
                 $json->data->relationships->origin->data->id == $pid &&
                 preg_match(IPlaylist::DUPLICATE_REGEX, $json->data->attributes->name) &&
                 $json->data->attributes->airname == $airname &&
-                sizeof($json->data->attributes->events) == 3;
+                sizeof($json->data->relationships->events->data) == 3;
             $this->showSuccess($successd1, $response);
         }
 

--- a/docs/PlaylistEvents.md
+++ b/docs/PlaylistEvents.md
@@ -20,7 +20,7 @@ airname.
 ### <a id="show"></a> Create the show:
 ---
 ````
-POST /api/v1/playlist HTTP/1.1
+POST /api/v2/playlist HTTP/1.1
 X-APIKEY: eb5e0e0b42a84531af5f257ed61505050494788d
 Content-Type: application/vnd.api+json
 
@@ -41,7 +41,7 @@ Content-Type: application/vnd.api+json
 ---
 ````
 HTTP/1.1 201 Created
-Location: /api/v1/playlist/628
+Location: /api/v2/playlist/628
 Content-Length: 0
 ````
 ---
@@ -58,7 +58,7 @@ The value of `Location` is used as the base for the subsequent requests.
 ### <a id="eventComment"></a> Add a comment:
 ---
 ````
-POST /api/v1/playlist/628/events HTTP/1.1
+POST /api/v2/playlist/628/events HTTP/1.1
 X-APIKEY: eb5e0e0b42a84531af5f257ed61505050494788d
 Content-Type: application/vnd.api+json
 
@@ -96,7 +96,7 @@ section 7.3.
 ### <a id="eventSpin"></a> Add a spin:
 ---
 ````
-POST /api/v1/playlist/628/events HTTP/1.1
+POST /api/v2/playlist/628/events HTTP/1.1
 X-APIKEY: eb5e0e0b42a84531af5f257ed61505050494788d
 Content-Type: application/vnd.api+json
 

--- a/docs/PlaylistImport.md
+++ b/docs/PlaylistImport.md
@@ -21,7 +21,7 @@ airname.
 
 ---
 ````
-POST /api/v1/playlist HTTP/1.1
+POST /api/v2/playlist HTTP/1.1
 X-APIKEY: eb5e0e0b42a84531af5f257ed61505050494788d
 Content-Type: application/vnd.api+json
 
@@ -29,45 +29,66 @@ Content-Type: application/vnd.api+json
   "data": {
     "type": "show",
     "attributes": {
-      "name": "example show",
-      "date": "2022-01-31",
-      "time": "1700-1900",
-      "airname": "Jim",
-      "events": [{
-        "type": "comment",
-        "comment": "welcome to the show",
-        "created": "17:00:00"
-      }, {
-        "type": "spin",
-        "artist": "Calla",
-        "track": "Elsewhere",
-        "album": "Calla",
-        "label": "Arena Rock Recording Co.",
-        "created": "17:01:00",
-        "xa:relationships": {
-          "album": {
-            "data": {
-              "type": "album",
-              "id": "1060007"
-            }
-          }
-        }
-      }]
+      "name": "Example Playlist",
+      "date": "2022-01-01",
+      "time": "1800-2000",
+      "airname": "Sample DJ"
+    },
+    "relationships": {
+      "events": {
+        "data": [{
+          "type": "event",
+          "id": "1"
+	}, {
+          "type": "event",
+          "id": "2"
+        }]
+      }
     }
-  }
+  },
+  "included": [{
+      "type": "event",
+      "id": "1",
+      "attributes": {
+          "type": "spin",
+	  "artist": "example artist",
+	  "track": "example track",
+	  "album": "example album",
+	  "label": "example label",
+	  "created": "2022-01-01 18:00:00"
+      }
+  }, {
+      "type": "event",
+      "id": "2",
+      "attributes": {
+          "type": "spin",
+	  "track": "another track",
+	  "created": "2022-01-01 18:02:30"
+      },
+      "relationships": {
+          "album": {
+	      "data": {
+	          "type": "album",
+		  "id": "1060007"
+	      }
+	  }
+      }
+  }]
 }
 ````
 ---
 
-The album tag, if any, is specified in the xa:relationships
-element.  For more information, see the [Complex Attribute
-Extension](xa.md).
+The album tag, if any, is specified in the relationships stanza of the
+included event.  If an album tag is supplied, it is unnecessary to
+specify the `album` or `label` attributes, or the `artist` attribute
+for non-compilations, as these will be populated automatically from
+the album record.
 
 ### The server responds:
 ---
 ````
 HTTP/1.1 201 Created
-Location: /api/v1/playlist/921
+Location: /api/v2/playlist/921
 Content-Length: 0
 ````
 ---

--- a/docs/Samples.md
+++ b/docs/Samples.md
@@ -147,7 +147,7 @@ The following are sample documents for each of the data types.
 }
 ````
 ---
-### <a id="playlist"></a> sample playlist document:
+### <a id="playlist"></a> sample playlist document (with `include=events`):
 
 ````
 {
@@ -159,130 +159,7 @@ The following are sample documents for each of the data types.
       "date": "2021-12-23",
       "time": "2100-2200",
       "airname": "DJ Away",
-      "rebroadcast": true,
-      "events": [{
-        "type": "comment",
-        "comment": "Rebroadcast of an episode originally aired on May 20, 2021.",
-        "created": null
-      }, {
-        "artist": "Marika Papagika",
-        "track": "Smyrneiko Minore",
-        "album": "I Believe I'll Go Back Home: 1906\u20131959",
-        "label": "Mississippi",
-        "created": "21:00:00",
-        "type": "spin"
-      }, {
-        "artist": "His Name Is Alive",
-        "track": "Liadin",
-        "album": "Hope Is a Candle",
-        "label": "Disciples",
-        "created": "21:04:00",
-        "type": "spin"
-      }, {
-        "artist": "The Durutti Column",
-        "track": "Weakness and Fever (originally released as a 7\" single)",
-        "album": "LC (Reissue)",
-        "label": "Factory Benelux",
-        "created": "21:07:00",
-        "type": "spin"
-      }, {
-        "artist": "For Against",
-        "track": "You Only Live Twice",
-        "album": "Aperture",
-        "label": "Independent Project",
-        "created": "21:12:00",
-        "type": "spin",
-        "xa:relationships": {
-          "album": {
-            "data": {
-              "type": "album",
-              "id": "118820"
-            }
-          }
-        }
-      }, {
-        "artist": "Andrew Weathers & Hayden Pedigo",
-        "track": "Tomorrow Is the Song I Sing",
-        "album": "Big Tex, Here We Come",
-        "label": "Debacle",
-        "created": "21:16:00",
-        "type": "spin"
-      }, {
-        "artist": "Souled American",
-        "track": "Dark as a Dungeon",
-        "album": "Sonny",
-        "label": "Rough Trade",
-        "created": "21:21:00",
-        "type": "spin"
-      }, {
-        "type": "break",
-        "created": null
-      }, {
-        "artist": "Hey Exit",
-        "track": "Last Harvest",
-        "album": "Eulogy for Land",
-        "label": "Full Spectrum",
-        "created": "21:26:00",
-        "type": "spin"
-      }, {
-        "artist": "Calla",
-        "track": "Elsewhere",
-        "album": "Calla",
-        "label": "Arena Rock Recording Co.",
-        "created": "21:34:00",
-        "type": "spin",
-        "xa:relationships": {
-          "album": {
-            "data": {
-              "type": "album",
-              "id": "1060007"
-            }
-          }
-        }
-      }, {
-        "artist": "claire rousay",
-        "track": "discrete (the market)",
-        "album": "a softer focus",
-        "label": "American Dreams",
-        "created": "21:39:00",
-        "type": "spin"
-      }, {
-        "artist": "Jusell, Prymek, Sage, Shiroishi",
-        "track": "Flower Clock",
-        "album": "Yamawarau (\u5c71\u7b11\u3046)",
-        "label": "cachedmedia",
-        "created": "21:45:00",
-        "type": "spin"
-      }, {
-        "artist": "Rolf Lislevand",
-        "track": "Santiago De Murcia: Folias Gallegas",
-        "album": "Altre Follie, 1500-1750",
-        "label": "AliaVox",
-        "created": "21:49:00",
-        "type": "spin"
-      }, {
-        "artist": "Loren Mazzacane Connors",
-        "track": "Dance Acadia",
-        "album": "Evangeline",
-        "label": "Road Cone",
-        "created": "21:52:00",
-        "type": "spin",
-        "xa:relationships": {
-          "album": {
-            "data": {
-              "type": "album",
-              "id": "463845"
-            }
-          }
-        }
-      }, {
-        "artist": "Paul Galbraith",
-        "track": "Sonata No. 3 BWV 1005 in D Major",
-        "album": "The Sonatas & Partitas (arr. for 8-String Guitar)",
-        "label": "Delos",
-        "created": "21:53:00",
-        "type": "spin"
-      }]
+      "rebroadcast": true
     },
     "relationships": {
       "origin": {
@@ -294,221 +171,244 @@ The following are sample documents for each of the data types.
           "id": "41522"
         }
       },
-      "albums": {
+      "events": {
         "links": {
-          "related": "/api/v1/playlist/42667/albums"
+          "related": "/api/v1/playlist/42667/events"
         },
         "data": [{
-          "type": "album",
-          "id": "118820"
+          "type": "event",
+          "id": "818834"
         }, {
-          "type": "album",
-          "id": "1060007"
+          "type": "event",
+          "id": "818835"
         }, {
-          "type": "album",
-          "id": "463845"
+          "type": "event",
+          "id": "818836"
+        }, {
+          "type": "event",
+          "id": "818837"
+        }, {
+          "type": "event",
+          "id": "818838"
+        }, {
+          "type": "event",
+          "id": "818839"
+        }, {
+          "type": "event",
+          "id": "818840"
+        }, {
+          "type": "event",
+          "id": "818841"
+        }, {
+          "type": "event",
+          "id": "818842"
+        }, {
+          "type": "event",
+          "id": "818843"
+        }, {
+          "type": "event",
+          "id": "818844"
+        }, {
+          "type": "event",
+          "id": "818845"
+        }, {
+          "type": "event",
+          "id": "818846"
+        }, {
+          "type": "event",
+          "id": "818847"
+        }, {
+          "type": "event",
+          "id": "818848"
         }]
       }
     },
-    "links": {
+    "included": [{
+      "type": "event",
+      "id": "818834",
+      "attributes": {
+        "type": "comment",
+        "comment": "Rebroadcast of an episode originally aired on May 20, 2021.",
+        "created": null
+      }
+    }, {
+      "type": "event",
+      "id": "818835",
+      "attributes": {
+        "type": "spin",
+        "artist": "Marika Papagika",
+        "track": "Smyrneiko Minore",
+        "album": "I Believe I'll Go Back Home: 1906\u20131959",
+        "label": "Mississippi",
+        "created": "21:00:00"
+      }
+    }, {
+      "type": "event",
+      "id": "818836",
+      "attributes": {
+        "type": "spin",
+        "artist": "His Name Is Alive",
+        "track": "Liadin",
+        "album": "Hope Is a Candle",
+        "label": "Disciples",
+        "created": "21:04:00"
+      }
+    }, {
+      "type": "event",
+      "id": "818837",
+      "attributes": {
+        "type": "spin",
+        "artist": "The Durutti Column",
+        "track": "Weakness and Fever (originally released as a 7\" single)",
+        "album": "LC (Reissue)",
+        "label": "Factory Benelux",
+        "created": "21:07:00"
+      }
+    }, {
+      "type": "event",
+      "id": "818838",
+      "attributes": {
+        "type": "spin",
+        "artist": "For Against",
+        "track": "You Only Live Twice",
+        "album": "Aperture",
+        "label": "Independent Project",
+        "created": "21:12:00"
+      },
+      "relationships": {
+        "album": {
+          "data": {
+            "type": "album",
+            "id": "118820"
+          }
+        }
+      }
+    }, {
+      "type": "event",
+      "id": "818839",
+      "attributes": {
+        "type": "spin",
+        "artist": "Andrew Weathers & Hayden Pedigo",
+        "track": "Tomorrow Is the Song I Sing",
+        "album": "Big Tex, Here We Come",
+        "label": "Debacle",
+        "created": "21:16:00"
+      }
+    }, {
+      "type": "event",
+      "id": "818840",
+      "attributes": {
+        "type": "spin",
+        "artist": "Souled American",
+        "track": "Dark as a Dungeon",
+        "album": "Sonny",
+        "label": "Rough Trade",
+        "created": "21:21:00"
+      }
+    }, {
+      "type": "event",
+      "id": "818841",
+      "attributes": {
+        "type": "break",
+        "created": null
+      }
+    }, {
+      "type": "event",
+      "id": "818842",
+      "attributes": {
+        "type": "spin",
+        "artist": "Hey Exit",
+        "track": "Last Harvest",
+        "album": "Eulogy for Land",
+        "label": "Full Spectrum",
+        "created": "21:26:00"
+      }
+    }, {
+      "type": "event",
+      "id": "818843",
+      "attributes": {
+        "type": "spin",
+        "artist": "Calla",
+        "track": "Elsewhere",
+        "album": "Calla",
+        "label": "Arena Rock Recording Co.",
+        "created": "21:34:00"
+      },
+      "relationships": {
+        "album": {
+          "data": {
+            "type": "album",
+            "id": "1060007"
+          }
+        }
+      }
+    }, {
+      "type": "event",
+      "id": "818844",
+      "attributes": {
+        "type": "spin",
+        "artist": "claire rousay",
+        "track": "discrete (the market)",
+        "album": "a softer focus",
+        "label": "American Dreams",
+        "created": "21:39:00"
+      }
+    }, {
+      "type": "event",
+      "id": "818845",
+      "attributes": {
+        "type": "spin",
+        "artist": "Jusell, Prymek, Sage, Shiroishi",
+        "track": "Flower Clock",
+        "album": "Yamawarau (\u5c71\u7b11\u3046)",
+        "label": "cachedmedia",
+        "created": "21:45:00"
+      }
+    }, {
+      "type": "event",
+      "id": "818846",
+      "attributes": {
+        "type": "spin",
+        "artist": "Rolf Lislevand",
+        "track": "Santiago De Murcia: Folias Gallegas",
+        "album": "Altre Follie, 1500-1750",
+        "label": "AliaVox",
+        "created": "21:49:00"
+      }
+    }, {
+      "type": "event",
+      "id": "818847",
+      "attributes": {
+        "type": "spin",
+        "artist": "Loren Mazzacane Connors",
+        "track": "Dance Acadia",
+        "album": "Evangeline",
+        "label": "Road Cone",
+        "created": "21:52:00"
+      },
+      "relationships": {
+        "album": {
+          "data": {
+            "type": "album",
+            "id": "463845"
+          }
+        }
+      }
+    }, {
+      "type": "event",
+      "id": "818848",
+      "attributes": {
+        "type": "spin",
+        "artist": "Paul Galbraith",
+        "track": "Sonata No. 3 BWV 1005 in D Major",
+        "album": "The Sonatas & Partitas (arr. for 8-String Guitar)",
+        "label": "Delos",
+        "created": "21:53:00"
+      }
+    }],
+      "links": {
       "self": "/api/v1/playlist/42667"
     }
-  },
-  "jsonapi": {
-    "version": "1.0"
-  }
-}
-````
----
-### <a id="events"></a> sample playlist events document:
-
-````
-{
-  "data": [{
-    "type": "event",
-    "id": "818834",
-    "attributes": {
-      "type": "comment",
-      "comment": "Rebroadcast of an episode originally aired on May 20, 2021.",
-      "created": null
-    }
-  }, {
-    "type": "event",
-    "id": "818835",
-    "attributes": {
-      "type": "spin",
-      "artist": "Marika Papagika",
-      "track": "Smyrneiko Minore",
-      "album": "I Believe I'll Go Back Home: 1906\u20131959",
-      "label": "Mississippi",
-      "created": "21:00:00"
-    }
-  }, {
-    "type": "event",
-    "id": "818836",
-    "attributes": {
-      "type": "spin",
-      "artist": "His Name Is Alive",
-      "track": "Liadin",
-      "album": "Hope Is a Candle",
-      "label": "Disciples",
-      "created": "21:04:00"
-    }
-  }, {
-    "type": "event",
-    "id": "818837",
-    "attributes": {
-      "type": "spin",
-      "artist": "The Durutti Column",
-      "track": "Weakness and Fever (originally released as a 7\" single)",
-      "album": "LC (Reissue)",
-      "label": "Factory Benelux",
-      "created": "21:07:00"
-    }
-  }, {
-    "type": "event",
-    "id": "818838",
-    "attributes": {
-      "type": "spin",
-      "artist": "For Against",
-      "track": "You Only Live Twice",
-      "album": "Aperture",
-      "label": "Independent Project",
-      "created": "21:12:00"
-    },
-    "relationships": {
-      "album": {
-        "data": {
-          "type": "album",
-          "id": "118820"
-        }
-      }
-    }
-  }, {
-    "type": "event",
-    "id": "818839",
-    "attributes": {
-      "type": "spin",
-      "artist": "Andrew Weathers & Hayden Pedigo",
-      "track": "Tomorrow Is the Song I Sing",
-      "album": "Big Tex, Here We Come",
-      "label": "Debacle",
-      "created": "21:16:00"
-    }
-  }, {
-    "type": "event",
-    "id": "818840",
-    "attributes": {
-      "type": "spin",
-      "artist": "Souled American",
-      "track": "Dark as a Dungeon",
-      "album": "Sonny",
-      "label": "Rough Trade",
-      "created": "21:21:00"
-    }
-  }, {
-    "type": "event",
-    "id": "818841",
-    "attributes": {
-      "type": "break",
-      "created": null
-    }
-  }, {
-    "type": "event",
-    "id": "818842",
-    "attributes": {
-      "type": "spin",
-      "artist": "Hey Exit",
-      "track": "Last Harvest",
-      "album": "Eulogy for Land",
-      "label": "Full Spectrum",
-      "created": "21:26:00"
-    }
-  }, {
-    "type": "event",
-    "id": "818843",
-    "attributes": {
-      "type": "spin",
-      "artist": "Calla",
-      "track": "Elsewhere",
-      "album": "Calla",
-      "label": "Arena Rock Recording Co.",
-      "created": "21:34:00"
-    },
-    "relationships": {
-      "album": {
-        "data": {
-          "type": "album",
-          "id": "1060007"
-        }
-      }
-    }
-  }, {
-    "type": "event",
-    "id": "818844",
-    "attributes": {
-      "type": "spin",
-      "artist": "claire rousay",
-      "track": "discrete (the market)",
-      "album": "a softer focus",
-      "label": "American Dreams",
-      "created": "21:39:00"
-    }
-  }, {
-    "type": "event",
-    "id": "818845",
-    "attributes": {
-      "type": "spin",
-      "artist": "Jusell, Prymek, Sage, Shiroishi",
-      "track": "Flower Clock",
-      "album": "Yamawarau (\u5c71\u7b11\u3046)",
-      "label": "cachedmedia",
-      "created": "21:45:00"
-    }
-  }, {
-    "type": "event",
-    "id": "818846",
-    "attributes": {
-      "type": "spin",
-      "artist": "Rolf Lislevand",
-      "track": "Santiago De Murcia: Folias Gallegas",
-      "album": "Altre Follie, 1500-1750",
-      "label": "AliaVox",
-      "created": "21:49:00"
-    }
-  }, {
-    "type": "event",
-    "id": "818847",
-    "attributes": {
-      "type": "spin",
-      "artist": "Loren Mazzacane Connors",
-      "track": "Dance Acadia",
-      "album": "Evangeline",
-      "label": "Road Cone",
-      "created": "21:52:00"
-    },
-    "relationships": {
-      "album": {
-        "data": {
-          "type": "album",
-          "id": "463845"
-        }
-      }
-    }
-  }, {
-    "type": "event",
-    "id": "818848",
-    "attributes": {
-      "type": "spin",
-      "artist": "Paul Galbraith",
-      "track": "Sonata No. 3 BWV 1005 in D Major",
-      "album": "The Sonatas & Partitas (arr. for 8-String Guitar)",
-      "label": "Delos",
-      "created": "21:53:00"
-    }
-  }],
-  "links": {
-    "self": "/api/v1/playlist/42667/events"
   },
   "jsonapi": {
     "version": "1.0"


### PR DESCRIPTION
This PR adds a new endpoint `api/v2/playlist` with the following characteristics:

* `events` attribute has been removed
* events can be added at playlist creation time via sideloading (events relationship + included event objects)
* `albums` relationship has been removed; related album is now available via events.album

**The legacy `api/v1.1/playlist` and `api/v1/playlist` endpoints remain unchanged.**  Functionality on these endpoints is exactly as before but is no longer documented.
