### PR TITLE
Playlist editor:  Improve synchronization and transactional integrity

### DIFF
--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -727,7 +727,7 @@ class Playlists implements RequestHandlerInterface {
         $event = $request->requestBody()->data()->first("event");
         $entry = PlaylistEntry::fromArray($event->attributes()->all());
 
-        $api->lockPlaylist($key);
+        $api->adviseLock($key);
         try {
 
         // set to 0 (in sync) else -1 (out of sync)
@@ -815,7 +815,7 @@ class Playlists implements RequestHandlerInterface {
         }
 
         } finally {
-            $api->unlockPlaylist($key);
+            $api->adviseUnlock($key);
         }
 
         throw new BadRequestException($status ?? "DB update error");
@@ -843,7 +843,7 @@ class Playlists implements RequestHandlerInterface {
 
         $event = $request->requestBody()->data()->first("event");
 
-        $api->lockPlaylist($key);
+        $api->adviseLock($key);
         try {
 
         $id = $event->id();
@@ -915,7 +915,7 @@ class Playlists implements RequestHandlerInterface {
         }
 
         } finally {
-            $api->unlockPlaylist($key);
+            $api->adviseUnlock($key);
         }
 
         if($success)
@@ -951,11 +951,11 @@ class Playlists implements RequestHandlerInterface {
         if(!$track || $track['list'] != $key)
             throw new NotAllowedException("event not in list");
 
-        $api->lockPlaylist($key);
+        $api->adviseLock($key);
 
         $success = $api->deleteTrack($id);
 
-        $api->unlockPlaylist($key);
+        $api->adviseUnlock($key);
 
         if($success)
             return new EmptyResponse();

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -832,6 +832,9 @@ class Playlists implements RequestHandlerInterface {
 
         $event = $request->requestBody()->data()->first("event");
 
+        $api->lockPlaylist($key);
+        try {
+
         $id = $event->id();
         $track = $api->getTrack($id);
         if(!$track || $track['list'] != $key)
@@ -887,6 +890,10 @@ class Playlists implements RequestHandlerInterface {
         if($success &&
                 ($moveTo = $event->metaInformation()->getOptional("moveTo")))
             $success = $api->moveTrack($key, $id, $moveTo);
+
+        } finally {
+            $api->unlockPlaylist($key);
+        }
 
         if($success && $list['airname'] && $api->isNowWithinShow($list))
             PushServer::sendAsyncNotification();

--- a/api/Playlists.php
+++ b/api/Playlists.php
@@ -951,7 +951,11 @@ class Playlists implements RequestHandlerInterface {
         if(!$track || $track['list'] != $key)
             throw new NotAllowedException("event not in list");
 
+        $api->lockPlaylist($key);
+
         $success = $api->deleteTrack($id);
+
+        $api->unlockPlaylist($key);
 
         if($success)
             return new EmptyResponse();

--- a/engine/DBO.php
+++ b/engine/DBO.php
@@ -322,6 +322,16 @@ abstract class DBO {
     }
 
     /**
+     * execute a statement
+     *
+     * @param stmt SQL statement
+     * @return number of rows affected
+     */
+    protected function exec(string $stmt) {
+        return $this->getPDO()->exec($stmt);
+    }
+
+    /**
      * return the ID of the last inserted row
      */
     public function lastInsertId() {

--- a/engine/DBO.php
+++ b/engine/DBO.php
@@ -231,6 +231,8 @@ abstract class DBO {
     private static $dbConfig;
     private static $pdo;
 
+    private $locks = [];
+
     /**
      * convenience method to retrieve a database configuration parameter
      *
@@ -329,6 +331,58 @@ abstract class DBO {
      */
     protected function exec(string $stmt) {
         return $this->getPDO()->exec($stmt);
+    }
+
+    private function getAdvisoryLockName(int $id): string {
+        // as advisory locks are global, we qualify with the db name
+        return implode('-', [
+            $this->dbConfig(DBO::DATABASE_MAIN),
+            (new \ReflectionClass($this))->getShortName(),
+            $id
+        ]);
+    }
+
+    /**
+     * acquire an advisory lock for the specified identifier
+     *
+     * The lock is specific to the {API, id} tuple.  Thus, there is
+     * no collision between locks made on different APIs.
+     *
+     * This method does not return until the lock has been acquired.
+     *
+     * The lock is automatically released upon close of the current
+     * session, or by calling @see DBO::adviseUnlock()
+     *
+     * @param int $id target identifier
+     */
+    public function adviseLock(int $id): void {
+        if(!array_key_exists($id, $this->locks)) {
+            $stmt = $this->prepare("DO get_lock(?, -1)");
+            $stmt->bindValue(1, $this->getAdvisoryLockName($id));
+            $stmt->execute();
+
+            $this->locks[$id] = 0;
+        }
+
+        $this->locks[$id]++;
+    }
+
+    /**
+     * release advisory lock
+     *
+     * @see DBO::adviseLock()
+     *
+     * @param int $id target identifier
+     */
+    public function adviseUnlock(int $id): void {
+        if(array_key_exists($id, $this->locks) &&
+                !--$this->locks[$id]) {
+            $stmt = $this->prepare("DO release_lock(?)");
+            $stmt->bindValue(1, $this->getAdvisoryLockName($id));
+            $stmt->execute();
+
+            unset($this->locks[$id]);
+        }
     }
 
     /**

--- a/engine/Engine.php
+++ b/engine/Engine.php
@@ -29,9 +29,11 @@ class Engine {
 
     const UA = "Zookeeper/2.0; (+https://zookeeper.ibinx.com/)";
 
-    private static $apis;
-    private static $config;
-    private static $session;
+    private static Config $apis;
+    private static Config $config;
+    private static Session $session;
+
+    private static array $apiCache = [];
 
     /*
      * install autoloader for the engine implementation classes
@@ -89,18 +91,18 @@ class Engine {
     }
 
     /**
-     * instantiate an API
-     * @param intf interface
-     * @return implementation
-     * @throws Exception if no implementation for specified interface
+     * return concrete API implementation
+     *
+     * @param string $intf interface name
+     * @return object API implementation
+     * @throws \Exception if no implementation for specified interface
      */
-    public static function api($intf) {
+    public static function api(string $intf): object {
         $impl = self::$apis->getParam($intf);
-        if($impl) {
-            $api = new $impl();
-            return $api;
-        } else
-            throw new \Exception("Unknown API '$intf'");
+        if($impl)
+            return self::$apiCache[$intf] ??= new $impl();
+
+        throw new \Exception("Unknown API '$intf'");
     }
 
     /**

--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -91,7 +91,6 @@ interface IPlaylist {
     function getTrack($id);
     function getTracks($playlist, $desc = 0);
     function getTracksWithObserver($playlist, PlaylistObserver $observer, $desc = 0, $filter = null);
-    function getTrackCount($playlist);
     function getTimestampWindow($playlistId, $allowGrace = true);
     function hashPlaylist($playlistId);
     function lockPlaylist($playlistId);

--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -93,6 +93,9 @@ interface IPlaylist {
     function getTracksWithObserver($playlist, PlaylistObserver $observer, $desc = 0, $filter = null);
     function getTrackCount($playlist);
     function getTimestampWindow($playlistId, $allowGrace = true);
+    function hashPlaylist($playlistId);
+    function lockPlaylist($playlistId);
+    function unlockPlaylist($playlistId);
     function insertTrack($playlistId, $tag, $artist, $track, $album, $label, $spinTimestamp, &$id, &$status);
     function updateTrack($playlistId, $id, $tag, $artist, $track, $album, $label, $dateTime);
     function insertTrackEntry($playlistId, PlaylistEntry $entry, &$status);

--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -92,9 +92,45 @@ interface IPlaylist {
     function getTracks($playlist, $desc = 0);
     function getTracksWithObserver($playlist, PlaylistObserver $observer, $desc = 0, $filter = null);
     function getTimestampWindow($playlistId, $allowGrace = true);
-    function hashPlaylist($playlistId);
-    function lockPlaylist($playlistId);
-    function unlockPlaylist($playlistId);
+
+    /**
+     * hash the tracks of the specified playlist
+     *
+     * hash will change if count, order, or timestamps of tracks change
+     *
+     * @param int $playlistId target playlist
+     * @return string hash value
+     */
+    function hashPlaylist(int $playlistId): string;
+
+    /**
+     * acquire an exclusive write lock for the specified playlist
+     *
+     * The contract is that any insertion, update, including track
+     * resequencing, and deletion of tracks will be performed only
+     * after this lock has been acquired, to ensure both protection
+     * from concurrent updates as well as transactional integrity.
+     *
+     * Note, this is an advisory lock and does not lock any tables.
+     *
+     * This method does not return until the lock has been acquired.
+     *
+     * The lock is automatically released upon close of the current
+     * PDO session, or by calling @see IPlaylist::unlockPlaylist()
+     *
+     * @param int $playlistId target playlist
+     */
+    function lockPlaylist(int $playlistId): void;
+
+    /**
+     * release playlist write lock
+     *
+     * @see IPlaylist::lockPlaylist()
+     *
+     * @param int $playlistId target playlist
+     */
+    function unlockPlaylist(int $playlistId): void;
+
     function insertTrack($playlistId, $tag, $artist, $track, $album, $label, $spinTimestamp, &$id, &$status);
     function updateTrack($playlistId, $id, $tag, $artist, $track, $album, $label, $dateTime);
     function insertTrackEntry($playlistId, PlaylistEntry $entry, &$status);

--- a/engine/IPlaylist.php
+++ b/engine/IPlaylist.php
@@ -103,34 +103,6 @@ interface IPlaylist {
      */
     function hashPlaylist(int $playlistId): string;
 
-    /**
-     * acquire an exclusive write lock for the specified playlist
-     *
-     * The contract is that any insertion, update, including track
-     * resequencing, and deletion of tracks will be performed only
-     * after this lock has been acquired, to ensure both protection
-     * from concurrent updates as well as transactional integrity.
-     *
-     * Note, this is an advisory lock and does not lock any tables.
-     *
-     * This method does not return until the lock has been acquired.
-     *
-     * The lock is automatically released upon close of the current
-     * PDO session, or by calling @see IPlaylist::unlockPlaylist()
-     *
-     * @param int $playlistId target playlist
-     */
-    function lockPlaylist(int $playlistId): void;
-
-    /**
-     * release playlist write lock
-     *
-     * @see IPlaylist::lockPlaylist()
-     *
-     * @param int $playlistId target playlist
-     */
-    function unlockPlaylist(int $playlistId): void;
-
     function insertTrack($playlistId, $tag, $artist, $track, $album, $label, $spinTimestamp, &$id, &$status);
     function updateTrack($playlistId, $id, $tag, $artist, $track, $album, $label, $dateTime);
     function insertTrackEntry($playlistId, PlaylistEntry $entry, &$status);

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -712,8 +712,6 @@ class PlaylistImpl extends DBO implements IPlaylist {
         $names = "(list, artist, track, album, label, seq, created {$tagName})";
         $values = "VALUES (?, ?, ?, ?, ?, ?, ? {$tagValue});";
 
-        $this->lockPlaylist($playlistId);
-
         $query = "INSERT INTO tracks {$names} {$values}";
         $stmt = $this->prepare($query);
         $stmt->bindValue(1, (int)$playlistId, \PDO::PARAM_INT); 
@@ -742,8 +740,6 @@ class PlaylistImpl extends DBO implements IPlaylist {
             } else
                 $updateStatus = 2;
         }
-
-        $this->unlockPlaylist($playlistId);
 
         return $updateStatus;
     }

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -611,14 +611,6 @@ class PlaylistImpl extends DBO implements IPlaylist {
         return $tracks;
     }
 
-    public function getTrackCount($playlist) {
-        $query = "SELECT COUNT(*) AS count FROM tracks WHERE list = ?";
-        $stmt = $this->prepare($query);
-        $stmt->bindValue(1, (int)$playlist, \PDO::PARAM_INT);
-        $row = $stmt->executeAndFetch();
-        return $row?$row['count']:0;
-    }
-
     // NOTE: this routine must be tolerant of improperly formatted dates.
     public function getTimestampWindowInternal($playlist, $allowGrace = true) {
         $result = null;

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -682,18 +682,6 @@ class PlaylistImpl extends DBO implements IPlaylist {
         return $row['hash'];
     }
 
-    public function lockPlaylist(int $playlistId): void {
-        $stmt = $this->prepare("DO get_lock(concat('list-', ?), -1)");
-        $stmt->bindValue(1, $playlistId);
-        $stmt->execute();
-    }
-
-    public function unlockPlaylist(int $playlistId): void {
-        $stmt = $this->prepare("DO release_lock(concat('list-', ?))");
-        $stmt->bindValue(1, $playlistId);
-        $stmt->execute();
-    }
-
     // insert playlist track. return following: 0 - fail, 1 - success no 
     // timestamp, 2 - sucess with timestamp.
     public function insertTrack($playlistId, $tag, $artist, $track, $album, $label,  $insertTime, &$id, &$status) {

--- a/engine/impl/Playlist.php
+++ b/engine/impl/Playlist.php
@@ -679,7 +679,7 @@ class PlaylistImpl extends DBO implements IPlaylist {
         $stmt = $this->prepare($query);
         $stmt->bindValue(1, $playlistId);
         $row = $stmt->executeAndFetch();
-        return $row['hash'];
+        return $row['hash'] ?? '';
     }
 
     // insert playlist track. return following: 0 - fail, 1 - success no 

--- a/js/playlists.track.js
+++ b/js/playlists.track.js
@@ -394,6 +394,8 @@ $().ready(function(){
                 type: 'event',
                 id: fromId,
                 meta: {
+                    wantMeta: true,
+                    hash: $("#track-hash").val(),
                     moveTo: toId
                 }
             }
@@ -406,9 +408,17 @@ $().ready(function(){
             accept: "application/json; charset=utf-8",
             data: JSON.stringify(postData),
             success: function(respObj) {
+                var meta = respObj.data.meta;
+                if(meta.seq == -1) {
+                    // playlist is out of sync with table; reload
+                    location.href = "?subaction=" + $("#track-action").val() +
+                        "&playlist=" + $("#track-playlist").val();
+                }
+
                 // move succeeded, clear timestamp
                 tr.find("td").eq(1).data('utc','').html('');
                 $("#error-msg").text("");
+                $("#track-hash").val(meta.hash);
                 updatePlayable();
             },
             error: function (jqXHR, textStatus, errorThrown) {
@@ -508,7 +518,7 @@ $().ready(function(){
                 meta: {
                     wantMeta: true,
                     action: $("#track-action").val(),
-                    size: $(".playlistTable > tbody > tr").length
+                    hash: $("#track-hash").val()
                 }
             }
         };
@@ -563,6 +573,8 @@ $().ready(function(){
                     $(".playlistTable > tbody > tr").eq(index).find(".grab").on('pointerdown', grabStart);
                     break;
                 }
+
+                $("#track-hash").val(meta.hash);
 
                 updatePlayable();
                 clearUserInput(true);
@@ -889,7 +901,7 @@ $().ready(function(){
                 meta: {
                     wantMeta: true,
                     action: $("#track-action").val(),
-                    size: $(".playlistTable > tbody > tr").length
+                    hash: $("#track-hash").val()
                 }
             }
         };
@@ -932,6 +944,8 @@ $().ready(function(){
                         rows.eq(rows.length - 1).after(meta.html);
 
                     $(".playlistTable > tbody > tr").eq(index).find(".grab").on('pointerdown', grabStart);
+
+                    $("#track-hash").val(meta.hash);
 
                     updatePlayable();
 

--- a/ui/Playlists.php
+++ b/ui/Playlists.php
@@ -307,6 +307,8 @@ class Playlists extends MenuItem {
 
         $playlistId = $playlist['id'];
 
+        $playlist['hash'] = $api->hashPlaylist($playlistId);
+
         $this->addVar('NME_PREFIX', self::NME_PREFIX);
         $this->addVar('BASE_URL', Engine::getBaseURL());
 

--- a/ui/templates/README.md
+++ b/ui/templates/README.md
@@ -15,14 +15,29 @@ __template__ is the filename of the default template; e.g.,
 
 ### Filters
 
+In addition to the usual Twig filters, the following
+application-specific filters are also available for use:
+
+#### decorate
 The 'decorate' filter decorates an asset URI in such a way that it
 will change when the referenced asset changes.  In this way, assets
-such as js and css files are guaranteed to load anew in the client
+such as .js and .css files are guaranteed to load anew in the client
 browser whenever they change in the service.
 
 Example:
 
     <link rel="stylesheet" type="text/css" href="{{ 'css/mystyle.css' | decorate }}" />
+
+where `css/mystyle.css` is the path to a real asset, relative to the
+project root.
+
+#### markdown
+The 'markdown' filter converts all markdown in the string to HTML.
+
+#### smartURL
+The 'smartURL' filter inserts HTML anchor tags for all URLs in the
+string, thereby rendering the URLs clickable.
+
 
 ### Template environment
 
@@ -54,6 +69,7 @@ The following values are available from `config/config.php`:
 * app.email.*
 * app.favicon
 * app.logo
+* app.nme
 * app.station
 * app.station_full
 * app.station_slogan

--- a/ui/templates/default/list/add.html
+++ b/ui/templates/default/list/add.html
@@ -41,6 +41,7 @@
     <input id='timezone-offset' type='hidden' value="{{ TZO }}" >
     <input id='track-playlist' type='hidden' value='{{ playlist.id }}'>
     <input id='track-action' type='hidden' value='{{ app.request.subaction }}'>
+    <input id='track-hash' type='hidden' value='{{ playlist.hash }}'>
     <input id='const-prefix' type='hidden' value='{{ NME_PREFIX }}'>
     <label></label><span id='error-msg' class='error'></span>
     <div>


### PR DESCRIPTION
When the playlist editor was first launched, there was only one ajax operation: adding a new track.  At that time, it was sufficient to check the size of the playlist table in the browser against the playlist's size on the server to detect that an update had been made in another window, and to initiate a refresh.

Since then, in addition to adding new entries, DJs can also resequence and timestamp tracks.  As a result, the size-based test is no longer sufficient.

This PR replaces the size-based test with a new test that compares the hash of all playlist entries.  Any change to the number, order, or timestamps of entries results in a different hash, and thus an indication that the playlist in the browser is out of sync with the service and in need of a refresh.

In addition, this PR provides transactional integrity to timestamp and track resequencing operations in the service, to prevent potential race conditions.