### PR TITLE
Add support for read-only replicas

### DIFF
--- a/engine/DBO.php
+++ b/engine/DBO.php
@@ -404,12 +404,12 @@ abstract class DBO {
      * @return PDOStatement
      */
     protected function prepare($stmt, $options = []) {
-        if (!empty($options[DBO::READONLY])) {
-            unset($options[DBO::READONLY]);
-            return $this->getPDO_RO()->prepare($stmt, $options);
-        }
+        $readonly = !empty($options[DBO::READONLY]);
+        unset($options[DBO::READONLY]);
 
-        return $this->getPDO()->prepare($stmt, $options);
+        return $readonly ?
+            $this->getPDO_RO()->prepare($stmt, $options) :
+            $this->getPDO()->prepare($stmt, $options);
     }
 
     /**

--- a/engine/DBO.php
+++ b/engine/DBO.php
@@ -251,6 +251,8 @@ abstract class DBO {
     const DB_DRIVER = 'driver';
     const DB_PARAMS = [ 'host', 'port', 'unix_socket' ];
 
+    const READONLY = '_ZK_ENGINE_DBO_READONLY'; // avoid collision with PDO options
+
     private const CONNECT_RETRY = 5; // number of times to try connecting
     private const CONNECT_BACKOFF = 4; // delay retry up to CONNECT_BACKOFF seconds
 
@@ -260,6 +262,7 @@ abstract class DBO {
 
     private $locks = [];
     private $dsn;
+    private $dsnRO;
 
     /**
      * convenience method to retrieve a database configuration parameter
@@ -365,6 +368,22 @@ abstract class DBO {
     }
 
     /**
+     * get read-only singleton PDO for the default database
+     *
+     * note that each PDO per DSN is shared across all DBO instances
+     *
+     * this method is not normally directly invoked; instead the
+     * convenience method 'prepare' is used to prepare a statement
+     * on the default database.
+     *
+     * @return PDO
+     */
+    protected function getPDO_RO() {
+        $this->dsnRO ??= $this->getDSN_RO(DBO::DATABASE_MAIN);
+        return self::$pdo[$this->dsnRO] ??= $this->newPDOwithDSN($this->dsnRO);
+    }
+
+    /**
      * release the default database singleton
      *
      * this method has the effect of closing the underlying
@@ -385,6 +404,11 @@ abstract class DBO {
      * @return PDOStatement
      */
     protected function prepare($stmt, $options = []) {
+        if (!empty($options[DBO::READONLY])) {
+            unset($options[DBO::READONLY]);
+            return $this->getPDO_RO()->prepare($stmt, $options);
+        }
+
         return $this->getPDO()->prepare($stmt, $options);
     }
 

--- a/engine/DBO.php
+++ b/engine/DBO.php
@@ -3,7 +3,7 @@
  * Zookeeper Online
  *
  * @author Jim Mason <jmason@ibinx.com>
- * @copyright Copyright (C) 1997-2025 Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2026 Jim Mason <jmason@ibinx.com>
  * @link https://zookeeper.ibinx.com/
  * @license GPL-3.0
  *
@@ -248,22 +248,27 @@ abstract class DBO {
     const DATABASE_MAIN = 'database';
     const DATABASE_LIBRARY = 'library';
 
+    const DB_DRIVER = 'driver';
+    const DB_PARAMS = [ 'host', 'port', 'unix_socket' ];
+
     private const CONNECT_RETRY = 5; // number of times to try connecting
     private const CONNECT_BACKOFF = 4; // delay retry up to CONNECT_BACKOFF seconds
 
     // we store these statically, as they are shared across all instances
     private static $dbConfig;
-    private static $pdo;
+    private static $pdo = [];
 
     private $locks = [];
+    private $dsn;
 
     /**
      * convenience method to retrieve a database configuration parameter
      *
-     * @param name parameter
-     * @return configuration value or null if does not exist
+     * @param string $name parameter
+     * @param string|null $default default value or null
+     * @return string|null configuration value or default if does not exist
      */
-    private function dbConfig($name) {
+    private function dbConfig(string $name, ?string $default = null): ?string {
         if(!self::$dbConfig) {
             self::$dbConfig = Engine::param('db');
 
@@ -275,23 +280,48 @@ abstract class DBO {
         }
 
         return array_key_exists($name, self::$dbConfig) ?
-                self::$dbConfig[$name] : null;
+                self::$dbConfig[$name] : $default;
     }
 
     /**
-     * instantiate a new PDO object from the config file db parameters
+     * construct the DSN for this PDO
      *
-     * instead of this method, use 'prepare' or 'getPDO' if possible.
-     *
-     * @param name config file database name key (optional)
-     * @return PDO
+     * @param string $name config file database name key
+     * @return string DSN
      */
-    protected function newPDO($name = DBO::DATABASE_MAIN) {
-        $dsn = $this->dbConfig('driver') .
-                ':host=' . $this->dbConfig('host') .
-                ';dbname=' . $this->dbConfig($name) .
-                ';charset=utf8mb4';
+    protected function getDSN(string $name): string {
+        $parts = [ $this->dbConfig(DBO::DB_DRIVER) . ':dbname=' . $this->dbConfig($name) ];
 
+        foreach (DBO::DB_PARAMS as $param) {
+            $value = $this->dbConfig($param);
+            if ($value)
+                $parts[] = "$param=$value";
+        }
+
+        return implode(';', $parts) . ";charset=utf8mb4";
+    }
+
+    /**
+     * construct a DSN for read-only access to this PDO
+     *
+     * if no read-only configuration is present, the usual DSN is returned
+     *
+     * @param string $name config file database name key
+     * @return string DSN
+     */
+    protected function getDSN_RO(string $name): string {
+        $parts = [ $this->dbConfig(DBO::DB_DRIVER) . ':dbname=' . $this->dbConfig($name) ];
+
+        foreach (DBO::DB_PARAMS as $param) {
+            $value = $this->dbConfig("ro_$param", $this->dbConfig($param));
+            if ($value)
+                $parts[] = "$param=$value";
+        }
+
+        return implode(';', $parts) . ";charset=utf8mb4";
+    }
+
+    private function newPDOwithDSN(string $dsn) {
         $retry = self::CONNECT_RETRY;
         while(true) {
             try {
@@ -306,9 +336,22 @@ abstract class DBO {
     }
 
     /**
+     * instantiate a new PDO object from the config file db parameters
+     *
+     * instead of this method, use 'prepare' or 'getPDO' if possible.
+     *
+     * @param string $name config file database name key (optional)
+     * @return PDO
+     */
+    protected function newPDO(string $name = DBO::DATABASE_MAIN) {
+        $dsn = $this->getDSN($name);
+        return $this->newPDOwithDSN($dsn);
+    }
+
+    /**
      * get singleton PDO for the default database
      *
-     * note the PDO is shared across all DBO instances
+     * note that each PDO per DSN is shared across all DBO instances
      *
      * this method is not normally directly invoked; instead the
      * convenience method 'prepare' is used to prepare a statement
@@ -317,10 +360,8 @@ abstract class DBO {
      * @return PDO
      */
     protected function getPDO() {
-        if(!self::$pdo)
-            self::$pdo = $this->newPDO();
-
-        return self::$pdo;
+        $this->dsn ??= $this->getDSN(DBO::DATABASE_MAIN);
+        return self::$pdo[$this->dsn] ??= $this->newPDOwithDSN($this->dsn);
     }
 
     /**
@@ -333,7 +374,7 @@ abstract class DBO {
      * until automatic database reconnection gets implemented
      */
     public static function release() {
-        self::$pdo = null;
+        self::$pdo = [];
     }
 
     /**

--- a/engine/ReadOnlyTrait.php
+++ b/engine/ReadOnlyTrait.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zookeeper Online
+ *
+ * @author Jim Mason <jmason@ibinx.com>
+ * @copyright Copyright (C) 1997-2026 Jim Mason <jmason@ibinx.com>
+ * @link https://zookeeper.ibinx.com/
+ * @license GPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3, along with this program.  If not, see
+ * http://www.gnu.org/licenses/
+ *
+ */
+
+namespace ZK\Engine;
+
+/**
+ * Trait to mark DBO that can use an optional read-only database
+ *
+ * The read-only database must be a replica of the main database.
+ * If no read-only database is configured, the main database will be used.
+ */
+trait ReadOnlyTrait {
+    protected function getDSN(string $name): string {
+        return $this->getDSN_RO($name);
+    }
+}

--- a/engine/impl/LibraryImpl.php
+++ b/engine/impl/LibraryImpl.php
@@ -29,6 +29,8 @@ namespace ZK\Engine;
  * Library operations
  */
 class LibraryImpl extends DBO implements ILibrary {
+    use ReadOnlyTrait;
+
     const DEFAULT_FT_LIMIT = 35;
     const MAX_FT_LIMIT = 200;
     const ENHANCED_COLLATION = false;

--- a/engine/impl/LibraryImpl.php
+++ b/engine/impl/LibraryImpl.php
@@ -29,8 +29,6 @@ namespace ZK\Engine;
  * Library operations
  */
 class LibraryImpl extends DBO implements ILibrary {
-    use ReadOnlyTrait;
-
     const DEFAULT_FT_LIMIT = 35;
     const MAX_FT_LIMIT = 200;
     const ENHANCED_COLLATION = false;
@@ -186,12 +184,16 @@ class LibraryImpl extends DBO implements ILibrary {
         // remove semicolons to thwart injection attacks
         $search = str_replace(';', '_', $search);
 
+        $readOnly = [];  // default use main database
+
         if(substr($search, strlen($search)-1, 1) == "*") {
             $search = trim(substr($search, 0, strlen($search)-1))."%";
 
             // return empty for degenerate search
             if ($tableIndex != ILibrary::PASSWD_NAME &&
                     strlen($search) < 4) return $count >= 0 ? $retVal : 0;
+
+            $readOnly = [ DBO::READONLY => true ];
         }
 
         switch($tableIndex) {
@@ -372,7 +374,7 @@ class LibraryImpl extends DBO implements ILibrary {
             if($rlike)
                 $query = "SELECT * FROM ( $query ) x WHERE $key RLIKE ?";
 
-            $stmt = $this->prepare($query);
+            $stmt = $this->prepare($query, $readOnly);
             switch($bindType) {
             case 1:
                 $stmt->bindValue(1, $search);
@@ -430,7 +432,7 @@ class LibraryImpl extends DBO implements ILibrary {
             if($rlike)
                 $query .= " WHERE $key RLIKE ?";
 
-            $stmt = $this->prepare($query);
+            $stmt = $this->prepare($query, $readOnly);
             switch($bindType) {
             case 1:
             case 3:
@@ -987,7 +989,7 @@ class LibraryImpl extends DBO implements ILibrary {
                 $paramCount = 1;
             }
 
-            $stmt = $this->prepare($query);
+            $stmt = $this->prepare($query, [ DBO::READONLY => true ]);
             $stmt->bindValue(1, $i?$search:$key);
             if($paramCount == 2)
                 $stmt->bindValue(2, $search);
@@ -1019,7 +1021,7 @@ class LibraryImpl extends DBO implements ILibrary {
                         $rsize[$i] -= $size;
                     }
                     $query = self::$ftSearch[$i][4].$l;
-                    $stmt = $this->prepare($query);
+                    $stmt = $this->prepare($query, [ DBO::READONLY => true ]);
                     $stmt->bindValue(1, $i?$search:$key);
                     if(strpos($query, " UNION SELECT "))
                         $stmt->bindValue(2, $search);


### PR DESCRIPTION
This PR adds optional support for read-only replica access at the DBO level.

DBOs which are read-only can avoid write locks by directing all queries to a read-only replica.
