### PR TITLE
Add album artwork to Library Editor

### DIFF
--- a/css/zoostyle.css
+++ b/css/zoostyle.css
@@ -1846,11 +1846,54 @@ div.toggle-time-entry div {
 .file-area input[type=file]:focus + .file-overlay {
     border-color: #637789;
 }
-.file-area input[type=file]:valid + .file-overlay .success {
+.file-area input[type=file].has-file + .file-overlay .success {
     display: inline-block;
 }
-.file-area input[type=file]:valid + .file-overlay .default {
+.file-area input[type=file].has-file + .file-overlay .default {
     display: none;
+}
+
+.file-area.album-thumb {
+    position: relative;
+    width: 130px;
+    height: 130px;
+    display: block;
+    margin-top: 2px;
+}
+.file-area.album-thumb .file-overlay {
+    max-width: 130px;
+    max-height: 130px;
+    padding: 0;
+}
+.file-area.album-thumb .default {
+    line-height: 1.5;
+    height: 126px;
+}
+.file-area.album-thumb .default h4 {
+    margin: 10px auto;
+}
+.file-area.album-thumb .default .pseudo-button {
+    display: inline-block;
+    margin-top: 8px;
+}
+.file-area.album-thumb .delete {
+    line-height: 30px;
+    width: 30px;
+    position: absolute;
+    bottom: 6px;
+    left: 4px;
+}
+.file-area input[name=userfile]:not(.has-file) + .file-overlay .delete {
+    display: none;
+}
+.file-area.album-thumb .delete a {
+    border-radius: 50%;
+    background-color: #d00;
+    color: #fff;
+    display: block;
+}
+.file-area.album-thumb .delete a:hover {
+    background-color: #f00;
 }
 
 .no-text-select {

--- a/docs/Albums.md
+++ b/docs/Albums.md
@@ -69,6 +69,7 @@ artwork is not cached for the album, or empty string if artwork is
 disabled for the album.  When setting `albumart` in a POST or PATCH
 request, supply the full URL to the image you want to cache for the
 album, null to remove album art, or empty string to disable album art.
+Alternatively, you may specify a [data URL](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data) with the image data.
 
 X-APIKEY authentication is required for use of the location filter.
 Possible filter values are (case-insensitive): A-File, Deaccessioned,

--- a/js/editor.album.js
+++ b/js/editor.album.js
@@ -33,7 +33,7 @@ function getAlbums(key) {
 }
 
 function paginateAlbums(op, url) {
-    url += "&fields[album]=-tracks,-coll,-albumart";
+    url += "&fields[album]=-tracks,-coll";
     url += "&fields[label]=name,address,city,state,zip&include=label";
 
     $.ajax({

--- a/js/playlists.import.js
+++ b/js/playlists.import.js
@@ -242,11 +242,14 @@ $().ready(function() {
                 return;
             }
             $("input[type=file]")[0].files = files;
+            $("input[type=file]").addClass('has-file');
             $(".file-area .success").text(files[0].name);
         }
     });
     $("input[type=file]").on('change', function(e) {
-        $(".file-area .success").text(this.files[0].name);
+        var hasFile = this.files.length > 0;
+        $(this).toggleClass('has-file', hasFile);
+        $(".file-area .success").text(hasFile ? this.files[0].name : '');
     });
 
     $("input[name=format]").on('change', function(e) {


### PR DESCRIPTION
This PR extends the Library Editor to allow manipulation of album artwork.

An artwork thumbnail appears on the Library Editor's album search page for each album which has artwork.  From the editor's album details page, artwork can be manipulated in several ways:
* new artwork can be uploaded manually for any album;
* existing artwork can be deleted (for eventual automatic replacement);
* artwork can be completely disabled for the album (where no artwork is available or desired).

This functionality is also available via the JSON:API; see 9620f97 

Satisfies #431 