### PR TITLE
Enhance album review hashtags

### DIFF
--- a/api/Albums.php
+++ b/api/Albums.php
@@ -66,6 +66,7 @@ class Albums implements RequestHandlerInterface {
         "track" =>                [ ILibrary::TRACK_NAME, null ],
         "label.id" =>             [ ILibrary::ALBUM_PUBKEY, null ],
         "reviews.airname.id" =>   [ ILibrary::ALBUM_AIRNAME, null ],
+        "reviews.hashtag" =>      [ ILibrary::ALBUM_HASHTAG, null ],
         "match(artist)" =>        [ -1, "artists" ],
         "match(artist,album)" =>  [ -1, "albums" ],
         "match(album,artist)" =>  [ -1, "albums" ],

--- a/controllers/Validate.php
+++ b/controllers/Validate.php
@@ -554,7 +554,7 @@ class Validate implements IController {
                         'attributes' => [
                             'airname' => $airname,
                             'date' => '2022-02-09',
-                            'review' => 'This is a review'
+                            'review' => 'This is a #review #test'
                         ],
                         'relationships' => [
                             'album' => [
@@ -575,7 +575,7 @@ class Validate implements IController {
         }
 
         if($this->doTest("validate review", $success9)) {
-            $success10 = $this->searchAlbum($albumname2, "review", "review", "This is a review");
+            $success10 = $this->searchAlbum($albumname2, "review", "review", "This is a #review #test");
             $this->showSuccess($success10);
         }
 

--- a/css/trending.css
+++ b/css/trending.css
@@ -1,0 +1,53 @@
+/* fonts */
+
+div.jqcloud {
+  font-size: 120%;
+}
+
+@media (max-width: 800px) {
+  div.jqcloud {
+    font-size: 100%;
+  }
+}
+
+div.jqcloud a {
+  font-size: inherit;
+  text-decoration: none;
+}
+
+div.jqcloud span.w10 { font-size: 300%; }
+div.jqcloud span.w9 { font-size: 280%; }
+div.jqcloud span.w8 { font-size: 260%; }
+div.jqcloud span.w7 { font-size: 240%; }
+div.jqcloud span.w6 { font-size: 220%; }
+div.jqcloud span.w5 { font-size: 200%; }
+div.jqcloud span.w4 { font-size: 180%; }
+div.jqcloud span.w3 { font-size: 140%; }
+div.jqcloud span.w2 { font-size: 120%; }
+div.jqcloud span.w1 { font-size: 100%; }
+
+/* colors */
+
+div.jqcloud { color: var(--theme-link-colour); }
+div.jqcloud a { color: inherit; }
+
+div.jqcloud a:hover { filter: saturate(2); }
+div.jqcloud span.w10 { filter: saturate(1.3); }
+div.jqcloud span.w9 { filter: saturate(1.25); }
+div.jqcloud span.w8 { filter: saturate(1.2); }
+div.jqcloud span.w7 { filter: saturate(1.1); }
+div.jqcloud span.w6 { filter: saturate(1.0); }
+div.jqcloud span.w5 { filter: saturate(0.9); }
+div.jqcloud span.w4 { filter: saturate(0.85); }
+div.jqcloud span.w3 { filter: saturate(0.80); }
+div.jqcloud span.w2 { filter: saturate(0.75); }
+div.jqcloud span.w1 { filter: saturate(0.70); }
+
+/* layout */
+
+div.jqcloud {
+  overflow: hidden;
+  position: relative;
+}
+
+div.jqcloud span { padding: 4px; }

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -784,6 +784,11 @@ th.sec {
     font-weight: bold;
     color: #cc0000;
 }
+.quiet-notice {
+    font-size: 20px;
+    color: #ccc;
+}
+
 .input { }
 .sel:link { color: #ff0000; }
 .sel:visited { color: #ff0000; }

--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -1576,6 +1576,16 @@ a:hover.copy {
     padding-top: 15px;
 }
 
+.album-hashtag-area a {
+    color: inherit;
+}
+.album-hashtag-area a:hover {
+    text-decoration: none;
+}
+.album-hashtag-area a:hover .album-hashtag {
+    filter: brightness(115%);
+}
+
 .album-hashtag {
     border-radius: 6px;
     border: 1px solid #666;

--- a/db/convert_v2_11_7_to_v3_0_0.sql
+++ b/db/convert_v2_11_7_to_v3_0_0.sql
@@ -58,6 +58,16 @@ ALTER TABLE `reviews` ADD COLUMN `exportid` varchar(80) DEFAULT NULL;
 ALTER TABLE `tracknames` ADD COLUMN `duration` time DEFAULT NULL;
 ALTER TABLE `colltracknames` ADD COLUMN `duration` time DEFAULT NULL;
 
+CREATE TABLE IF NOT EXISTS `reviews_hashtags` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `tag` int(11) NOT NULL,
+  `user` varchar(8) NOT NULL,
+  `hashtag` varchar(190) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `tu` (`tag`,`user`),
+  KEY `hashtag` (`hashtag`)
+) ENGINE=MyISAM  DEFAULT CHARSET=utf8mb4 ;
+
 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT;
 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS;
 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION;

--- a/db/zkdbSchema.sql
+++ b/db/zkdbSchema.sql
@@ -336,6 +336,22 @@ CREATE TABLE IF NOT EXISTS `reviews` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `reviews_hashtags`
+--
+
+CREATE TABLE IF NOT EXISTS `reviews_hashtags` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `tag` int(11) NOT NULL,
+  `user` varchar(8) NOT NULL,
+  `hashtag` varchar(190) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `tu` (`tag`,`user`),
+  KEY `hashtag` (`hashtag`)
+) ENGINE=MyISAM  DEFAULT CHARSET=utf8mb4 ;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `sessions`
 --
 

--- a/engine/ILibrary.php
+++ b/engine/ILibrary.php
@@ -87,6 +87,7 @@ interface ILibrary {
     const TRACK_KEY = 9;
     const TRACK_NAME = 10;
     const ALBUM_LOCATION = 11;
+    const ALBUM_HASHTAG = 12;
 
     const OP_PREV_LINE = 0;
     const OP_NEXT_LINE = 1;

--- a/engine/IReview.php
+++ b/engine/IReview.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2023 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2024 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -47,6 +47,7 @@ interface IReview {
     function getRecentReviews($user = "", $weeks = 0, $limit = 0, $loggedIn = 0);
     function getActiveReviewers($viewAll=0, $loggedIn=0);
     function getReviews($tag, $byName=1, $user = "", $loggedIn = 0, $byId = 0);
+    function getTrending(int $limit = 50);
     function insertReview($tag, $private, $airname, $review, $user);
     function updateReview($tag, $private, $airname, $review, $user);
     function deleteReview($tag, $user);

--- a/engine/impl/ReviewImpl.php
+++ b/engine/impl/ReviewImpl.php
@@ -192,7 +192,7 @@ class ReviewImpl extends DBO implements IReview {
     
     public function insertReview($tag, $private, $airname, $review, $user) {
         // we must do this first, as caller depends on lastInsertId from INSERT
-        $this->syncHashtags($tag, $user, $review);
+        $this->syncHashtags($tag, $user, $private ? null : $review);
 
         $query = "INSERT INTO reviews " .
                  "(tag, user, created, private, review, airname) VALUES (" .
@@ -233,7 +233,7 @@ class ReviewImpl extends DBO implements IReview {
         $count = $stmt->execute() ? $stmt->rowCount() : 0;
 
         if($count)
-            $this->syncHashtags($tag, $user, $review);
+            $this->syncHashtags($tag, $user, $private ? null : $review);
 
         return $count;
     }

--- a/js/search.library.js
+++ b/js/search.library.js
@@ -144,7 +144,7 @@ function emitAlbumsEx(table, data) {
     tr.append(header("Album", true));
     tr.append(header("Collection", false));
     tr.append(header("Media", false).attr('colSpan', 2));
-    tr.append(header("Added", false));
+    tr.append(header("Added", $("#type").val() == 'hashtags'));
     tr.append(header("Label", true));
     table.append($("<THEAD>").append(tr));
 
@@ -215,7 +215,8 @@ var requestMap = {
     albumsByPubkey: "album?filter[label.id]=",
     tracks: "album?filter[track]=",
     labels: "label?filter[name]=",
-    reviews: "album?filter[reviews.airname.id]="
+    reviews: "album?filter[reviews.airname.id]=",
+    hashtags: "album?filter[reviews.hashtag]="
 };
 
 var lists = {
@@ -370,6 +371,9 @@ var lists = {
     },
 };
 
+// hashtags and albums share the same marshaller
+lists.hashtags = lists.albums;
+
 function search(size, offset) {
     var suffix, type = $("#type").val();
     if(!type || !requestMap[type])
@@ -377,6 +381,7 @@ function search(size, offset) {
     switch(type) {
     case "albumsByPubkey":
     case "reviews":
+    case "hashtags":
         suffix = "";
         break;
     default:
@@ -428,6 +433,9 @@ function search(size, offset) {
                 case "albumsByPubkey":
                     ttype = "albums";
                     break;
+                case "hashtags":
+                    ttype = "albums tagged #" + $("#fkey").val();
+                    break;
                 default:
                     ttype = type;
                     break;
@@ -457,7 +465,7 @@ function search(size, offset) {
                 if($("#sortBy").val() == "")
                     $("#sortBy").val("Artist");
                 lists[type](results, response);
-            } else {
+            } else if (type != 'hashtags' ) {
                 if($("#m").is(":checked"))
                     results.append('Hint: Uncheck "Exact match" box to broaden search.');
                 else

--- a/js/trending.js
+++ b/js/trending.js
@@ -1,0 +1,73 @@
+//
+// Zookeeper Online
+//
+// @author Jim Mason <jmason@ibinx.com>
+// @copyright Copyright (C) 1997-2024 Jim Mason <jmason@ibinx.com>
+// @link https://zookeeper.ibinx.com/
+// @license GPL-3.0
+//
+// This code is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License,
+// version 3, along with this program.  If not, see
+// http://www.gnu.org/licenses/
+//
+
+/*! Zookeeper Online (C) 1997-2024 Jim Mason <jmason@ibinx.com> | @source: https://zookeeper.ibinx.com/ | @license: magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3.0 */
+
+var trending = null;
+var loading = false;
+var timeout;
+
+function reposition() {
+    var pos = $("#cloud span").toArray().reduce(function(carry, span) {
+        if(span.offsetLeft < carry.left)
+            carry.left = span.offsetLeft;
+        if(span.offsetTop < carry.top)
+            carry.top = span.offsetTop;
+        return carry;
+    }, { left: 1000, top: 1000 } );
+
+    $("#cloud").css('margin-left', -pos.left + 'px')
+        .css('margin-top', -pos.top+20 + 'px')
+        .css('opacity', 1);
+
+    loading = false;
+}
+
+function loadCloud() {
+    if(trending && !loading) {
+        loading = true;
+        var width = $(".content").outerWidth();
+        $("#cloud").css('opacity', 0).empty().jQCloud(trending, {
+            width: width,
+            height: 350,
+            removeOverflowing: false,
+            afterCloudRender: reposition
+        });
+    }
+}
+
+$().ready(function() {
+    $.ajax({
+        dataType: 'json',
+        type: 'GET',
+        accept: 'application/json; charset=utf-8',
+        url: '?action=viewRecent&subaction=trendingData'
+    }).done(function(response) {
+        trending = response;
+        loadCloud();
+    });
+
+    window.addEventListener('resize', function(event) {
+        clearTimeout(timeout);
+        timeout = setTimeout(loadCloud, 100);
+    });
+});

--- a/js/trending.js
+++ b/js/trending.js
@@ -56,6 +56,13 @@ function loadCloud() {
 }
 
 $().ready(function() {
+    if(!$.fn.jQCloud) {
+        $("#cloud").append($("<p>", {
+            class: 'quiet-notice'
+        }).html('The trending cloud is unavailable.'));
+        return;
+    }
+
     $.ajax({
         dataType: 'json',
         type: 'GET',

--- a/ui/Reviews.php
+++ b/ui/Reviews.php
@@ -53,6 +53,8 @@ class Reviews extends MenuItem {
     private static $subactions = [
         [ "a", "", "Recent Reviews", "viewRecentReviews" ],
         [ "a", "viewDJ", "By DJ", "reviewsByDJ" ],
+        [ "a", "viewHashtag", "Trending", "viewTrending" ],
+        [ "a", "trendingData", 0, "getTrendingData" ],
     ];
 
     private $subaction;
@@ -125,6 +127,25 @@ class Reviews extends MenuItem {
         }
 
         $this->emitViewDJMain();
+    }
+
+    public function viewTrending() {
+        $this->setTemplate("review.trending.html");
+    }
+
+    public function getTrendingData() {
+        $limit = 50;
+        $scale = $limit / 5;
+        $trending = Engine::api(IReview::class)->getTrending($limit);
+        $data = array_map(function($entry) use(&$limit, $scale) {
+            return [
+                'text' => $entry['hashtag'],
+                'weight' => $entry['freq'] * $scale + floor($limit-- / 10),
+                'link' => '?action=search&s=byHashtag&n=' . urlencode($entry['hashtag'])
+            ];
+        }, $trending);
+
+        echo json_encode($data);
     }
 
     public function viewRecentReviews() {

--- a/ui/Search.php
+++ b/ui/Search.php
@@ -46,7 +46,8 @@ class Search extends MenuItem {
         "byArtist" => "artists",
         "byTrack" => "tracks",
         "byLabel" => "labels",
-        "byLabelKey" => "albumsByPubkey"
+        "byLabelKey" => "albumsByPubkey",
+        "byHashtag" => "hashtags"
     ];
 
     public $searchText;

--- a/ui/Search.php
+++ b/ui/Search.php
@@ -132,7 +132,7 @@ class Search extends MenuItem {
 
         // hashtags
         $hashtags = array_reduce(array_reverse($reviews), function($carry, $review) {
-            return preg_match_all('/#\pL\w*/u', $review['review'], $matches) ?
+            return !$review['private'] && preg_match_all('/#\pL\w*/u', $review['review'], $matches) ?
                 array_merge($carry, $matches[0]) : $carry;
         }, []);
         $normalized = array_unique(array_map('strtolower', $hashtags));

--- a/ui/templates/default/album/info.html
+++ b/ui/templates/default/album/info.html
@@ -76,7 +76,7 @@
 {% if hashtags | length %}
   <div class='album-hashtag-area'>
 {% for tag, index in hashtags %}
-    <span class='album-hashtag palette-{{ index }}'>{{ tag }}</span>
+    <a href='?action=search&amp;s=byHashtag&amp;n={{ tag | slice(1) }}'><span class='album-hashtag palette-{{ index }}'>{{ tag }}</span></a>
 {% endfor %}
   </div>
 {% endif %}

--- a/ui/templates/default/review.trending.html
+++ b/ui/templates/default/review.trending.html
@@ -1,0 +1,5 @@
+<link rel="stylesheet" type="text/css" href="{{ 'css/trending.css' | decorate }}" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jqcloud/1.0.3/jqcloud.min.js"></script>
+<script src="{{ 'js/trending.js' | decorate }}"></script>
+<h3>Music review tags trending on {{ app.station_title }}:</h3>
+<div id="cloud"></div>

--- a/ui/templates/default/search.library.html
+++ b/ui/templates/default/search.library.html
@@ -9,7 +9,7 @@ $().ready(function() {
 {% if type == "all" %}
     $(".search-data").val(text);
     $("#fkey").val(text);
-{% elseif type == "albumsByPubkey" %}
+{% elseif type == "albumsByPubkey" or type == "hashtags" %}
     $("#fkey").val(text);
 {% else %}
     $("#search-filter").val(type).selectmenu('refresh');
@@ -22,6 +22,7 @@ $().ready(function() {
     var sortBy;
     switch(type) {
     case "artists":
+    case "hashtags":
         sortBy = "Artist";
         break;
     case "albums":


### PR DESCRIPTION
The PR makes the album review hashtag cartouches active, such that activating (clicking) one generates a report of all albums which contain the corresponding tag.

In addition, it also adds a 'trending' cloud, weighted to recent and recurring hashtags.
