### PR TITLE
Add new Twig truncate filter

### DIFF
--- a/controllers/templates/default/rss/reviews.xml
+++ b/controllers/templates/default/rss/reviews.xml
@@ -13,7 +13,7 @@
   {%~ autoescape 'html' %}
       <p>Review by {{ review.airname ?? review.realname }}</p>
     {%~ if app.request.fmt %}
-      <p>{{ review.body | nl2br }}</p>
+      <p>{{ review.body | truncate(800, true) | nl2br }}</p>
       {%~ if review.tracks %}
       <details>
         <summary><span>Explore the tracks</span></summary>

--- a/engine/TemplateFactory.php
+++ b/engine/TemplateFactory.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2024 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2025 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -105,6 +105,32 @@ class TemplateFactory {
         $this->twig->addGlobal('app', $this->app);
 
         $filter = new \Twig\TwigFilter('decorate', [ '\ZK\Engine\Engine', 'decorate' ]);
+        $this->twig->addFilter($filter);
+        $filter = new \Twig\TwigFilter('truncate', function($value, $length = 80, $preserveWords = false, $ellipsis = '...') {
+            if (mb_strlen($value) > $length) {
+                $ellipsisLen = mb_strlen($ellipsis);
+                if ($length <= $ellipsisLen)
+                    return mb_substr($value, 0, $length);
+
+                $length -= $ellipsisLen;
+                $nextChar = mb_substr($value, $length, 1);
+                $value = rtrim(mb_substr($value, 0, $length));
+
+                // If we did not rtrim (and hence are not already at the
+                // end of a word) and the next character is also not
+                // whitespace, then trim to the last whole word.
+                if ($preserveWords
+                        && mb_strlen($value) == $length
+                        && !ctype_space($nextChar)
+                        && preg_match('/^(.+?)\s+\S+$/su', $value, $matches)) {
+                    $value = $matches[1];
+                }
+
+                $value .= $ellipsis;
+            }
+
+            return $value;
+        });
         $this->twig->addFilter($filter);
     }
 

--- a/ui/templates/README.md
+++ b/ui/templates/README.md
@@ -38,6 +38,13 @@ The 'markdown' filter converts all markdown in the string to HTML.
 The 'smartURL' filter inserts HTML anchor tags for all URLs in the
 string, thereby rendering the URLs clickable.
 
+#### truncate
+The 'truncate' filter shortens a string to a specified length.  It
+has the signature `truncate(length|80, preserveWords|false, ellipsis|'...')`
+where *length* is the length to truncate to (default 80), *preserveWords*
+avoids breaking words, and *ellipsis* is the string to append to the
+truncated string.  The returned string is guaranteed never to exceed *length*.
+
 
 ### Template environment
 

--- a/ui/templates/default/currents/albums.html
+++ b/ui/templates/default/currents/albums.html
@@ -44,7 +44,7 @@
       <td align='center'>{{ _self.catcodes(catmap, album.afile_category) ?? '-' }}</td>
       <td>{{ album.reviewer }}</td>
       <td>{{ album.afile_number }}</td>
-      <td>{{ album.iscoll ? "Various Artists" : static and album.artist | length > 50 ? album.artist[:50] ~ '...' : album.artist }}&nbsp;&nbsp;</td>
+      <td>{{ album.iscoll ? "Various Artists" : static ? album.artist | truncate(50) : album.artist }}&nbsp;&nbsp;</td>
   {%~ if playableCell | length %}
       <td>
     {%~ if album.playable %}
@@ -53,7 +53,7 @@
       </td>
   {%~ endif %}
   {%~ if static %}
-      <td>{{ album.album | length > 50 ? album.album[:50] ~ '...' : album.album }}{{ _self.medium(album.medium) }}&nbsp;&nbsp;</td>
+      <td>{{ album.album | truncate(50) }}{{ _self.medium(album.medium) }}&nbsp;&nbsp;</td>
   {%~ else %}
       <td><a class='nav' href='?s=byAlbumKey&amp;n={{ album.tag }}&amp;action=search'>{{ album.album }}</a>{{ _self.medium(album.medium) }}&nbsp;&nbsp;</td>
       <td>{{ album.label }}</td>


### PR DESCRIPTION
This PR adds a new Twig filter `truncate` and applies it in place of erstwhile ad-hoc truncation.

In addition, the PR applies truncation in the new-format RSS review feed.  The legacy RSS review feed remains unchanged.

Other than the above mentioned change to the new-format RSS review feed, there should be no user-observable differences in formatting or behaviour.
