### PR TITLE
Update CI build targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.2', '8.3']
+        php-versions: ['7.4', '8.2', '8.4']
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
The PR removes php 8.3 as a CI build target and adds in its place the newly released php 8.4.